### PR TITLE
[wip] add subset string view comparator

### DIFF
--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1282,156 +1282,96 @@ void Tree::merge_with(Tree const *src, size_t src_node, size_t dst_node)
 
 //-----------------------------------------------------------------------------
 
-bool Tree::is_subset_strview(Tree const *dst, size_t dst_node, size_t src_node)
+bool Tree::has_all(Tree const* reftree, size_t refnode, size_t subject_node) const
 {
-    return _is_subset_strview_init(dst, dst_node, src_node, false /* don't skip values */);
+    _RYML_CB_ASSERT(m_callbacks, reftree != nullptr);
+    if (subject_node == NONE)
+        subject_node = root_id();
+    if (refnode == NONE)
+        refnode = reftree->root_id();
+
+    return _has_all_recursive(reftree, refnode, subject_node);
 }
 
-bool Tree::is_subset_strview_skipval(Tree const *dst, size_t dst_node, size_t src_node)
+bool Tree::_has_all_recursive(Tree const* reftree, size_t refnode, size_t subject_node) const
 {
-    return _is_subset_strview_init(dst, dst_node, src_node, true /* skip values */);
-}
-
-bool Tree::_is_subset_strview_init(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val)
-{
-    _RYML_CB_ASSERT(m_callbacks, dst != nullptr);
-    if (src_node == NONE)
-        src_node = root_id();
-    if (dst_node == NONE)
-        dst_node = dst->root_id();
-
-    // guard against different types
-    if(!_is_subset_type_equal(dst, dst_node, src_node))
-        return false;
-
-    // stream
-    if (is_stream(src_node))
+    if (is_val(subject_node))
     {
-        if (num_children(src_node) > dst->num_children(dst_node))
+        if( ! reftree->is_val(refnode))
             return false;
-
-        size_t dch = dst->first_child(dst_node);
-        for (size_t sch = first_child(src_node); sch != NONE;sch = next_sibling(sch))
-        {
-            if (!_is_subset_strview_recursive(dst, dch, sch, skip_val))
-                return false;
-            dch = dst->next_sibling(dch);
-        }
+        // skip value comparison
         return true;
     }
-    else
+    else if (is_keyval(subject_node))
     {
-        return _is_subset_strview_recursive(dst, dst_node, src_node, skip_val);
-    }
-}
-
-bool Tree::_is_subset_strview_recursive(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val)
-{
-    // guard against different types
-    if(!_is_subset_type_equal(dst, dst_node, src_node))
-        return false;
-
-    // docval | val
-    if (is_val(src_node))
-    {
-        if (is_val_anchor(src_node))
-        {
-            if (val_anchor(src_node) != dst->val_anchor(dst_node))
-                return false;
-        }
-
-        if(skip_val)
-          return true;
-
-        if (val(src_node) == dst->val(dst_node))
+        if( ! reftree->is_keyval(refnode))
+            return false;
+        if (key(subject_node) == reftree->key(refnode))
             return true;
         return false;
     }
-    // keyval
-    else if (is_keyval(src_node))
+    else if (is_map(subject_node))
     {
-        if (is_key_anchor(src_node))
-        {
-            if (key_anchor(src_node) != dst->key_anchor(dst_node))
-                return false;
-        }
-
-        if (is_val_anchor(src_node))
-        {
-            if (val_anchor(src_node) != dst->val_anchor(dst_node))
-                return false;
-        }
-
-        if (key(src_node) == dst->key(dst_node) && (skip_val || val(src_node) == dst->val(dst_node)))
-            return true;
-        return false;
-    }
-    // docseq | keyseq | seq
-    else if (is_seq(src_node))
-    {
-        if (num_children(src_node) > dst->num_children(dst_node))
+        if( ! reftree->is_map(refnode))
             return false;
 
-        size_t dch = dst->first_child(dst_node);
-        for (size_t sch = first_child(src_node); sch != NONE; sch = next_sibling(sch))
-        {
-            if (!_is_subset_strview_recursive(dst, dch, sch, skip_val))
-                return false;
-            dch = dst->next_sibling(dch);
-        }
-        return true;
-    }
-    // docmap | keymap | map
-    else if (is_map(src_node))
-    {
-        if (num_children(src_node) > dst->num_children(dst_node))
+        if (num_children(subject_node) > reftree->num_children(refnode))
             return false;
 
-        for (size_t sch = first_child(src_node); sch != NONE; sch = next_sibling(sch))
+        for (size_t sch = first_child(subject_node); sch != NONE; sch = next_sibling(sch))
         {
-            size_t dch = dst->find_child(dst_node, key(sch));
-            if (dch == NONE)
+            size_t rch = reftree->find_child(refnode, key(sch));
+            if (rch == NONE)
                 return false;
-            if (!_is_subset_strview_recursive(dst, dch, sch, skip_val))
+            if ( ! _has_all_recursive(reftree, rch, sch))
                 return false;
         }
         return true;
     }
-    // notype
-    else if(type(src_node) == NOTYPE)
+    else if (is_seq(subject_node))
     {
+        if( ! reftree->is_seq(refnode))
+            return false;
+
+        if (num_children(subject_node) > reftree->num_children(refnode))
+            return false;
+
+        size_t rch = reftree->first_child(refnode);
+        for (size_t sch = first_child(subject_node); sch != NONE; sch = next_sibling(sch))
+        {
+            if ( ! _has_all_recursive(reftree, rch, sch))
+                return false;
+            rch = reftree->next_sibling(rch);
+        }
+        return true;
+    }
+    else if (is_stream(subject_node))
+    {
+        if( ! reftree->is_stream(refnode))
+            return false;
+
+        if (num_children(subject_node) > reftree->num_children(refnode))
+            return false;
+
+        size_t rch = reftree->first_child(refnode);
+        for (size_t sch = first_child(subject_node); sch != NONE;sch = next_sibling(sch))
+        {
+            if ( ! _has_all_recursive(reftree, rch, sch))
+                return false;
+            rch = reftree->next_sibling(rch);
+        }
+        return true;
+    }
+    else if(type(subject_node) == NOTYPE)
+    {
+        if(reftree->type(refnode) != NOTYPE)
+            return false;
         return true;
     }
     else
     {
         C4_NEVER_REACH();
     }
-}
-
-bool Tree::_is_subset_type_equal(Tree const *dst, size_t dst_node, size_t src_node)
-{
-    /* compare different node types for equality. A MAP/SEQ which only
-     * differs from one of these types (see below) is accepted because a subset
-     * comparator does not care if the MAP/SEQ was from a doc or a key.
-     *
-     *   interchangeable valid types: DOC[MAP/SEQ], KEY[MAP/SEQ] and MAP/SEQ */
-    if (type(src_node) != dst->type(dst_node))
-    {
-        if(is_map(src_node))
-        {
-            // recheck if the type matches when removing interchangeable types
-            if((type(src_node) & ~(DOCMAP | KEYMAP | MAP)) != (dst->type(dst_node) & ~(DOCMAP | KEYMAP | MAP)))
-                return false;
-        }
-        else if(is_seq(src_node))
-        {
-            if((type(src_node) & ~(DOCSEQ | KEYSEQ | SEQ)) != (dst->type(dst_node) & ~(DOCSEQ | KEYSEQ | SEQ)))
-                return false;
-        }
-        else
-            return false;
-    }
-    return true;
 }
 
 

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -927,6 +927,19 @@ public:
 
     void merge_with(Tree const* src, size_t src_node=NONE, size_t dst_root=NONE);
 
+public:
+
+    /** compare string views to see if src node is a subset of dst node */
+    bool is_subset_strview(Tree const *dst, size_t dst_node = NONE, size_t src_node = NONE);
+    bool is_subset_strview_skipval(Tree const *dst, size_t dst_node = NONE, size_t src_node = NONE);
+
+private:
+    /** compare subset node types */
+    bool _is_subset_type_equal(Tree const *dst, size_t dst_node, size_t src_node);
+
+    bool _is_subset_strview_init(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val);
+    bool _is_subset_strview_recursive(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val);
+
     /** @} */
 
 public:

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -929,16 +929,17 @@ public:
 
 public:
 
-    /** compare string views to see if src node is a subset of dst node */
-    bool is_subset_strview(Tree const *dst, size_t dst_node = NONE, size_t src_node = NONE);
-    bool is_subset_strview_skipval(Tree const *dst, size_t dst_node = NONE, size_t src_node = NONE);
+    /** non-recursive predicates: */
+
+    /** return true if subject_node has all the keys or indices in refnode from a reftree
+     * @note does not check values, only keys (for maps) or indices (for seqs) */
+    bool has_all(Tree const* reftree, size_t refnode = NONE, size_t subject_node = NONE ) const;
 
 private:
-    /** compare subset node types */
-    bool _is_subset_type_equal(Tree const *dst, size_t dst_node, size_t src_node);
 
-    bool _is_subset_strview_init(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val);
-    bool _is_subset_strview_recursive(Tree const *dst, size_t dst_node, size_t src_node, bool skip_val);
+    /** and helper functions to drive the recursive descent: */
+
+    bool _has_all_recursive(Tree const* reftree, size_t refnode, size_t subject_node) const;
 
     /** @} */
 


### PR DESCRIPTION
This PR implements a subset comparator for string views. It is really helpful to find mispelled yaml keys that are usually silently ignored when deserializing objects that have optional keys. The `is_subset_strview` method is highly dependant on formaters so not really usable, but the `is_subset_strview_skipval` is usefull for my context because my keys don't have floating numbers.    
```cpp
collision_detection::CollisionRequest req;

ryml::Tree t = ryml::parse_in_arena(ryml::csubstr(
R"(
collision_request:
  distance: true
  cost: true
  contacts: true
  mispelled_key: true
)"));

// deserialize
ryml::NodeRef n = t.rootref();
n["collision_request"] >> req;

// reserialize
ryml::Tree t1;
ryml::NodeRef n1 = t1.rootref();
n1 << ryml::key("collision_request") << req;

// t.is_subset_strview(&t1);
t.is_subset_strview_skipval(&t1);
// would return 'false' because the 'mispelled_key' is not a subset of the deserialized object
```
I have tried to follow your C++ style. You can close if you don't want this subset implementation. Will change code to your liking. Tags are not compared at the moment. Are they resolved before being added in the string views ?

~~I will also implement a `is_subset` method in another PR, which will need decoding with variadic templates.~~ 
**EDIT:** Not needed, can be implemented here.

TODO:
- [ ] Add proper tests in `test/test_subset.cpp`  (have tested against 15 tests internally)
- [ ] Check equality for key and val ref


