### PR TITLE
modify sample_create_trees()

### DIFF
--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -1751,7 +1751,7 @@ void sample_create_trees()
         std::string a_drop = "a drop of golden sun";
         // this will copy the string to the tree's arena:
         // (see the serialization samples below)
-        root["ray"] << "a drop of golden sun";
+        root["ray"] << a_drop;
         // and now you can modify the original string without changing
         // the tree:
         a_drop[0] = 'Z';


### PR DESCRIPTION
In `quickstart.cpp`, due to line 1749, the sample wants to show how to use `<<` to avoid lifetime dependency. Thus, a `std::string a_drop` is defined, but after this `a_drop` is not really used.