### PR TITLE
fix possible error: local variable 'c4core_amalgamated' referenced before assignment.

### DIFF
--- a/tools/amalgamate.py
+++ b/tools/amalgamate.py
@@ -43,6 +43,7 @@ def amalgamate_ryml(filename: str,
                     with_c4core: bool,
                     with_fastfloat: bool,
                     with_stl: bool):
+    c4core_amalgamated = ""
     if with_c4core:
         c4core_amalgamated = "src/c4/c4core_all.hpp"
         am_c4core.amalgamate_c4core(f"{projdir}/{c4core_amalgamated}",


### PR DESCRIPTION
When using amalgamate.py to generate head files, `--no-c4core` can cause error:
```
Traceback (most recent call last):
  File "tools/amalgamate.py", line 126, in <module>
    amalgamate_ryml(filename=args.output,
  File "tools/amalgamate.py", line 75, in amalgamate_ryml
    am.onlyif(with_c4core, c4core_amalgamated),
UnboundLocalError: local variable 'c4core_amalgamated' referenced before assignment
```
So `c4core_amalgamated` needs to be defined even if `with_c4core` is false. Here I defined it as a empty string.