### PR TITLE
Swap std::is_trivial with non deprecated traits

### DIFF
--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -288,7 +288,8 @@ struct RYML_EXPORT LineCol
     //! construct from offset, line and column
     LineCol(size_t o, size_t l, size_t c) : offset(o), line(l), col(c) {}
 };
-static_assert(std::is_trivially_copyable<LineCol>::value && std::is_trivially_default_constructible<LineCol>::value, "LineCol not trivial");
+static_assert(std::is_trivially_copyable<LineCol>::value, "LineCol not trivially copyable");
+static_assert(std::is_trivially_default_constructible<LineCol>::value, "LineCol not trivially default constructible");
 static_assert(std::is_standard_layout<LineCol>::value, "Location not trivial");
 
 

--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -288,7 +288,7 @@ struct RYML_EXPORT LineCol
     //! construct from offset, line and column
     LineCol(size_t o, size_t l, size_t c) : offset(o), line(l), col(c) {}
 };
-static_assert(std::is_trivial<LineCol>::value, "LineCol not trivial");
+static_assert(std::is_trivially_copyable<LineCol>::value && std::is_trivially_default_constructible<LineCol>::value, "LineCol not trivial");
 static_assert(std::is_standard_layout<LineCol>::value, "Location not trivial");
 
 


### PR DESCRIPTION
### Summary

This PR resolves the deprecation warning triggered by the use of `std::is_trivial<LineCol>` in RapidYAML headers when building on C++26 standard.

---

### Warning Details

During build, the following warning was emitted:
```
/bin/_deps/rapidyaml-src/src/c4/yml/common.hpp:291:20: warning: 'is_trivial[c4::yml::LineCol]' is deprecated:
Consider using is_trivially_copyable<T>::value && is_trivially_default_constructible<T>::value instead [-Wdeprecated-declarations]

```
On line:

`static_assert(std::is_trivial<LineCol>::value, "LineCol not trivial");`


---

### Notes

- No functional changes to RapidYAML.  
- Build output is now clean on all supported platforms/compilers.  
- Future-proof against deprecated traits warnings in C++26, but still complies with C++11.

