### PR TITLE
Update natvis to include a few tweaks

### DIFF
--- a/src/ryml.natvis
+++ b/src/ryml.natvis
@@ -71,7 +71,8 @@ See also:
       <Item Name="val ref" Condition="(m_type.type &amp; c4::yml::VALREF) != 0">m_val.anchor</Item>
       <Item Name="key anchor" Condition="(m_type.type &amp; c4::yml::KEYANCH) != 0">m_key.anchor</Item>
       <Item Name="val anchor" Condition="(m_type.type &amp; c4::yml::VALANCH) != 0">m_val.anchor</Item>
-      <Item Name="parent">m_parent</Item>
+      <Item Name="parent" Condition="m_parent == c4::yml::NONE">NONE</Item>
+      <Item Name="parent" Condition="m_parent != c4::yml::NONE">m_parent</Item>
       <Item Name="first child"  Condition="m_first_child != c4::yml::NONE">m_first_child</Item>
       <Item Name="last child"   Condition="m_last_child != c4::yml::NONE">m_last_child</Item>
       <Item Name="prev sibling" Condition="m_prev_sibling != c4::yml::NONE">m_prev_sibling</Item>
@@ -128,9 +129,33 @@ See also:
     <DisplayString>{*(m_tree->m_buf + m_id)}</DisplayString>
     <Expand>
       <Item Name="id">m_id</Item>
-      <Item Name="elm">*(m_tree->m_buf + m_id)</Item>
+      <Item Name="element">*(m_tree->m_buf + m_id)</Item>
       <Item Name="tree">m_tree</Item>
-      <Synthetic Name="[children]" Condition="(m_id != c4::yml::NONE) &amp;&amp; ((m_tree->m_buf + m_id)->m_type.type &amp; (c4::yml::MAP|c4::yml::SEQ) != 0)">
+      <Synthetic Name="[children]" Condition="(m_id != c4::yml::NONE) &amp;&amp; (((m_tree->m_buf + m_id)->m_type.type &amp; (c4::yml::MAP|c4::yml::SEQ)) != 0)">
+        <Expand>
+          <CustomListItems>
+            <Variable Name="tree" InitialValue="m_tree"/>
+            <Variable Name="buf" InitialValue="m_tree->m_buf"/>
+            <Variable Name="curr" InitialValue="(m_tree->m_buf + m_id)->m_first_child"/>
+            <Loop>
+              <Item>buf + curr</Item>
+              <Exec>curr = (buf + curr)->m_next_sibling</Exec>
+              <Break Condition="curr == c4::yml::NONE"/>
+            </Loop>
+          </CustomListItems>
+        </Expand>
+      </Synthetic>
+    </Expand>
+  </Type>
+
+  <Type Name="c4::yml::ConstNodeRef">
+    <DisplayString Condition="(m_id == c4::yml::NONE)">(void)</DisplayString>
+    <DisplayString>{*(m_tree->m_buf + m_id)}</DisplayString>
+    <Expand>
+      <Item Name="id">m_id</Item>
+      <Item Name="element">*(m_tree->m_buf + m_id)</Item>
+      <Item Name="tree">m_tree</Item>
+      <Synthetic Name="[children]" Condition="(m_id != c4::yml::NONE) &amp;&amp; (((m_tree->m_buf + m_id)->m_type.type &amp; (c4::yml::MAP|c4::yml::SEQ)) != 0)">
         <Expand>
           <CustomListItems>
             <Variable Name="tree" InitialValue="m_tree"/>


### PR DESCRIPTION
## Why is this change being made?
I set up the natvis in a new project that is using rapidyml and it was missing the primary type that we are using (`ConstNodeRef`).  Additionally I discovered that the children synthetic visualization for NodeRef/ConstNodeRef was not being parsed correctly.  The order of operations on the bitwise operator was causing the condition to always evaluate to false.

## Briefly summarize what changed
* Duplicate the `NodeRef` visualization as `ConstNodeRef`.  ConstNodeRef does not have an m_seed field so it cannot be exactly identical or else it fails to apply.
* Tweak `NodeData::m_parent` to special-case `NONE` instead of printing uint64(-1).
* Fix the [children] expansion in NodeRef/ConstNodeRef.
* Expand `elm` to `element`.  (This one is arguable; I'm tempted to expand them all out so they are easier to understand without abbreviation).

I also tried to get `NodeData` to have a synthetic child with the expansion of the sub-elements (e.g. `KEYMAP` can print the keys in the map).  Unfortunately this does not seem to be possible because the `NodeData` has the raw indexes but no pointer to the memory allocation.

## How was this change tested?
I have a ~10 line program using rapidyml along with an OpenAPI.yml file from a public sample.

Closes #380