### PR TITLE
Fix \x codepoint parsing, was not decoded

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ ja: 惑星（ガス）
 zh: 行星（气体）
 # UTF8 decoding only happens in double-quoted strings,
 # as per the YAML standard
-decode this: "\u263A \xE2\x98\xBA"
+decode this: "\u263A c\x61f\xE9"
 and this as well: "\u2705 \U0001D11E"
 not decoded: '\u263A \xE2\x98\xBA'
 neither this: '\u2705 \U0001D11E'
@@ -410,7 +410,8 @@ CHECK(langs["zh"].val() == "行星（气体）");
 // and \x \u \U codepoints are decoded, but only when they appear
 // inside double-quoted strings, as dictated by the YAML
 // standard:
-CHECK(langs["decode this"].val() == "☺ ☺");
+CHECK(langs["decode this"].val() == "A");
+CHECK(langs["decode this"].val() == "☺ café");
 CHECK(langs["and this as well"].val() == "✅ 𝄞");
 CHECK(langs["not decoded"].val() == "\\u263A \\xE2\\x98\\xBA");
 CHECK(langs["neither this"].val() == "\\u2705 \\U0001D11E");

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -895,7 +895,7 @@ ja: 惑星（ガス）
 zh: 行星（气体）
 # UTF8 decoding only happens in double-quoted strings,
 # as per the YAML standard
-decode this: "\u263A \xE2\x98\xBA"
+decode this: "\u263A c\x61f\xE9"
 and this as well: "\u2705 \U0001D11E"
 not decoded: '\u263A \xE2\x98\xBA'
 neither this: '\u2705 \U0001D11E'
@@ -909,7 +909,7 @@ neither this: '\u2705 \U0001D11E'
     // and \x \u \U codepoints are decoded, but only when they appear
     // inside double-quoted strings, as dictated by the YAML
     // standard:
-    CHECK(langs["decode this"].val() == "☺ ☺");
+    CHECK(langs["decode this"].val() == "☺ café");
     CHECK(langs["and this as well"].val() == "✅ 𝄞");
     CHECK(langs["not decoded"].val() == "\\u263A \\xE2\\x98\\xBA");
     CHECK(langs["neither this"].val() == "\\u2705 \\U0001D11E");

--- a/test/test_scalar_dquoted.cpp
+++ b/test/test_scalar_dquoted.cpp
@@ -294,34 +294,40 @@ dquoted_case test_cases_filter[] = {
     // 50
     dqc(R"(\P\P\P\P)", dqesc_P4),
     dqc(R"(\\\"\n\r\t\	\/\ \0\b\f\a\v\e\_\N\L\P)", dqescparsed),
+    dqc(R"(\xE4)", R"(ä)"),
+    dqc(R"(\xD7)", R"(×)"),
+    dqc(R"(\xA9)", R"(©)"),
+    // 55
+    dqc(R"(\xB5)", R"(µ)"),
+    dqc(R"(\xF7)", R"(÷)"),
     dqc(R"(\u263A)", R"(☺)"),
     dqc(R"(\u263a)", R"(☺)"),
     dqc(R"(\u2705)", R"(✅)"),
-    // 55
+    // 60
     dqc(R"(\u2705\u2705)", R"(✅✅)"),
     dqc(R"(\u2705\u2705\u2705)", R"(✅✅✅)"),
     dqc(R"(\u2705\u2705\u2705\u2705)", R"(✅✅✅✅)"),
     dqc(R"(\U0001D11E)", R"(𝄞)"),
     dqc(R"(\U0001d11e)", R"(𝄞)"),
-    // 60
+    // 65
     dqc(R"(\U0001d11e\U0001D11E)", R"(𝄞𝄞)"),
     dqc(R"(\U0001d11e\U0001D11E\U0001D11E)", R"(𝄞𝄞𝄞)"),
     dqc(R"(\U0001d11e\U0001D11E\U0001D11E\U0001D11E)", R"(𝄞𝄞𝄞𝄞)"),
     dqc(R"(\u263A\u2705\U0001D11E)", R"(☺✅𝄞)"),
     dqc(R"(\b1998\t1999\t2000\n)", "\b1998\t1999\t2000\n"),
-    // 65
+    // 70
     dqc(R"(\x0d\x0a is \r\n)", "\r\n is \r\n"),
     dqc("\n  foo\n\n    bar\n\n  baz\n", " foo\nbar\nbaz "),
     dqc(" 1st non-empty\n\n 2nd non-empty \n 3rd non-empty ", " 1st non-empty\n2nd non-empty 3rd non-empty "),
     dqc(" 1st non-empty\n\n 2nd non-empty \n	3rd non-empty ", " 1st non-empty\n2nd non-empty 3rd non-empty "),
     dqc(" 1st non-empty\n\n 2nd non-empty 	\n 	3rd non-empty ", " 1st non-empty\n2nd non-empty 3rd non-empty "),
-    // 70
+    // 75
     dqc(" 1st non-empty\n\n 2nd non-empty	 \n	3rd non-empty ", " 1st non-empty\n2nd non-empty 3rd non-empty "),
     dqc("\n  ", " "),
     dqc("  \n  ", " "),
     dqc("\n\n  ", "\n"),
     dqc("\n\n\n  ", "\n\n"),
-    // 75
+    // 80
     dqc("folded \nto a space,	\n \nto a line feed, or 	\\\n \\ 	non-content", "folded to a space,\nto a line feed, or \t \tnon-content"),
     dqc("folded \nto a space,\n \nto a line feed, or 	\\\n \\ 	non-content", "folded to a space,\nto a line feed, or \t \tnon-content"),
     //dqc("	\n\ndetected\n\n", "\t\ndetected\n"), // this case cannot be prefixed with anything.


### PR DESCRIPTION
This part was unescaping `\xXX` incorrectly (it was just dumping the codepoint as a byte.)