### PR TITLE
[break] use null strings when parsing YAML-null values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,41 @@
 # Changelog
 
-## Changes in master
+Currently there are no ryml releases. However, the master branch is always
+stable; it is validated by requiring all tests to succeed before merging to it.
+So for now, only major changes to master are listed.
+
+* 2020/September
+  * [***Breaking change***] [MR#85](https://github.com/biojppm/rapidyaml/pull/85)
+    null values in YAML are now parsed to null
+    strings instead of YAML null token "~":
+    ```c++
+    auto tree = parse("{foo: , bar: ''}");
+    // previous:
+    assert(tree["foo"].val() == "~");
+    assert(tree["bar"].val() == "");
+    // now:
+    assert(tree["foo"].val() == nullptr); // notice that this is now null
+    assert(tree["bar"].val() == "");
+    ```
+  * [MR#85](https://github.com/biojppm/rapidyaml/pull/85) Commas after tags are now allowed:
+    ```yaml
+    {foo: !!str, bar: ''}  # now the comma does not cause an error
+    ```
+  * [MR#81](https://github.com/biojppm/rapidyaml/pull/81): Always compile
+    with extra pedantic warnings.
 
 * 2020/May
-  * ***Breaking change***: the error callback now receives a source location object:
+  *  [***Breaking change***] the error callback now receives a source location object:
     ```c++
     // previous
     using pfn_error = void (*)(const char* msg, size_t msg_len, void *user_data);
     // now:
     using pfn_error = void (*)(const char* msg, size_t msg_len, Location location, void *user_data);
     ```
+  * Parser fixes to improve test suite success:
+    [MR#73](https://github.com/biojppm/rapidyaml/pull/73),
+    [MR#71](https://github.com/biojppm/rapidyaml/pull/71),
+    [MR#68](https://github.com/biojppm/rapidyaml/pull/68),
+    [MR#67](https://github.com/biojppm/rapidyaml/pull/67),
+    [MR#66](https://github.com/biojppm/rapidyaml/pull/66)
+  * Fix compilation as DLL on windows [MR#69](https://github.com/biojppm/rapidyaml/pull/69)

--- a/src/c4/yml/emit.def.hpp
+++ b/src/c4/yml/emit.def.hpp
@@ -340,7 +340,14 @@ void Emitter<Writer>::_write_scalar(csubstr s)
         }
         else
         {
-            this->Writer::_do_write("''");
+            if(s.str != nullptr)
+            {
+                this->Writer::_do_write("''");
+            }
+            else
+            {
+                this->Writer::_do_write('~');
+            }
         }
     }
     else

--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -1601,7 +1601,7 @@ bool Parser::_handle_types()
     if(rem.begins_with("!!"))
     {
         _c4dbgp("begins with '!!'");
-        t = rem.left_of(rem.first_of(' '));
+        t = rem.left_of(rem.first_of(" ,"));
         RYML_ASSERT(t.len >= 2);
         //t = t.sub(2);
         if(t == "!!set")

--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -576,6 +576,11 @@ bool Parser::_handle_seq_expl()
     else if(rem.begins_with(']'))
     {
         _c4dbgp("end the sequence");
+        if(has_all(RVAL))
+        {
+            _c4dbgp("there is a value pending - using null");
+            _append_val_null();
+        }
         _pop_level();
         _line_progressed(1);
         if(has_all(RSEQIMAP))
@@ -645,6 +650,20 @@ bool Parser::_handle_seq_expl()
         }
         else if(_handle_val_anchors_and_refs())
         {
+            return true;
+        }
+        else if(rem.begins_with(", "))
+        {
+            _c4dbgp("found ',' -- the value was null");
+            _append_val_null();
+            _line_progressed(2);
+            return true;
+        }
+        else if(rem.begins_with(','))
+        {
+            _c4dbgp("found ',' -- the value was null");
+            _append_val_null();
+            _line_progressed(1);
             return true;
         }
         else

--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -576,11 +576,6 @@ bool Parser::_handle_seq_expl()
     else if(rem.begins_with(']'))
     {
         _c4dbgp("end the sequence");
-        if(has_all(RVAL))
-        {
-            _c4dbgp("there is a value pending - using null");
-            _append_val_null();
-        }
         _pop_level();
         _line_progressed(1);
         if(has_all(RSEQIMAP))

--- a/src/c4/yml/parse.hpp
+++ b/src/c4/yml/parse.hpp
@@ -154,11 +154,14 @@ private:
     void  _start_new_doc(csubstr rem);
     void  _end_stream();
 
-    NodeData* _append_val(csubstr const& val);
-    NodeData* _append_key_val(csubstr const& val);
+    NodeData* _append_val(csubstr val);
+    NodeData* _append_key_val(csubstr val);
+    inline NodeData* _append_val_null() { return _append_val({}/*"~"*/); }
+    inline NodeData* _append_key_val_null() { return _append_key_val({}/*"~"*/); }
     bool  _rval_dash_start_or_continue_seq();
 
     void  _store_scalar(csubstr const& s);
+    void  _store_scalar_null() { _store_scalar({}/*"~"*/); }
     csubstr _consume_scalar();
     void  _move_scalar_from_top();
 

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1628,11 +1628,11 @@ size_t Tree::_next_node(lookup_result * r, bool modify, _lookup_path_token *pare
                     {
                         if(is_map(r->closest))
                         {
-                            to_keyval(node, "~", "~");
+                            to_keyval(node, /*"~"*/{}, /*"~"*/{});
                         }
                         else if(is_seq(r->closest))
                         {
-                            to_val(node, "~");
+                            to_val(node, /*"~"*/{});
                         }
                     }
                 }

--- a/test/test_case.cpp
+++ b/test/test_case.cpp
@@ -239,6 +239,58 @@ TEST(CaseNode, setting_up)
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
+NodeType_e CaseNode::_guess() const
+{
+    NodeType t;
+    C4_ASSERT(!val.empty() != !children.empty() || (val.empty() && children.empty()));
+    if(children.empty())
+    {
+        C4_ASSERT(parent);
+        if(key.empty())
+        {
+            t = VAL;
+        }
+        else
+        {
+            t = KEYVAL;
+        }
+    }
+    else
+    {
+        NodeType_e has_key = key.empty() ? NOTYPE : KEY;
+        auto const& ch = children.front();
+        if(ch.key.empty())
+        {
+            t = (has_key|SEQ);
+        }
+        else
+        {
+            t = (has_key|MAP);
+        }
+    }
+    if( ! key_tag.empty())
+    {
+        C4_ASSERT( ! key.empty());
+        t.add(KEYTAG);
+    }
+    if( ! val_tag.empty())
+    {
+        C4_ASSERT( ! val.empty() || ! children.empty());
+        t.add(VALTAG);
+    }
+    if( ! key_anchor.str.empty())
+    {
+        t.add(key_anchor.type);
+    }
+    if( ! val_anchor.str.empty())
+    {
+        t.add(val_anchor.type);
+    }
+    return t;
+}
+
+
+//-----------------------------------------------------------------------------
 void CaseNode::compare_child(yml::NodeRef const& n, size_t pos) const
 {
     EXPECT_TRUE(pos < n.num_children());

--- a/test/test_case.hpp
+++ b/test/test_case.hpp
@@ -300,55 +300,7 @@ public:
         }
     }
 
-    NodeType_e _guess() const
-    {
-        NodeType t;
-        C4_ASSERT(!val.empty() != !children.empty() || (val.empty() && children.empty()));
-        if(children.empty())
-        {
-            C4_ASSERT(parent);
-            if(key.empty())
-            {
-                t = VAL;
-            }
-            else
-            {
-                t = KEYVAL;
-            }
-        }
-        else
-        {
-            NodeType_e has_key = key.empty() ? NOTYPE : KEY;
-            auto const& ch = children.front();
-            if(ch.key.empty())
-            {
-                t = (has_key|SEQ);
-            }
-            else
-            {
-                t = (has_key|MAP);
-            }
-        }
-        if( ! key_tag.empty())
-        {
-            C4_ASSERT( ! key.empty());
-            t.add(KEYTAG);
-        }
-        if( ! val_tag.empty())
-        {
-            C4_ASSERT( ! val.empty() || ! children.empty());
-            t.add(VALTAG);
-        }
-        if( ! key_anchor.str.empty())
-        {
-            t.add(key_anchor.type);
-        }
-        if( ! val_anchor.str.empty())
-        {
-            t.add(val_anchor.type);
-        }
-        return t;
-    }
+    NodeType_e _guess() const;
 
     bool is_root() const { return parent; }
     bool is_doc() const { return type & DOC; }

--- a/test/test_github_issues.cpp
+++ b/test/test_github_issues.cpp
@@ -202,7 +202,7 @@ C("github3-problem2-ex1",
 R"(
 audio resource:
 )",
-L{N("audio resource", "~")}
+L{N(KEYVAL, "audio resource", /*"~"*/{})}
 ),
 C("github3-problem2-ex2",
 R"(
@@ -210,7 +210,7 @@ audio resource:
 more:
   example: y
 )",
-L{N("audio resource", "~"), N("more", L{N("example", "y")})}
+L{N(KEYVAL, "audio resource", /*"~"*/{}), N("more", L{N("example", "y")})}
 ),
 
 C("github3-problem3",

--- a/test/test_null_val.cpp
+++ b/test/test_null_val.cpp
@@ -24,7 +24,7 @@ CASE_GROUP(NULL_VAL)
 C("null map vals, expl",
 R"({foo: , bar: , baz: }
 )",
-L{N("foo", "~"), N("bar", "~"), N("baz", "~")}
+L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})}
 ),
 
 C("null map vals, impl",
@@ -33,7 +33,7 @@ foo:
 bar: 
 baz: 
 )",
-L{N("foo", "~"), N("bar", "~"), N("baz", "~")}
+L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})}
 ),
 
 C("null seq vals, impl",
@@ -41,7 +41,7 @@ R"(-
 - 
 - 
 )",
-L{N("~"), N("~"), N("~")}
+L{N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{})}
 ),
 
 C("null seq vals in map, impl, mixed 1",
@@ -53,7 +53,7 @@ foo:
 bar: 
 baz: 
 )",
-L{N("foo", L{N("~"), N("~"), N("~")}), N("bar", "~"), N("baz", "~")}
+L{N("foo", L{N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{})}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})}
 ),
 
 C("null seq vals in map, impl, mixed 2",
@@ -65,7 +65,7 @@ bar:
   - 
 baz: 
 )",
-L{N("foo", "~"), N("bar", L{N("~"), N("~"), N("~")}), N("baz", "~")}
+L{N(KEYVAL, "foo", /*"~"*/{}), N("bar", L{N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{})}), N(KEYVAL, "baz", /*"~"*/{})}
 ),
 
 C("null seq vals in map, impl, mixed 3",
@@ -77,7 +77,7 @@ baz:
   - 
   - 
 )",
-L{N("foo", "~"), N("bar", "~"), N("baz", L{N("~"), N("~"), N("~")})}
+L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N("baz", L{N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{})})}
 ),
 
 C("null map vals in seq, impl, mixed 1",
@@ -88,7 +88,7 @@ R"(
 - 
 - 
 )",
-L{N(L{N("foo", "~"), N("bar", "~"), N("baz", "~")}), N("~"), N("~")}
+L{N(L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})}), N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{})}
 ),
 
 C("null map vals in seq, impl, mixed 2",
@@ -99,7 +99,7 @@ R"(
   baz: 
 - 
 )",
-L{N("~"), N(L{N("foo", "~"), N("bar", "~"), N("baz", "~")}), N("~")}
+L{N(VAL, /*"~"*/{}), N(L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})}), N(VAL, /*"~"*/{})}
 ),
 
 C("null map vals in seq, impl, mixed 3",
@@ -110,7 +110,7 @@ R"(
   bar: 
   baz: 
 )",
-L{N("~"), N("~"), N(L{N("foo", "~"), N("bar", "~"), N("baz", "~")})}
+L{N(VAL, /*"~"*/{}), N(VAL, /*"~"*/{}), N(L{N(KEYVAL, "foo", /*"~"*/{}), N(KEYVAL, "bar", /*"~"*/{}), N(KEYVAL, "baz", /*"~"*/{})})}
 ),
 
 C("issue84.1",
@@ -124,7 +124,7 @@ your case:
 whatever: baz
 )",
 L{
-N("fixed case", L{N("foo", "a"), N("bar", "~")}),
+N("fixed case", L{N("foo", "a"), N(KEYVAL, "bar", /*"~"*/{})}),
 N("your case", L{N("foo", "a"), N("bar", "")}),
 N("whatever", "baz"),
 }),
@@ -161,7 +161,7 @@ N("param_root", L{
             N("IsLifeInfinite", "false"),
             N("ElectricalDischarge", "1.0"),
             N("IsBurnOutBorn", "false"),
-            N("BurnOutBornName", "~"),
+            N(KEYVAL, "BurnOutBornName", /*"~"*/{}),
             N("IsBurnOutBornIdent", "false"),
             N("ChangeDropTableName", ""),
         }),
@@ -188,7 +188,7 @@ N("param_root", L{
     N("objects", L{
         N("TestContent", L{
             N("Str64_empty", ""),
-            N("Str64_empty2", "~"),
+            N(KEYVAL, "Str64_empty2", /*"~"*/{}),
             N("Str64_empty3", ""),
         }),
     }),

--- a/test/test_null_val.cpp
+++ b/test/test_null_val.cpp
@@ -23,12 +23,12 @@ TEST(null_val, simple)
 
     EXPECT_EQ(tree["foo"].val(), nullptr);
     EXPECT_EQ(tree["bar"].val(), "");
-    EXPECT_EQ(tree["baz"].num_children(), 4);
+    EXPECT_EQ(tree["baz"].num_children(), 4u);
     EXPECT_EQ(tree["baz"][0].val(), nullptr);
     EXPECT_EQ(tree["baz"][1].val(), nullptr);
     EXPECT_EQ(tree["baz"][2].val(), nullptr);
     EXPECT_EQ(tree["baz"][3].val(), nullptr);
-    EXPECT_EQ(tree["bat"].num_children(), 4);
+    EXPECT_EQ(tree["bat"].num_children(), 4u);
     EXPECT_EQ(tree["bat"][0].val(), nullptr);
     EXPECT_EQ(tree["bat"][1].val(), nullptr);
     EXPECT_EQ(tree["bat"][2].val(), nullptr);
@@ -44,7 +44,7 @@ TEST(null_val, simple)
 - 
 - 
 )");
-    EXPECT_EQ(tree.rootref().num_children(), 6);
+    EXPECT_EQ(tree.rootref().num_children(), 6u);
     EXPECT_EQ(tree[0].val(), nullptr);
     EXPECT_EQ(tree[1].val(), nullptr);
     EXPECT_EQ(tree[2].val(), nullptr);

--- a/test/test_null_val.cpp
+++ b/test/test_null_val.cpp
@@ -19,20 +19,24 @@ namespace yml {
 
 TEST(null_val, simple)
 {
-    auto tree = parse("{foo: , bar: '', baz: [,,,], bat: [ , , , ]}");
+    auto tree = parse("{foo: , bar: '', baz: [,,,], bat: [ , , , ], two: [,,], one: [,], empty: []}");
 
     EXPECT_EQ(tree["foo"].val(), nullptr);
     EXPECT_EQ(tree["bar"].val(), "");
-    EXPECT_EQ(tree["baz"].num_children(), 4u);
+    ASSERT_EQ(tree["baz"].num_children(), 3u);
     EXPECT_EQ(tree["baz"][0].val(), nullptr);
     EXPECT_EQ(tree["baz"][1].val(), nullptr);
     EXPECT_EQ(tree["baz"][2].val(), nullptr);
-    EXPECT_EQ(tree["baz"][3].val(), nullptr);
-    EXPECT_EQ(tree["bat"].num_children(), 4u);
+    ASSERT_EQ(tree["bat"].num_children(), 3u);
     EXPECT_EQ(tree["bat"][0].val(), nullptr);
     EXPECT_EQ(tree["bat"][1].val(), nullptr);
     EXPECT_EQ(tree["bat"][2].val(), nullptr);
-    EXPECT_EQ(tree["bat"][3].val(), nullptr);
+    ASSERT_EQ(tree["two"].num_children(), 2u);
+    EXPECT_EQ(tree["two"][0].val(), nullptr);
+    EXPECT_EQ(tree["two"][1].val(), nullptr);
+    ASSERT_EQ(tree["one"].num_children(), 1u);
+    EXPECT_EQ(tree["one"][0].val(), nullptr);
+    EXPECT_EQ(tree["empty"].num_children(), 0u);
 
     tree = parse(R"(
 # these have no space after the dash
@@ -44,7 +48,7 @@ TEST(null_val, simple)
 - 
 - 
 )");
-    EXPECT_EQ(tree.rootref().num_children(), 6u);
+    ASSERT_EQ(tree.rootref().num_children(), 6u);
     EXPECT_EQ(tree[0].val(), nullptr);
     EXPECT_EQ(tree[1].val(), nullptr);
     EXPECT_EQ(tree[2].val(), nullptr);

--- a/test/test_null_val.cpp
+++ b/test/test_null_val.cpp
@@ -17,6 +17,43 @@ namespace yml {
     "issue84.3"
 
 
+TEST(null_val, simple)
+{
+    auto tree = parse("{foo: , bar: '', baz: [,,,], bat: [ , , , ]}");
+
+    EXPECT_EQ(tree["foo"].val(), nullptr);
+    EXPECT_EQ(tree["bar"].val(), "");
+    EXPECT_EQ(tree["baz"].num_children(), 4);
+    EXPECT_EQ(tree["baz"][0].val(), nullptr);
+    EXPECT_EQ(tree["baz"][1].val(), nullptr);
+    EXPECT_EQ(tree["baz"][2].val(), nullptr);
+    EXPECT_EQ(tree["baz"][3].val(), nullptr);
+    EXPECT_EQ(tree["bat"].num_children(), 4);
+    EXPECT_EQ(tree["bat"][0].val(), nullptr);
+    EXPECT_EQ(tree["bat"][1].val(), nullptr);
+    EXPECT_EQ(tree["bat"][2].val(), nullptr);
+    EXPECT_EQ(tree["bat"][3].val(), nullptr);
+
+    tree = parse(R"(
+# these have no space after the dash
+-
+-
+-
+# these have ONE space after the dash
+- 
+- 
+- 
+)");
+    EXPECT_EQ(tree.rootref().num_children(), 6);
+    EXPECT_EQ(tree[0].val(), nullptr);
+    EXPECT_EQ(tree[1].val(), nullptr);
+    EXPECT_EQ(tree[2].val(), nullptr);
+    EXPECT_EQ(tree[3].val(), nullptr);
+    EXPECT_EQ(tree[4].val(), nullptr);
+    EXPECT_EQ(tree[5].val(), nullptr);
+}
+
+
 CASE_GROUP(NULL_VAL)
 {
     APPEND_CASES(

--- a/test/test_seq_of_map.cpp
+++ b/test/test_seq_of_map.cpp
@@ -151,7 +151,7 @@ c : [
 L{
   N("a", L{N(MAP, L{N("", "foo")}),}),
   N("b", L{N(MAP, L{N("", "foo")}),}),
-  N("c", L{N(MAP, L{N("", "~")}), N(MAP, L{N("", "~")}),}),
+  N("c", L{N(MAP, L{N(KEYVAL, "", /*"~"*/{})}), N(MAP, L{N(KEYVAL, "", /*"~"*/{})}),}),
 }
 ),
 

--- a/test/test_simple_map.cpp
+++ b/test/test_simple_map.cpp
@@ -180,12 +180,12 @@ f:
 g:
 foo: bar
 )",
-L{N("key", "val"), N("a", "~"), N("b", "~"), N("c", "~"), N("d", "~"), N("e", "~"), N("f", "~"), N("g", "~"), N("foo", "bar"),}
+L{N("key", "val"), N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{}), N(KEYVAL, "c", /*"~"*/{}), N(KEYVAL, "d", /*"~"*/{}), N(KEYVAL, "e", /*"~"*/{}), N(KEYVAL, "f", /*"~"*/{}), N(KEYVAL, "g", /*"~"*/{}), N("foo", "bar"),}
 ),
 
 C("simple map expl, null values 1",
 R"({key: val, a, b, c, d, e: , f: , g: , foo: bar})",
-L{N("key", "val"), N("a", "~"), N("b", "~"), N("c", "~"), N("d", "~"), N("e", "~"), N("f", "~"), N("g", "~"), N("foo", "bar"),}
+L{N("key", "val"), N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{}), N(KEYVAL, "c", /*"~"*/{}), N(KEYVAL, "d", /*"~"*/{}), N(KEYVAL, "e", /*"~"*/{}), N(KEYVAL, "f", /*"~"*/{}), N(KEYVAL, "g", /*"~"*/{}), N("foo", "bar"),}
 ),
 
 C("simple map expl, null values 2",
@@ -197,11 +197,11 @@ R"(
 - {a, b: 1, c: 2}
 )",
 L{
-   N(L{N("a", "~")}),
-   N(L{N("a", "~"), N("b", "~"), N("c", "~")}),
-   N(L{N("a", "1"), N("b", "2"), N("c", "~")}),
-   N(L{N("a", "1"), N("b", "~"), N("c", "2")}),
-   N(L{N("a", "~"), N("b", "1"), N("c", "2")}),
+   N(L{N(KEYVAL, "a", /*"~"*/{})}),
+   N(L{N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{}), N(KEYVAL, "c", /*"~"*/{})}),
+   N(L{N("a", "1"), N("b", "2"), N(KEYVAL, "c", /*"~"*/{})}),
+   N(L{N("a", "1"), N(KEYVAL, "b", /*"~"*/{}), N("c", "2")}),
+   N(L{N(KEYVAL, "a", /*"~"*/{}), N("b", "1"), N("c", "2")}),
  }
 ),
 
@@ -441,22 +441,22 @@ e ,f: val , 000
 h ,i: val ,000
 })",
     L{ // this is crazy...
-        N{"a", "~"}, N{"b", "val"}, N{"000 c", "~"},
-                     N{"d", "val"}, N{"000 e", "~"},
-                     N{"f", "val"}, N{"000 h", "~"},
-                     N{"i", "val"}, N{"000 a", "~"},
-                     N{"b", "val"}, N{"000 c", "~"},
-                     N{"d", "val"}, N{"000 e", "~"},
-                     N{"f", "val"}, N{"000 h", "~"},
-                     N{"i", "val"}, N{"000 a", "~"},
-                     N{"b", "val"}, N{"000 c", "~"},
-                     N{"d", "val"}, N{"000 e", "~"},
-                     N{"f", "val"}, N{"000 h", "~"},
-                     N{"i", "val"}, N{"000 a", "~"},
-                     N{"b", "val"}, N{"000 c", "~"},
-                     N{"d", "val"}, N{"000 e", "~"},
-                     N{"f", "val"}, N{"000 h", "~"},
-                     N{"i", "val"}, N{"000", "~"},
+        N(KEYVAL, "a", /*"~"*/{}), N("b", "val"), N(KEYVAL, "000 c", /*"~"*/{}),
+        N("d", "val"), N(KEYVAL, "000 e", /*"~"*/{}),
+        N("f", "val"), N(KEYVAL, "000 h", /*"~"*/{}),
+        N("i", "val"), N(KEYVAL, "000 a", /*"~"*/{}),
+        N("b", "val"), N(KEYVAL, "000 c", /*"~"*/{}),
+        N("d", "val"), N(KEYVAL, "000 e", /*"~"*/{}),
+        N("f", "val"), N(KEYVAL, "000 h", /*"~"*/{}),
+        N("i", "val"), N(KEYVAL, "000 a", /*"~"*/{}),
+        N("b", "val"), N(KEYVAL, "000 c", /*"~"*/{}),
+        N("d", "val"), N(KEYVAL, "000 e", /*"~"*/{}),
+        N("f", "val"), N(KEYVAL, "000 h", /*"~"*/{}),
+        N("i", "val"), N(KEYVAL, "000 a", /*"~"*/{}),
+        N("b", "val"), N(KEYVAL, "000 c", /*"~"*/{}),
+        N("d", "val"), N(KEYVAL, "000 e", /*"~"*/{}),
+        N("f", "val"), N(KEYVAL, "000 h", /*"~"*/{}),
+        N("i", "val"), N(KEYVAL, "000", /*"~"*/{}),
 }
 ),
 

--- a/test/test_simple_set.cpp
+++ b/test/test_simple_set.cpp
@@ -58,7 +58,7 @@ R"(!!set
 ? a
 ? b
 )",
-N(TL("!!set", L{N("a", "~"), N("b", "~")}))
+N(TL("!!set", L{N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{})}))
 ),
 
 C("doc as set",
@@ -67,7 +67,7 @@ R"(--- !!set
 ? bb
 ? cc
 )",
-N(STREAM, L{N(DOCMAP, TL("!!set", L{N("aa", "~"), N("bb", "~"), N("cc", "~")}))})
+N(STREAM, L{N(DOCMAP, TL("!!set", L{N(KEYVAL, "aa", /*"~"*/{}), N(KEYVAL, "bb", /*"~"*/{}), N(KEYVAL, "cc", /*"~"*/{})}))})
 ),
 
 C("sets 2XXW",
@@ -78,9 +78,9 @@ R"(
 ? Ken Griff
 )",
 N(STREAM, L{N(DOCMAP, TL("!!set", L{
-  N("Mark McGwire", "~"),
-  N("Sammy Sosa", "~"),
-  N("Ken Griff", "~"),})
+  N(KEYVAL, "Mark McGwire", /*"~"*/{}),
+  N(KEYVAL, "Sammy Sosa", /*"~"*/{}),
+  N(KEYVAL, "Ken Griff", /*"~"*/{}),})
 )})),
 
 C("sets 2XXW, indented",
@@ -91,9 +91,9 @@ R"(
     ? Ken Griff
 )",
 N(STREAM, L{N(DOCMAP, TL("!!set", L{
-  N("Mark McGwire", "~"),
-  N("Sammy Sosa", "~"),
-  N("Ken Griff", "~"),})
+  N(KEYVAL, "Mark McGwire", /*"~"*/{}),
+  N(KEYVAL, "Sammy Sosa", /*"~"*/{}),
+  N(KEYVAL, "Ken Griff", /*"~"*/{}),})
 )})),
 
 C("sets 2XXW, no set",
@@ -104,9 +104,9 @@ R"(
 ? Ken Griff
 )",
 N(STREAM, L{N(DOCMAP, L{
-  N("Mark McGwire", "~"),
-  N("Sammy Sosa", "~"),
-  N("Ken Griff", "~"),}
+  N(KEYVAL, "Mark McGwire", /*"~"*/{}),
+  N(KEYVAL, "Sammy Sosa", /*"~"*/{}),
+  N(KEYVAL, "Ken Griff", /*"~"*/{}),}
 )})),
 
 C("sets 2XXW, no doc",
@@ -116,9 +116,9 @@ R"(!!set
 ? Ken Griff
 )",
 TL("!!set", L{
-  N("Mark McGwire", "~"),
-  N("Sammy Sosa", "~"),
-  N("Ken Griff", "~"),
+  N(KEYVAL, "Mark McGwire", /*"~"*/{}),
+  N(KEYVAL, "Sammy Sosa", /*"~"*/{}),
+  N(KEYVAL, "Ken Griff", /*"~"*/{}),
 })),
 
 C("sets 2XXW, no doc, no set",
@@ -128,9 +128,9 @@ R"(
 ? Ken Griff
 )",
 L{
-  N("Mark McGwire", "~"),
-  N("Sammy Sosa", "~"),
-  N("Ken Griff", "~"),
+  N(KEYVAL, "Mark McGwire", /*"~"*/{}),
+  N(KEYVAL, "Sammy Sosa", /*"~"*/{}),
+  N(KEYVAL, "Ken Griff", /*"~"*/{}),
 }),
 
     )

--- a/test/test_tag_property.cpp
+++ b/test/test_tag_property.cpp
@@ -137,8 +137,8 @@ N(STREAM, L{
     N(DOCVAL, TS("!!str", "a: b")),
     N(DOCMAP, L{N(TS("!!str", "a"), "b")}),
     N(DOCVAL, TS("!!str", "a b")),
-    N(DOCMAP, TL("!!set", L{N("a", "~"), N("b", "~")})),
-    N(DOCMAP, TL("!!set", L{N("a", "~"), N("b", "~")})),
+    N(DOCMAP, TL("!!set", L{N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{})})),
+    N(DOCMAP, TL("!!set", L{N(KEYVAL, "a", /*"~"*/{}), N(KEYVAL, "b", /*"~"*/{})})),
 })
 ),
 


### PR DESCRIPTION
***Breaking change***: null values in YAML are now parsed to null strings instead of YAML null token `"~"`:
```c++
auto tree = parse("{foo: , bar: ''}");

// previous:
assert(tree["foo"].val() == "~");
assert(tree["bar"].val() == "");
    
// now:
assert(tree["foo"].val() == nullptr); // notice that this is now null
assert(tree["bar"].val() == "");
```
Fixes [#84](https://github.com/biojppm/rapidyaml/issues/84).
