### PR TITLE
fix: Add swig as build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,5 @@ requires = [
          "setuptools-git",
          "wheel",
          "ninja",
-         "cmake_build_extension"]
+         "cmake_build_extension",
+         "swig"]


### PR DESCRIPTION
https://github.com/Farama-Foundation/Gymnasium/issues/245#issuecomment-1377986714