### PR TITLE
Fix: Tree::relocate() triggers assertions with zero-length strings

### DIFF
--- a/.github/workflows-in/benchmarks.ys
+++ b/.github/workflows-in/benchmarks.ys
@@ -23,7 +23,7 @@ jobs:
         - {std: 17, comp: clang18, os: ubuntu-24.04, cmkflags: -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18}
         #- {std: 17, comp: vs2019 , os: windows-2019, cmkflags: -G 'Visual Studio 16 2019' -A x64}
         - {std: 17, comp: vs2022 , os: windows-2022, cmkflags: -G 'Visual Studio 17 2022' -A x64}
-        - {std: 17, comp: xcode15, os: macos-13, xcver: 15, cmkflags: -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64}
+        - {std: 17, comp: xcode15, os: macos-15-intel, xcver: 16, cmkflags: -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64}
     env:: -{'BM' 'ON'} + load('share/env.yaml')
     steps:
     - :: checkout-action

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -108,8 +108,8 @@ jobs:
           cmkflags: -G 'Visual Studio 17 2022' -A x64
         - std: 17
           comp: xcode15
-          os: macos-13
-          xcver: 15
+          os: macos-15-intel
+          xcver: 16
           cmkflags: -G Xcode -DCMAKE_OSX_ARCHITECTURES=x86_64
     env:
       BM: 'ON'

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,5 +1,6 @@
 ### Changes
 
+- [PR#565](https://github.com/biojppm/rapidyaml/pull/565) (fixes [#564](https://github.com/biojppm/rapidyaml/issues/564)) - `Tree` arena: allow relocation of zero-length strings when placed at the end (relax assertions triggered in `Tree::_relocated()`)
 - [PR#561](https://github.com/biojppm/rapidyaml/pull/561) (fixes [#559](https://github.com/biojppm/rapidyaml/issues/559)) - Byte Order Mark: account for BOM when determining block indentation
 - [PR#563](https://github.com/biojppm/rapidyaml/pull/563) (fixes [#562](https://github.com/biojppm/rapidyaml/issues/562)) - Fix bug in `NodeRef::cend()`
 - [PR#547](https://github.com/biojppm/rapidyaml/pull/547) - Fix parsing of implicit first documents with empty sequences, caused by a problem in `Tree::set_root_as_stream()`:

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -1009,12 +1009,12 @@ private:
 
     substr _relocated(csubstr s, substr next_arena) const
     {
-        _RYML_CB_ASSERT(m_callbacks, m_arena.is_super(s));
-        _RYML_CB_ASSERT(m_callbacks, m_arena.sub(0, m_arena_pos).is_super(s));
+        _RYML_CB_ASSERT(m_callbacks, m_arena.is_super(s) || s.len == 0);
+        _RYML_CB_ASSERT(m_callbacks, m_arena.sub(0, m_arena_pos).is_super(s) || s.len == 0);
         auto pos = (s.str - m_arena.str); // this is larger than 0 based on the assertions above
         substr r(next_arena.str + pos, s.len);
         _RYML_CB_ASSERT(m_callbacks, r.str - next_arena.str == pos);
-        _RYML_CB_ASSERT(m_callbacks, next_arena.sub(0, m_arena_pos).is_super(r));
+        _RYML_CB_ASSERT(m_callbacks, next_arena.sub(0, m_arena_pos).is_super(r) || r.len == 0);
         return r;
     }
 


### PR DESCRIPTION
... when they are placed at the beginning or end of the arena

Fixes #564 