### PR TITLE
[doc] fix git submodule recursive command

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ when cloning the repo, to ensure ryml's submodules are checked out as well:
 git clone --recursive https://github.com/biojppm/rapidyaml
 ```
 If you omit `--recursive`, after cloning you
-will have to do `git submodule init` and `git submodule update` 
+will have to do `git submodule update --init --recursive`
 to ensure ryml's submodules are checked out.
 
 ### Quickstart samples


### PR DESCRIPTION
> If you omit --recursive, after cloning you will have to do git submodule init and git submodule update to ensure ryml's submodules are checked out.

With git version `2.25.1` the proposed doc does not add submodules from the `c4core` library:
```bash
$ git clone https://github.com/biojppm/rapidyaml.git
$ cd rapidyaml

$ git submodule init
Submodule 'extern/c4core' (https://github.com/biojppm/c4core) registered for path 'ext/c4core'

$ git submodule update
Cloning into '/tmp/zzz/rapidyaml/ext/c4core'...
Submodule path 'ext/c4core': checked out 'e4c1554283cdc1a22a358b59df4e30b5e2edebe6'
```
This command adds submodules from the c4core lib:
```bash
$ git submodule update --init --recursive
...
Submodule path 'ext/c4core': checked out 'e4c1554283cdc1a22a358b59df4e30b5e2edebe6'
...
Submodule path 'ext/c4core/cmake': checked out '3f9518f4aa2bc04514cdf60b7f86e1aaadd12cf6'
Submodule path 'ext/c4core/src/c4/ext/debugbreak': checked out '5dcbe41d2bd4712c8014aa7e843723ad7b40fd74'
Submodule path 'ext/c4core/src/c4/ext/fast_float': checked out '32d21dcecb404514f94fb58660b8029a4673c2c1'
```
Taken from [here](https://stackoverflow.com/a/10168693).