### PR TITLE
common: Fix USE_ASSERT check

### DIFF
--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -24,7 +24,7 @@
 #endif
 
 
-#ifndef RYML_USE_ASSERT
+#if RYML_USE_ASSERT
 #   define RYML_ASSERT(cond)
 #   define RYML_ASSERT_MSG(cond, msg)
 #else


### PR DESCRIPTION
This replaces RYML_USE_ASSERT with C4_USE_ASSERT since there is no easy
way to rename the preprocessor macro. Currently, if RYML_USE_ASSERT is
not defined, then RYML_USE_ASSERT is always defined, which means that
asserts are always enabled (regardless of whether C4_USE_ASSERT is
defined or not).