### PR TITLE
[fix] specify python3 command for the amalgamate tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,7 @@ you can also generate a customized file suiting your particular needs
 (or commit):
 
 ```console
-[user@host rapidyaml]$ python tools/amalgamate.py -h
+[user@host rapidyaml]$ python3 tools/amalgamate.py -h
 usage: amalgamate.py [-h] [--c4core | --no-c4core] [--fastfloat | --no-fastfloat] [--stl | --no-stl] [output]
 
 positional arguments:

--- a/samples/singleheader/amalgamate.cmake
+++ b/samples/singleheader/amalgamate.cmake
@@ -1,3 +1,4 @@
+find_package(Python3 COMPONENTS Interpreter)
 
 # amalgamate ryml to get the single header
 function(amalgamate_ryml header_dir header_file)
@@ -9,8 +10,8 @@ function(amalgamate_ryml header_dir header_file)
         LIST_DIRECTORIES FALSE
         CONFIGURE_DEPENDS "${rymldir}/src")
     add_custom_command(OUTPUT "${singleheader}"
-        COMMAND python "${amscript}" "${singleheader}"
-        COMMENT "python ${amscript} ${singleheader}"
+        COMMAND "${Python3_EXECUTABLE}" "${amscript}" "${singleheader}"
+        COMMENT "${Python3_EXECUTABLE} ${amscript} ${singleheader}"
         DEPENDS ${srcfiles} "${amscript}" "${rymldir}/ext/c4core/cmake/amalgamate_utils.py")
     set(${header_dir} "${singleheaderdir}" PARENT_SCOPE)
     set(${header_file} "${singleheader}" PARENT_SCOPE)


### PR DESCRIPTION
In Ubuntu 20.04 the default `python` [command](https://github.com/biojppm/rapidyaml/blob/master/samples/singleheader/amalgamate.cmake#L12-L13) is associated with python 2.7.X. This PR changes the amalgamate tool command to use `python3` because of the incompability with python2.

Alternatives:
- Change `f-Strings` to `str.format()` ... 
- Add `#!/usr/bin/env python3` in file and call without python command (also make script executable). Would be best for portability ? E.g I suspect python and python3 commands to not work in windows...

I can remove the change in the doc if you want.