### PR TITLE
[fix] Add missing Python runtime dep. on deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
         'setuptools-git',
         'setuptools',
     ],
+    install_requires=['deprecation'],
     # Extra arguments
     **setup_kw,
 )


### PR DESCRIPTION
The dependency on the PyPI [deprecation](https://pypi.org/project/deprecation/) package already appears in requirements.txt,

https://github.com/biojppm/rapidyaml/blob/b35ccb150282760cf5c2d316895cb86bd161ac89/requirements.txt#L8

but it is not only a build-time dependency. The import in `api/ryml.i`

https://github.com/biojppm/rapidyaml/blob/b35ccb150282760cf5c2d316895cb86bd161ac89/api/ryml.i#L218

ends up in the generated `ryml/ryml.py`, so we need to add a runtime dependency. This commit adds the necessary dependency via a new `install_requires` argument in `setup.py`.

Fixes:

```
==================================== ERRORS ====================================
_______________ ERROR collecting api/python/tests/test_parse.py ________________
ImportError while importing test module '/builddir/build/BUILD/rapidyaml-0.5.0/api/python/tests/test_parse.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
api/python/tests/test_parse.py:1: in <module>
    import ryml
../../BUILDROOT/rapidyaml-0.5.0-2.fc38.x86_64/usr/lib64/python3.11/site-packages/ryml/__init__.py:1: in <module>
    from ryml.ryml import *
../../BUILDROOT/rapidyaml-0.5.0-2.fc38.x86_64/usr/lib64/python3.11/site-packages/ryml/ryml.py:99: in <module>
    from deprecation import deprecated
E   ModuleNotFoundError: No module named 'deprecation'
=========================== short test summary info ============================
ERROR api/python/tests/test_parse.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.94s ===============================
```