### PR TITLE
fix: add /Zc:__cplusplus for correct __cplusplus value in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     endif()
 endif()
 
+if(MSVC)
+    option(ENABLE_ZC__cplusplus "Enable /Zc:__cplusplus compile option" ON)
+    if(ENABLE_ZC__cplusplus)
+        target_compile_options(ryml PUBLIC /Zc:__cplusplus)
+    endif()
+endif()
 
 #-------------------------------------------------------
 

--- a/samples/singleheader/CMakeLists.txt
+++ b/samples/singleheader/CMakeLists.txt
@@ -11,6 +11,13 @@ target_compile_features(ryml-quickstart PUBLIC cxx_std_11)
 target_compile_definitions(ryml-quickstart PUBLIC -DRYML_SINGLE_HEADER)
 target_include_directories(ryml-quickstart PUBLIC "${SINGLE_HEADER_DIR}")
 
+if(MSVC)
+    option(ENABLE_ZC__cplusplus "Enable /Zc:__cplusplus compile option" ON)
+    if(ENABLE_ZC__cplusplus)
+        target_compile_options(ryml-quickstart PRIVATE /Zc:__cplusplus)
+    endif()
+endif()
+
 add_custom_target(run ryml-quickstart
     COMMAND $<TARGET_FILE:ryml-quickstart>
     DEPENDS ryml-quickstart)

--- a/samples/singleheaderlib/CMakeLists.txt
+++ b/samples/singleheaderlib/CMakeLists.txt
@@ -10,6 +10,13 @@ add_library(ryml lib.cpp ${SINGLE_HEADER})
 target_compile_features(ryml PUBLIC cxx_std_11)
 target_include_directories(ryml PUBLIC "${SINGLE_HEADER_DIR}")
 
+if(MSVC)
+    option(ENABLE_ZC__cplusplus "Enable /Zc:__cplusplus compile option" ON)
+    if(ENABLE_ZC__cplusplus)
+        target_compile_options(ryml PUBLIC /Zc:__cplusplus)
+    endif()
+endif()
+
 # now simply define the executable:
 add_executable(ryml-quickstart ../quickstart.cpp)
 target_link_libraries(ryml-quickstart PRIVATE ryml)

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -3,6 +3,10 @@
 #include "c4/yml/node.hpp"
 #include "c4/yml/reference_resolver.hpp"
 
+#define STRINGIZE(x) #x
+#define TOSTRING(x) STRINGIZE(x)
+
+#pragma message("__cplusplus = " TOSTRING(__cplusplus))
 
 C4_SUPPRESS_WARNING_MSVC_WITH_PUSH(4296/*expression is always 'boolean_value'*/)
 C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wold-style-cast")


### PR DESCRIPTION
When compiling with C++17 in MSVC (VS2022), error C2039: 'chars_format': is not a member of 'std' occurs. This is due to the __cplusplus macro always being set to 199711L, regardless of the specified C++ standard. Consequently, conditionally included headers such as <charconv> are not included.

Adding the /Zc:__cplusplus option ensures the __cplusplus macro reflects the correct C++ standard. Please consider this change.