### PR TITLE
WIP no submodules

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -136,3 +136,6 @@
     -
     ```
 - [PR#628](https://github.com/biojppm/rapidyaml/pull/628): Add serialization fuzzing. Relax `c4::atof()` / `c4::atod()`, disable redundant assertions that prevent returning false on bad strings.
+- [PR#629](https://github.com/biojppm/rapidyaml/pull/629): int events:
+  - Rename `to_chars(substr,DataType)` to `to_str()` (the c4 existing overload will always win because it's an int)
+  - Do not use c4/bitmask.hpp

--- a/samples/quickstart-ints.cpp
+++ b/samples/quickstart-ints.cpp
@@ -125,7 +125,7 @@ int main(int, const char *[])
         // let's format the event flags to print them as string.
         // we need to zero-terminate them to be able to align using printf.
         memset(flags, 0, sizeof(flags)); // ensure flags are zero-terminated
-        size_t len = c4::yml::extra::ievt::to_chars(flags, events[pos]);
+        size_t len = c4::yml::extra::ievt::to_str(flags, events[pos]);
         if(len + 1 >= sizeof(flags)) { printf("error: could not format flags"); return 1; } // ensure flags are zero-terminated
         // print the event
         printf("pos=%d\tevent[%d]:\t%20s = 0x%08x", pos, evt, flags, events[pos]);

--- a/src_extra/c4/yml/extra/ints_to_testsuite.cpp
+++ b/src_extra/c4/yml/extra/ints_to_testsuite.cpp
@@ -16,10 +16,6 @@
 #include "c4/yml/extra/ints_utils.hpp"
 #endif
 
-#ifndef _C4_BITMASK_HPP_
-#include "c4/bitmask.hpp"
-#endif
-
 
 C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wold-style-cast")
 C4_SUPPRESS_WARNING_CLANG_WITH_PUSH("-Wold-style-cast")

--- a/src_extra/c4/yml/extra/ints_utils.cpp
+++ b/src_extra/c4/yml/extra/ints_utils.cpp
@@ -12,14 +12,6 @@
 #include "c4/yml/extra/ints_utils.hpp"
 #endif
 
-#ifndef _C4_YML_ERROR_HPP_
-#include "c4/yml/error.hpp"
-#endif
-
-#ifndef _C4_BITMASK_HPP_
-#include "c4/bitmask.hpp"
-#endif
-
 
 C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wold-style-cast")
 C4_SUPPRESS_WARNING_CLANG_WITH_PUSH("-Wold-style-cast")
@@ -27,56 +19,73 @@ C4_SUPPRESS_WARNING_CLANG_WITH_PUSH("-Wold-style-cast")
 
 
 namespace c4 {
-template<>
-c4::EnumSymbols<yml::extra::ievt::EventFlags> esyms<yml::extra::ievt::EventFlags>()
-{
-    static constexpr const EnumSymbols<yml::extra::ievt::EventFlags>::Sym syms[] = {
-        {yml::extra::ievt::KEY_, "KEY_"},
-        {yml::extra::ievt::VAL_, "VAL_"},
-        {yml::extra::ievt::SCLR, "SCLR"},
-        {yml::extra::ievt::BSEQ, "BSEQ"},
-        {yml::extra::ievt::ESEQ, "ESEQ"},
-        {yml::extra::ievt::BMAP, "BMAP"},
-        {yml::extra::ievt::EMAP, "EMAP"},
-        {yml::extra::ievt::ALIA, "ALIA"},
-        {yml::extra::ievt::ANCH, "ANCH"},
-        {yml::extra::ievt::TAG_, "TAG_"},
-        {yml::extra::ievt::PLAI, "PLAI"},
-        {yml::extra::ievt::SQUO, "SQUO"},
-        {yml::extra::ievt::DQUO, "DQUO"},
-        {yml::extra::ievt::LITL, "LITL"},
-        {yml::extra::ievt::FOLD, "FOLD"},
-        {yml::extra::ievt::FLOW, "FLOW"},
-        {yml::extra::ievt::BLCK, "BLCK"},
-        {yml::extra::ievt::BDOC, "BDOC"},
-        {yml::extra::ievt::EDOC, "EDOC"},
-        {yml::extra::ievt::BSTR, "BSTR"},
-        {yml::extra::ievt::ESTR, "ESTR"},
-        {yml::extra::ievt::EXPL, "EXPL"},
-        {yml::extra::ievt::AREN, "AREN"},
-        {yml::extra::ievt::PSTR, "PSTR"},
-        {yml::extra::ievt::UNFILT, "UNFILT"},
-        {yml::extra::ievt::YAML, "YAML"},
-        {yml::extra::ievt::TAGH, "TAGH"},
-        {yml::extra::ievt::TAGP, "TAGP"},
-    };
-    return EnumSymbols<yml::extra::ievt::EventFlags>(syms);
-}
 namespace yml {
 namespace extra {
 namespace ievt {
-size_t to_chars(substr buf, ievt::DataType flags)
+
+namespace {
+struct FlagSym { const char *str; EventFlags flags; };
+const FlagSym flag_syms_[] = {
+    {"KEY_", KEY_},
+    {"VAL_", VAL_},
+    {"SCLR", SCLR},
+    {"BSEQ", BSEQ},
+    {"ESEQ", ESEQ},
+    {"BMAP", BMAP},
+    {"EMAP", EMAP},
+    {"ALIA", ALIA},
+    {"ANCH", ANCH},
+    {"TAG_", TAG_},
+    {"PLAI", PLAI},
+    {"SQUO", SQUO},
+    {"DQUO", DQUO},
+    {"LITL", LITL},
+    {"FOLD", FOLD},
+    {"FLOW", FLOW},
+    {"BLCK", BLCK},
+    {"BDOC", BDOC},
+    {"EDOC", EDOC},
+    {"BSTR", BSTR},
+    {"ESTR", ESTR},
+    {"EXPL", EXPL},
+    {"AREN", AREN},
+    {"PSTR", PSTR},
+    {"UNFILT", UNFILT},
+    {"YAML", YAML},
+    {"TAGH", TAGH},
+    {"TAGP", TAGP},
+};
+} // namespace
+
+size_t to_str(substr buf, ievt::DataType flags) noexcept
 {
-    flags &= ievt::MASK; // clear any other bits
-    return c4::bm2str<ievt::EventFlags>(flags, buf.str, buf.len);
+    detail::_SubstrWriter writer(buf);
+    for(const FlagSym sym : flag_syms_)
+    {
+        if(flags & sym.flags)
+        {
+            if(writer.pos)
+                writer.append('|');
+            writer.append(sym.str);
+            flags &= ~sym.flags;
+        }
+    }
+    if(!writer.pos)
+        writer.append("NONE");
+    if(buf.len > writer.pos)
+        buf[writer.pos] = '\0';
+    return writer.pos;
 }
-csubstr to_chars_sub(substr buf, ievt::DataType flags)
+
+csubstr to_str_sub(substr buf, ievt::DataType flags)
 {
-    size_t reqsize = ievt::to_chars(buf, flags);
+    size_t reqsize = ievt::to_str(buf, flags);
     _RYML_CHECK_BASIC(reqsize > 0u);
     _RYML_CHECK_BASIC(reqsize < buf.len);
-    return buf.first(reqsize - 1u);
+    return buf.first(reqsize);
 }
+
+
 } // namespace ievt
 } // namespace extra
 } // namespace yml
@@ -100,7 +109,7 @@ void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::DataType const*
             evtpos += ((evts[evtpos] & ievt::WSTR) ? 3 : 1))
     {
         ievt::DataType evt = evts[evtpos];
-        csubstr flags = ievt::to_chars_sub(buf, evt);
+        csubstr flags = ievt::to_str_sub(buf, evt);
         printf("[%d][%d] %.*s(0x%x)", evtnumber, evtpos, (int)flags.len, flags.str, evt);
         if (evt & ievt::WSTR)
         {

--- a/src_extra/c4/yml/extra/ints_utils.hpp
+++ b/src_extra/c4/yml/extra/ints_utils.hpp
@@ -19,9 +19,9 @@ namespace extra {
 
 namespace ievt {
 /** Convert bit mask of @ref ievt::EventFlags to text. */
-RYML_EXPORT size_t to_chars(substr buf, yml::extra::ievt::DataType flags);
+RYML_EXPORT size_t to_str(substr buf, yml::extra::ievt::DataType flags) noexcept;
 /** Convert bit mask of @ref ievt::EventFlags to text. */
-RYML_EXPORT csubstr to_chars_sub(substr buf, yml::extra::ievt::DataType flags);
+RYML_EXPORT csubstr to_str_sub(substr buf, yml::extra::ievt::DataType flags);
 } // namespace ievt
 
 

--- a/test/test_extra_ints.cpp
+++ b/test/test_extra_ints.cpp
@@ -15,6 +15,31 @@ namespace yml {
 namespace extra {
 
 
+TEST(flags, to_chars)
+{
+    using namespace ievt;
+    char buf1_[1]; substr buf1 = buf1_;
+    char buf_[200]; substr buf = buf_;
+#define _(flags, str)                                       \
+    {                                                       \
+        ievt::DataType flags_{flags};                       \
+        csubstr actual(str);                                \
+        EXPECT_EQ(ievt::to_str(buf1, flags_), actual.len);  \
+        size_t ret = ievt::to_str(buf, flags_);             \
+        ASSERT_LE(ret, buf.len);                            \
+        EXPECT_EQ(buf.first(ret), actual);                  \
+        buf.fill(0);                                        \
+        csubstr r = ievt::to_str_sub(buf, flags_);          \
+        ASSERT_LE(r.len, buf.len);                          \
+        EXPECT_EQ(r, actual);                               \
+    }
+    _(0, "NONE");
+    _(KEY_, "KEY_");
+    _(VAL_, "VAL_");
+    _(KEY_|VAL_, "KEY_|VAL_");
+}
+
+
 struct IntEventsCase
 {
     const char *file;

--- a/test/test_lib/test_events_ints_helpers.cpp
+++ b/test/test_lib/test_events_ints_helpers.cpp
@@ -28,8 +28,8 @@ void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
     EXPECT_EQ(actual_sz, num_ints_expected);
     status = (actual_sz == num_ints_expected);
 
-    char actualbuf[100];(void)actualbuf;
-    char expectedbuf[100];(void)expectedbuf;
+    char actualbuf[200];(void)actualbuf;
+    char expectedbuf[200];(void)expectedbuf;
     for(size_t ia = 0, ie = 0; ie < expected_sz; ++ie)
     {
         EXPECT_LT(ia, actual_sz);
@@ -43,8 +43,8 @@ void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
         status &= int(lhs == rhs);                              \
         EXPECT_EQ(lhs, rhs);                                    \
     } while(0)
-        csubstr sactual = ievt::to_chars_sub(actualbuf, actual[ia]);
-        csubstr sexpect = ievt::to_chars_sub(expectedbuf, expected[ie].flags);
+        csubstr sactual = ievt::to_str_sub(actualbuf, actual[ia]);
+        csubstr sexpect = ievt::to_str_sub(expectedbuf, expected[ie].flags);
         _test_eq(actual[ia], expected[ie].flags, "", 0);
         _test_eq(sactual, sexpect, "", 0);
         if((expected[ie].flags & ievt::WSTR) && (actual[ia] & ievt::WSTR))
@@ -103,8 +103,8 @@ void test_events_ints_invariants(csubstr parsed_yaml,
                                  ievt::DataType const* evts,
                                  ievt::DataType evts_sz)
 {
-    char bufpos[100];
-    char bufprev[100];
+    char bufpos[200];
+    char bufprev[200];
     EXPECT_GT(evts_sz, 0);
     for(ievt::DataType evtpos = 0, evtnumber = 0;
         evtpos < evts_sz;
@@ -117,7 +117,7 @@ void test_events_ints_invariants(csubstr parsed_yaml,
         ievt::DataType next = {};
         SCOPED_TRACE(evtpos); // position in the array
         SCOPED_TRACE(evtnumber); // event number
-        SCOPED_TRACE(ievt::to_chars_sub(bufpos, evt));
+        SCOPED_TRACE(ievt::to_str_sub(bufpos, evt));
         if(evtpos)
             prev = (evt & ievt::PSTR) ? evts[evtpos - 3] : evts[evtpos - 1];
         if(nextpos < evts_sz)
@@ -146,7 +146,7 @@ void test_events_ints_invariants(csubstr parsed_yaml,
         {
             EXPECT_GT(evtnumber, 0);
             EXPECT_GE(evtpos, 3);
-            SCOPED_TRACE(ievt::to_chars_sub(bufprev, prev));
+            SCOPED_TRACE(ievt::to_str_sub(bufprev, prev));
             EXPECT_NE(prev & ievt::WSTR, 0);
         }
         constexpr const ievt::DataType style = ievt::PLAI|ievt::SQUO|ievt::DQUO|ievt::LITL|ievt::FOLD;


### PR DESCRIPTION
This PR removes c4core as a submodule. It is split into two sub-requests
  - Part 1 #630:  This only copies the c4core source code and required project files. Just copy, no logic changes.
  - Part 2 #631: adjust this project to pass the CI. Focus on this one.

---
From the [comments below](https://github.com/biojppm/rapidyaml/pull/512#issuecomment-3865697023):


> If I understand correctly, the c4core submodule is replaced by a copy of the c4core repository, correct ?

Yes, with some details to it:

  - this PR removes the c4core submodule, and copies c4core code into the rapidyaml tree, to two different dirs:
     - `ext/c4core.src`: c4core code used in the rapidyaml library 
     - `ext/c4core.dev`: c4core code used by tests/benchmarks
    Doing this makes the standalone library marginally smaller, and enforces the standalone default of rapidyaml bypassing the submodule. So most users (which don't care about c4core itself) will now see rapidyaml as a plain project without extra dependencies or submodules.
  - this PR retains the existing option to compile against a full instance of the c4core library, thus ignoring the in-source copy under `ext/c4core.src` and `ext/c4core.dev`
    - the default is still to compile in standalone mode (ie c4core part of rapidyaml)
    - the pre-existing cmake option `RYML_STANDALONE` still enables users to build rapidyaml against a previously build c4core library (like in the ubuntu packages where rapidyaml depends on c4core).
  - the amalgamation tool should work just as before

---

> Why is this desirable, and what issue does this resolve ?

I have had repeated feedback that the c4core submodule makes it impossible for some people to use rapidyaml, either because it contains submodules, or because c4core is a dependency boogeyman. 

While I disagree with both of these reasonings, it is not for me to dispute their choice.

So I am removing these reasons by making the c4core code really standalone in rapidyaml, while striving to retain all current existing workflows.

---
> 
> Do you plan to remove the c4core repository and only maintain it within rapidyaml

**No, not at all. c4core will remain just as it is, in https://github.com/biojppm/c4core.**


> and if not, how will the fixes from c4core be applied to rapidyaml (beside manually) ?

This PR adds a helper makefile to simplify the workflow, with two main approaches:

 - create an in-source clone of c4core (parallel to the existing copies, under the old location of the submodule `ext/c4core`) and...
 - importing changes from c4core clone to rapidyaml copies
 - exporting changes from rapidyaml copies to c4core clone
 - check sync status.

The CI enforces that the in-source c4core copy is in sync with the target commit hash (just like a submodule dirty status).

The makefile helper to sync with c4core is at [ext/Makefile](https://github.com/biojppm/rapidyaml/blob/nosubmodules/ext/Makefile), and the README with instructions will be at [ext/README.md](https://github.com/biojppm/rapidyaml/blob/nosubmodules/ext/README.md).

The file enforcing the c4core version is at [ext/c4core.mk](https://github.com/biojppm/rapidyaml/blob/nosubmodules/ext/c4core.mk).

---

> 
> Please clarify the intent here, I am really worried about this change.

Thanks for looking into this, I truly appreciate.

I am still working in this PR, so this is truly the proper time to start offering feedback. I have made a conscious effort to retain all existing usage scenarios, but if there is something I'm overlooking, I'd like to hear about it.

And FWIW, after getting this PR ready and green, I will let it linger for some weeks before merging it.
