### PR TITLE
[fix] update group test after function is renamed

### DIFF
--- a/test/test_group.cpp
+++ b/test/test_group.cpp
@@ -197,7 +197,7 @@ void YmlTestCase::_test_emit_yml_ofstream(CaseDataLineEndings *cd)
         f << cd->parsed_tree;
     }
     auto r = c4::fs::file_get_contents<std::string>(fn.c_str());
-    c4::fs::delete_file(fn.c_str());
+    c4::fs::rmfile(fn.c_str());
     // using ofstream will use \r\n. So delete it.
     std::string filtered;
     filtered.reserve(r.size());


### PR DESCRIPTION
The following error was found when building RapidYaml on MSVC, recent change https://github.com/biojppm/c4fs/commit/6fbf3136c1dab5357f303249033276c96700f536 renamed function from 'delete_file' to 'rmfile' which caused this issue, fix it now.

F:\gitP\biojppm\rapidyaml\test\test_group.cpp(200,13): error C2039: 'delete_file': is not a member of 'c4::fs'
F:\gitP\biojppm\rapidyaml\build_amd64\subprojects\c4fs\src\src\c4/fs/fs.hpp(21): note: see declaration of 'c4::fs'
F:\gitP\biojppm\rapidyaml\test\test_group.cpp(200,24): error C3861: 'delete_file': identifier not found