### PR TITLE
Add missing node predicates in the Python API

### DIFF
--- a/api/python/Makefile
+++ b/api/python/Makefile
@@ -89,7 +89,7 @@ install: | $(ACTIVATE_SCRIPT)
 .PHONY: install
 
 test: | $(ACTIVATE_SCRIPT)
-	${ACTIVATE} pytest
+	${ACTIVATE} python -m nose ryml/tests
 
 .PHONY: test
 

--- a/api/python/ryml/tests/test_parse.py
+++ b/api/python/ryml/tests/test_parse.py
@@ -156,7 +156,7 @@ def check_tree_mod(ut, t):
 # -----------------------------------------------------------------------------
 class SimpleHardcoded:
 
-    yaml = "{HELLO: a, foo: b, bar: c, baz: d, seq: [0, 1, 2, 3]}"
+    yaml = "{'HELLO': a, foo: \"b\", bar: c, baz: d, seq: [0, 1, 2, 3]}"
 
     def check(self, ut, t):
         # some convenient shorthands
@@ -209,6 +209,29 @@ class SimpleHardcoded:
         eq(t.val(7), b"1")
         eq(t.val(8), b"2")
         eq(t.val(9), b"3")
+        tr(t.is_key_quoted(1))
+        fs(t.is_key_quoted(2))
+        fs(t.is_key_quoted(3))
+        fs(t.is_key_quoted(4))
+        fs(t.is_key_quoted(5))
+        fs(t.is_val_quoted(1))
+        tr(t.is_val_quoted(2))
+        fs(t.is_val_quoted(3))
+        fs(t.is_val_quoted(4))
+        fs(t.is_val_quoted(5))
+        fs(t.is_val_quoted(6))
+        fs(t.is_val_quoted(7))
+        fs(t.is_val_quoted(8))
+        fs(t.is_val_quoted(9))
+        tr(t.is_quoted(1))
+        tr(t.is_quoted(2))
+        fs(t.is_quoted(3))
+        fs(t.is_quoted(4))
+        fs(t.is_quoted(5))
+        fs(t.is_quoted(6))
+        fs(t.is_quoted(7))
+        fs(t.is_quoted(8))
+        fs(t.is_quoted(9))
         tr(t.has_sibling(1, b"bar"))
         tr(t.has_sibling(1, b"baz"))
         tr(t.has_sibling(2, b"foo"))

--- a/api/ryml.i
+++ b/api/ryml.i
@@ -326,6 +326,10 @@ struct NodeType
     bool is_key_ref() const;
     bool is_val_ref() const;
     bool is_ref() const;
+    bool is_anchor_or_ref() const;
+    bool is_key_quoted() const;
+    bool is_val_quoted() const;
+    bool is_quoted() const;
 };
 
 
@@ -389,6 +393,10 @@ public:
     bool is_key_ref(size_t node) const;
     bool is_val_ref(size_t node) const;
     bool is_ref(size_t node) const;
+    bool is_anchor_or_ref(size_t node) const;
+    bool is_key_quoted(size_t node) const;
+    bool is_val_quoted(size_t node) const;
+    bool is_quoted(size_t node) const;
     bool is_anchor(size_t node) const;
     bool parent_is_seq(size_t node) const;
     bool parent_is_map(size_t node) const;


### PR DESCRIPTION
This PR adds node predicates `is_anchor_or_ref()`, `is_quoted()`, `is_key_quoted()` and `is_val_quoted()` to the SWIG API definition for both `struct Tree` and `struct NodeType`.

Additionally, the PR changes the `SimpleHardCoded` Python API test case to have a quoted key and value respectively and adds assertions for the quoting-related predicates.

Fixes #165 