### PR TITLE
[fix] ensure keys starting with `%` are quoted to prevent them from being treated as a directive

### DIFF
--- a/src/c4/yml/emit.def.hpp
+++ b/src/c4/yml/emit.def.hpp
@@ -827,8 +827,8 @@ void Emitter<Writer>::_write_scalar(csubstr s, bool was_quoted)
                 // has leading whitespace
                 s.begins_with_any(" \n\t\r")
                 ||
-                // looks like reference or anchor
-                s.begins_with_any("*&")
+                // looks like reference or anchor or would be treated as a directive
+                s.begins_with_any("*&%")
                 ||
                 s.begins_with("<<")
                 ||


### PR DESCRIPTION
Hey, ran into this small edge-case when working with this library.  Consider the initial YAML file:
```yaml
'%ROOT':
  timeCreated: 1642559912
  timeModified: 1642553437
somethingElse:
  timeCreated: 1642559912
  timeModified: 1642553437
```
After parsing and re-emitting this:
```cpp
std::optional<std::vector<u8>> buf(Host::ReadResourceFile("test.yaml"));
const ryml::substr view = c4::basic_substring<char>(reinterpret_cast<char*>(buf->data()), buf->size());
ryml::Tree tree = ryml::parse(view);

const std::string full_filename(Path::CombineStdString(EmuFolders::Resources, "test-modified.yaml"));
FILE* modifiedFile = fopen(full_filename.c_str(), "w");
ryml::emit(tree, tree.root_id(), modifiedFile);
fclose(modifiedFile);
```
The quotes are lost:
```yaml
%ROOT:
  timeCreated: 1642559912
  timeModified: 1642553437
somethingElse:
  timeCreated: 1642559912
  timeModified: 1642553437
```

The `%ROOT` key will now be treated as a preprocessor directive (i assume), which means the file will unexpectedly be handled differently and modified.  Parsing the above and re-emitting results in the following:
```yaml
timeCreated: 1642559912
timeModified: 1642553437
somethingElse:
  timeCreated: 1642559912
  timeModified: 1642553437
```

Which completely changes the schema.  Ensuring keys that begin with `%` are quoted seems to prevent this edge-case.

Relevant spec docs - https://yaml.org/spec/1.2.2/#example-directive-indicator
