### PR TITLE
Fixes to method NodeType::is_val(): it always returns false

### DIFF
--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -169,7 +169,7 @@ public:
     C4_ALWAYS_INLINE bool is_seq()            const noexcept { return (type & SEQ) != 0; }
     C4_ALWAYS_INLINE bool has_key()           const noexcept { return (type & KEY) != 0; }
     C4_ALWAYS_INLINE bool has_val()           const noexcept { return (type & VAL) != 0; }
-    C4_ALWAYS_INLINE bool is_val()            const noexcept { return (type & KEYVAL) == VAL; }
+    C4_ALWAYS_INLINE bool is_val()            const noexcept { return (type & VAL) == VAL; }
     C4_ALWAYS_INLINE bool is_keyval()         const noexcept { return (type & KEYVAL) == KEYVAL; }
     C4_ALWAYS_INLINE bool key_is_null()       const noexcept { return (type & KEYNIL) != 0; }
     C4_ALWAYS_INLINE bool val_is_null()       const noexcept { return (type & VALNIL) != 0; }


### PR DESCRIPTION
The method NodeType::is_val() always returns false since it is implemented as follows:

File src/c4/yml/node_type.hpp:172
```
C4_ALWAYS_INLINE bool is_val() const noexcept { return (type & KEYVAL) == VAL; }
```
However `KEYVAL = 3U`, while `VAL = 2U`, so
`type & KEYVAL` will always returns either `0` or `KEYVAL` which differs from `VAL`.

To fix the issue, one should replace KEYVAL with VAL, and change the functions as follows:

C4_ALWAYS_INLINE bool is_val() const noexcept { return (type & VAL) == VAL; }

Fixes #537 