### PR TITLE
Fix anchor reference issue in Map keys

### DIFF
--- a/src/c4/yml/parse_engine.def.hpp
+++ b/src/c4/yml/parse_engine.def.hpp
@@ -675,7 +675,7 @@ csubstr ParseEngine<EventHandler>::_scan_ref_map()
 {
     csubstr s = m_evt_handler->m_curr->line_contents.rem;
     _RYML_CB_ASSERT(m_evt_handler->m_stack.m_callbacks, s.begins_with('*'));
-    csubstr ref = s.first(s.first_of(",} "));
+    csubstr ref = s.first(s.first_of(",} :"));
     _line_progressed(ref.len);
     return ref;
 }


### PR DESCRIPTION
This PR fixes a bug where an extra colon `:` is appended to the anchor reference name when used in Map keys.

### Reproduction Steps

Parsing the following `ng.yaml` with `./tools/ryml-yaml-events` results in an error.

```bash
$ cat ng.yaml
abc: &foo FOO
*foo: bar

$ ./build/tools/ryml-yaml-events ng.yaml
ng.yaml:2:7: (20B): ERROR: could not find ':' colon after key
ng.yaml:2:7: *foo: bar  (size=9)
                   ^~~  (cols 7-10)
```
