### PR TITLE
Do not mark visit functions as pure

### DIFF
--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -503,7 +503,7 @@ public:
 
     /** visit every child node calling fn(node) */
     template<class Visitor>
-    C4_ALWAYS_INLINE C4_PURE bool visit(Visitor fn, size_t indentation_level=0, bool skip_root=true) const noexcept
+    C4_ALWAYS_INLINE bool visit(Visitor fn, size_t indentation_level=0, bool skip_root=true) const noexcept
     {
         return detail::_visit(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }
@@ -517,7 +517,7 @@ public:
 
     /** visit every child node calling fn(node, level) */
     template<class Visitor>
-    C4_ALWAYS_INLINE C4_PURE bool visit_stacked(Visitor fn, size_t indentation_level=0, bool skip_root=true) const noexcept
+    C4_ALWAYS_INLINE bool visit_stacked(Visitor fn, size_t indentation_level=0, bool skip_root=true) const noexcept
     {
         return detail::_visit_stacked(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }


### PR DESCRIPTION
Marking a function as pure implies that it does not have any observable side effects (only the return value is used). So if the compiler detects that the return value of a pure function is not used, it may eliminate the call to the pure function.

This would be wrong, however, if the passed in Visitor has side effects which are needed by the program.
Fix this by not marking the visit functions as pure.