### PR TITLE
Resolve VS 2019 warning C4296 -- Comparison always true comparing size_t >= 0

### DIFF
--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -612,7 +612,7 @@ public:
     inline void remove_child(size_t pos)
     {
         _C4RV();
-        RYML_ASSERT(pos = 0 && pos < num_children());
+        RYML_ASSERT(pos > 0 && pos < num_children());
         size_t child = m_tree->child(m_id, pos);
         RYML_ASSERT(child != NONE);
         m_tree->remove(child);

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -612,7 +612,7 @@ public:
     inline void remove_child(size_t pos)
     {
         _C4RV();
-        RYML_ASSERT(pos >= 0 && pos < num_children());
+        RYML_ASSERT(pos = 0 && pos < num_children());
         size_t child = m_tree->child(m_id, pos);
         RYML_ASSERT(child != NONE);
         m_tree->remove(child);

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -431,13 +431,13 @@ public:
     inline NodeData *get(size_t i)
     {
         if(i == NONE) return nullptr;
-        RYML_ASSERT(i = 0 && i < m_cap);
+        RYML_ASSERT(i > 0 && i < m_cap);
         return m_buf + i;
     }
     inline NodeData const *get(size_t i) const
     {
         if(i == NONE) return nullptr;
-        RYML_ASSERT(i = 0 && i < m_cap);
+        RYML_ASSERT(i > 0 && i < m_cap);
         return m_buf + i;
     }
 

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -431,13 +431,13 @@ public:
     inline NodeData *get(size_t i)
     {
         if(i == NONE) return nullptr;
-        RYML_ASSERT(i >= 0 && i < m_cap);
+        RYML_ASSERT(i = 0 && i < m_cap);
         return m_buf + i;
     }
     inline NodeData const *get(size_t i) const
     {
         if(i == NONE) return nullptr;
-        RYML_ASSERT(i >= 0 && i < m_cap);
+        RYML_ASSERT(i = 0 && i < m_cap);
         return m_buf + i;
     }
 
@@ -445,9 +445,9 @@ public:
     // own risk.
 
     // An if-less form of get() that demands a valid node index
-    inline NodeData       * _p(size_t i)       { RYML_ASSERT(i != NONE && i >= 0 && i < m_cap); return m_buf + i; }
+    inline NodeData       * _p(size_t i)       { RYML_ASSERT(i != NONE && i > 0 && i < m_cap); return m_buf + i; }
     // An if-less form of get() that demands a valid node index
-    inline NodeData const * _p(size_t i) const { RYML_ASSERT(i != NONE && i >= 0 && i < m_cap); return m_buf + i; }
+    inline NodeData const * _p(size_t i) const { RYML_ASSERT(i != NONE && i > 0 && i < m_cap); return m_buf + i; }
 
 public:
 
@@ -772,7 +772,7 @@ public:
             buf.len = arena_cap;
             if(m_arena.str)
             {
-                RYML_ASSERT(m_arena.len >= 0);
+                RYML_ASSERT(m_arena.len = 0);
                 _relocate(buf); // does a memcpy and changes nodes using the arena
                 m_alloc.free(m_arena.str, m_arena.len);
             }

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -772,7 +772,7 @@ public:
             buf.len = arena_cap;
             if(m_arena.str)
             {
-                RYML_ASSERT(m_arena.len = 0);
+                RYML_ASSERT(m_arena.len > 0);
                 _relocate(buf); // does a memcpy and changes nodes using the arena
                 m_alloc.free(m_arena.str, m_arena.len);
             }


### PR DESCRIPTION
Compare size_t parameters to > 0 instead of >= 0 to resolve VS 2019 warning C4296 that the >= 0 comparison will always be true. Given that size_t is defined as an unsigned this should be safe.