### PR TITLE
Fix parse failure in comments ending with colon (#124)

### DIFF
--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -801,7 +801,7 @@ bool Parser::_handle_seq_impl()
                 rem = rem.sub(skip);
             }
 
-            if(rem.begins_with(": ") || rem.ends_with(':'))
+            if(!rem.begins_with('#') && (rem.begins_with(": ") || rem.ends_with(':')))
             {
                 _c4dbgp("actually, the scalar is the first key of a map, and it opens a new scope");
                 addrem_flags(RNXT, RVAL); // before _push_level! This prepares the current level for popping by setting it to RNXT

--- a/test/test_basic.cpp
+++ b/test/test_basic.cpp
@@ -1701,6 +1701,33 @@ a:
     print_tree(t);
 }
 
+TEST(general, github_issue_124)
+{
+    // All these inputs are basically the same.
+    // However, the comment was found to confuse the parser in #124.
+    const std::string yaml[] =
+        {
+            "a:\n  - b\nc: d",
+            "a:\n  - b\n\n# ignore me:\nc: d",
+            "a:\n  - b\n\n  # ignore me:\nc: d",
+            "a:\n  - b\n\n    # ignore me:\nc: d",
+            "a:\n  - b\n\n#:\nc: d", // also try with just a ':' in the comment
+            "a:\n  - b\n\n# :\nc: d",
+            "a:\n  - b\n\n#\nc: d",  // also try with empty comment
+        };
+
+    for(const auto &inp : yaml)
+    {
+        Tree t = parse(c4::to_csubstr(inp));
+        auto s = emitrs<std::string>(t);
+
+        // The re-emitted output should not contain the comment.
+        const char expected[] = "a:\n  - b\nc: d\n";
+        EXPECT_EQ(s, std::string(expected));
+    }
+}
+
+
 //-------------------------------------------
 // this is needed to use the test case library
 Case const* get_case(csubstr /*name*/)


### PR DESCRIPTION
As discussed in #124, the parser gets confused on the following input:

```yaml
a:
  - b

# ignore me:
c: d
```

This PR adds a test case for this input and also contains a fix.