### PR TITLE
fix empty line detection

### DIFF
--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -4991,7 +4991,7 @@ csubstr Parser::_filter_block_scalar(substr s, BlockStyle_e style, BlockChomp_e 
 
     _c4dbgfbl(": indentation={} before=[{}]~~~{}~~~", indentation, s.len, s);
 
-    if(chomp != CHOMP_KEEP && s.trim(" \n\r\t").len == 0u)
+    if(chomp != CHOMP_KEEP && s.trim(" \n\r").len == 0u)
     {
         _c4dbgp("filt_block: empty scalar");
         return s.first(0);

--- a/test/test_block_folded.cpp
+++ b/test/test_block_folded.cpp
@@ -1232,6 +1232,13 @@ another: text
       })
 );
 
+ADD_CASE_TO_GROUP("block folded with tab and spaces",
+R"(>
+       	  )",
+  N(DOCVAL|VALQUO, "\t  \n")
+    );
+
+
 ADD_CASE_TO_GROUP("block folded with empty docval 1",
 R"(>)",
   N(DOCVAL|VALQUO, "")
@@ -1263,22 +1270,8 @@ R"(>
   N(DOCVAL|VALQUO, "")
     );
 
-ADD_CASE_TO_GROUP("block folded with empty docval 6",
-R"(>
-       	  )",
-  N(DOCVAL|VALQUO, "")
-    );
-
-ADD_CASE_TO_GROUP("block folded with empty docval 7",
-R"(>
-       	  
-)",
-  N(DOCVAL|VALQUO, "")
-    );
-
 ADD_CASE_TO_GROUP("block folded with empty docval 8",
 R"(>
-
 
 )",
   N(DOCVAL|VALQUO, "")

--- a/test/test_block_literal.cpp
+++ b/test/test_block_literal.cpp
@@ -836,6 +836,13 @@ R"(
   L{N(L{N(QV, "aaa", "xxx\n"), N(QV, "bbb", "yyy\n")})}
     );
 
+ADD_CASE_TO_GROUP("block literal with tab and spaces",
+R"(|
+       	  )",
+  N(DOCVAL|VALQUO, "\t  \n")
+    );
+
+
 ADD_CASE_TO_GROUP("block literal with empty docval 1",
 R"(|)",
   N(DOCVAL|VALQUO, "")
@@ -863,19 +870,6 @@ R"(|
 ADD_CASE_TO_GROUP("block literal with empty docval 5",
 R"(|
     
-)",
-  N(DOCVAL|VALQUO, "")
-    );
-
-ADD_CASE_TO_GROUP("block literal with empty docval 6",
-R"(|
-       	  )",
-  N(DOCVAL|VALQUO, "")
-    );
-
-ADD_CASE_TO_GROUP("block literal with empty docval 7",
-R"(|
-       	  
 )",
   N(DOCVAL|VALQUO, "")
     );

--- a/test/test_suite/test_suite_parts.cpp
+++ b/test/test_suite/test_suite_parts.cpp
@@ -21,8 +21,6 @@ constexpr const AllowedFailure allowed_failures[] = {
     _("G4RS-in_json"            , "special characters must be emitted in double quoted style"),
     _("G4RS-in_yaml"            , "special characters must be emitted in double quoted style"),
     _("G4RS-out_yaml"           , "special characters must be emitted in double quoted style"),
-    // block scalars
-    _("Y79Y_001"                , "tab problems"),
     // other
     _("UKK6_01-in_yaml"         , "fails to parse double :: in UNK state"),
 


### PR DESCRIPTION
Empty lines in block scalars cannot contain a `\t`-character.

All non-failing YAML parsers on YAML playground do not recognize the `\t`-character as part of an empty line, too.

Fixes #337