### PR TITLE
Replacing noexcept to RYML_NOEXCEPT for stack and tree

### DIFF
--- a/src/c4/yml/detail/stack.hpp
+++ b/src/c4/yml/detail/stack.hpp
@@ -51,7 +51,7 @@ public:
         _free();
     }
 
-    stack(stack const& that) noexcept : stack(that.m_callbacks)
+    stack(stack const& that) RYML_NOEXCEPT : stack(that.m_callbacks)
     {
         resize(that.m_size);
         _cp(&that);
@@ -62,7 +62,7 @@ public:
         _mv(&that);
     }
 
-    stack& operator= (stack const& that) noexcept
+    stack& operator= (stack const& that) RYML_NOEXCEPT
     {
         _cb(that.m_callbacks);
         resize(that.m_size);

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -339,7 +339,7 @@ public:
 
     void clear() noexcept { tag.clear(); scalar.clear(); anchor.clear(); }
 
-    void set_ref_maybe_replacing_scalar(csubstr ref, bool has_scalar) noexcept
+    void set_ref_maybe_replacing_scalar(csubstr ref, bool has_scalar) RYML_NOEXCEPT
     {
         csubstr trimmed = ref.begins_with('*') ? ref.sub(1) : ref;
         anchor = trimmed;


### PR DESCRIPTION
I have replaced `noexcept` for a few places with macro but not the ones that are move constructor.
All the ones I replaces have asserts which can throw (I think)

For #411 