### PR TITLE
allow build for MSVC clang-cl and some BSD systems

### DIFF
--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -11,6 +11,9 @@
 
 #if defined(C4_MSVC) || defined(C4_MINGW)
 #include <malloc.h>
+#elif (defined(__clang__) && defined(_MSC_VER)) || \
+      defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#include <stdlib.h>
 #else
 #include <alloca.h>
 #endif


### PR DESCRIPTION
Allow build ryml lib for MSVC Clang-cl compiler and some BSD systems (mainly freebsd). these systems and compilers dont have `<alloca.h> `header, but `alloca()` function is defined in `<stdlib.h>`.