### PR TITLE
fix: correct parser for double-quoted keys in map block

### DIFF
--- a/src/c4/yml/parse_engine.def.hpp
+++ b/src/c4/yml/parse_engine.def.hpp
@@ -6037,7 +6037,7 @@ mapblck_start:
         {
             _c4dbgp("mapblck[RKEY]: scanning double-quoted scalar");
             sc = _scan_scalar_dquot();
-            csubstr maybe_filtered = _maybe_filter_val_scalar_squot(sc);
+            csubstr maybe_filtered = _maybe_filter_val_scalar_dquot(sc);
             _handle_annotations_before_blck_key_scalar();
             m_evt_handler->set_key_scalar_dquoted(maybe_filtered);
             addrem_flags(RVAL, RKEY);


### PR DESCRIPTION
This PR fixes an issue where the single-quote parser was incorrectly specified for double-quoted keys in YAML map blocks.