### PR TITLE
disable ci test for RYML_DBG 32 bit test: test in gcc

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,9 +43,6 @@ jobs:
         - std: 11
           namesfx: 32bit
           cmk: -DCMAKE_CXX_FLAGS=-m32
-        - std: 11
-          namesfx: 32bit_dbg
-          cmk: -DCMAKE_CXX_FLAGS=-m32 -DRYML_DBG=ON
     env:
       GCC_VERSION: 13
       LCOV_ARGS: -v --ignore-errors mismatch,mismatch --ignore-errors unused,unused
@@ -59,17 +56,22 @@ jobs:
         fetch-depth: 0
     - name: install compiler
       run: |
-        sudo dpkg --add-architecture i386
+        if [[ ${{matrix}} == *"32"* ]] ; then
+           sudo dpkg --add-architecture i386
+        fi
         sudo apt-get update
+        if [[ ${{matrix}} == *"32"* ]] ; then
+          sudo apt-get install -y \
+              linux-libc-dev:i386 \
+              libc6:i386 \
+              libc6-dev:i386 \
+              libc6-dbg:i386
+        fi
         sudo apt-get install -y \
             build-essential \
             cmake \
             git \
             lcov \
-            linux-libc-dev:i386 \
-            libc6:i386 \
-            libc6-dev:i386 \
-            libc6-dbg:i386 \
             g++-$GCC_VERSION \
             g++-$GCC_VERSION-multilib
     - name: show info

--- a/.github/workflows/coverage.ys
+++ b/.github/workflows/coverage.ys
@@ -18,7 +18,7 @@ jobs:
         - {std: 11, namesfx: 64bit_exc  , cmk: "-DCMAKE_CXX_FLAGS='-m64' -DRYML_DEFAULT_CALLBACK_USES_EXCEPTIONS=ON"}
         - {std: 11, namesfx: 64bit_dbg  , cmk: "-DCMAKE_CXX_FLAGS=-m64 -DRYML_DBG=ON"}
         - {std: 11, namesfx: 32bit      , cmk: "-DCMAKE_CXX_FLAGS=-m32"}
-        - {std: 11, namesfx: 32bit_dbg  , cmk: "-DCMAKE_CXX_FLAGS=-m32 -DRYML_DBG=ON"}
+        #- {std: 11, namesfx: 32bit_dbg  , cmk: "-DCMAKE_CXX_FLAGS=-m32 -DRYML_DBG=ON"}
     env:
       GCC_VERSION: 13 # the default compiler
       LCOV_ARGS: -v --ignore-errors mismatch,mismatch --ignore-errors unused,unused
@@ -28,17 +28,22 @@ jobs:
     - :: checkout-action
     - name: install compiler
       run: |
-        sudo dpkg --add-architecture i386
+        if [[ ${{matrix}} == *"32"* ]] ; then
+           sudo dpkg --add-architecture i386
+        fi
         sudo apt-get update
+        if [[ ${{matrix}} == *"32"* ]] ; then
+          sudo apt-get install -y \
+              linux-libc-dev:i386 \
+              libc6:i386 \
+              libc6-dev:i386 \
+              libc6-dbg:i386
+        fi
         sudo apt-get install -y \
             build-essential \
             cmake \
             git \
             lcov \
-            linux-libc-dev:i386 \
-            libc6:i386 \
-            libc6-dev:i386 \
-            libc6-dbg:i386 \
             g++-$GCC_VERSION \
             g++-$GCC_VERSION-multilib
     - name: show info

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -452,6 +452,101 @@ jobs:
       run: source .github/setenv.sh && c4_run_test shared32
     - name: shared32-pack
       run: source .github/setenv.sh && c4_package shared32
+  dbg:
+    if: always()
+    continue-on-error: false
+    name: dbg/${{matrix.name}}/${{matrix.gcc}}
+    runs-on: ubuntu-24.04
+    container: ghcr.io/biojppm/c4core/ubuntu${{matrix.img}}:latest
+    needs: canary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - name: 64bit_g
+          std: 11
+          gcc: 13
+          bt: Debug
+          img: 22.04
+          cxxflags: null
+        - name: 64bit_O1
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -O1 -DNDEBUG
+        - name: 64bit_O2
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -O2 -DNDEBUG
+        - name: 64bit_O3
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -O3 -DNDEBUG
+        - name: 32bit_g
+          std: 11
+          gcc: 13
+          bt: Debug
+          img: 22.04
+          cxxflags: -m32
+        - name: 32bit_O1
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -m32 -O1 -DNDEBUG
+        - name: 32bit_O2
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -m32 -O2 -DNDEBUG
+        - name: 32bit_O3
+          std: 11
+          gcc: 13
+          bt: Release
+          img: 22.04
+          cxxflags: -m32 -O3 -DNDEBUG
+    env:
+      STD: ${{matrix.std}}
+      CXX_: ${{matrix.gcc}}
+      BT: ${{matrix.bt}}
+      BITLINKS: ${{matrix.bitlinks}}
+      VG: ${{matrix.vg}}
+      SAN: ${{matrix.san}}
+      LINT: ${{matrix.lint}}
+      OS: ${{matrix.os}}
+    steps:
+    - name: checkout (action + docker)
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - run: git config --system --add safe.directory '*'
+    - run: c4core-install g++-${{matrix.gcc}}
+    - name: show info
+      run: source .github/setenv.sh && c4_show_info
+    - name: configure (issue \#${{matrix.issue}})
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_CXX_COMPILER=g++-${{matrix.gcc}} \
+          -DCMAKE_C_COMPILER=gcc-${{matrix.gcc}} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS_DEBUG="${{matrix.cxxflags}}" \
+          -DCMAKE_CXX_FLAGS_RELEASE="${{matrix.cxxflags}}" \
+          -DRYML_BUILD_TESTS=ON \
+          -DRYML_DBG=ON
+    - name: build (issue \#${{matrix.issue}})
+      run: cmake --build build --target ryml-test-build --parallel --verbose
+    - name: run (issue \#${{matrix.issue}})
+      run: |
+        source .github/setenv.sh
+        export CTEST_PARALLEL_LEVEL=`_c4getnumcores`
+        cmake --build build --target ryml-test-run
   misbuild:
     if: always()
     continue-on-error: false

--- a/.github/workflows/gcc.ys
+++ b/.github/workflows/gcc.ys
@@ -15,7 +15,7 @@ jobs:
       matrix:
         item =: \({:std %1, :cxx "g++-$a(%2)", :bt %3, :bitlinks 'shared64 static32', :img "$a(%4)"})
         include: &include1
-        # use gcc13 because it's a lot faster than gcc14
+        # for canary use gcc13 because it's a lot faster than gcc14
         - ! item(11  13 'Debug'   '22.04')
         - ! item(11  13 'Release' '22.04')
         - ! item(20  13 'Debug'   '22.04')
@@ -54,6 +54,48 @@ jobs:
     steps:: checkout-manual + install-cxx + run-steps
 
   #----------------------------------------------------------------------------
+  dbg:
+    :: setup-job('gcc' 'dbg')
+    name: dbg/${{matrix.name}}/${{matrix.gcc}}
+    :: runs-on-docker-c4core('${{matrix.img}}')
+    needs: canary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - {name: 64bit_g , std: 11, gcc: 13 , bt: Debug  , img: 22.04, cxxflags:      }
+        - {name: 64bit_O1, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags:      -O1 -DNDEBUG}
+        - {name: 64bit_O2, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags:      -O2 -DNDEBUG}
+        - {name: 64bit_O3, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags:      -O3 -DNDEBUG}
+        - {name: 32bit_g , std: 11, gcc: 13 , bt: Debug  , img: 22.04, cxxflags: -m32 }
+        - {name: 32bit_O1, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags: -m32 -O1 -DNDEBUG}
+        - {name: 32bit_O2, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags: -m32 -O2 -DNDEBUG}
+        - {name: 32bit_O3, std: 11, gcc: 13 , bt: Release, img: 22.04, cxxflags: -m32 -O3 -DNDEBUG}
+    env:: load('share/env.yaml') + {'CXX_' '${{matrix.gcc}}'}
+    steps:
+    - :: checkout-action-docker
+    - run: c4core-install g++-${{matrix.gcc}}
+    - name: show info
+      run: source .github/setenv.sh && c4_show_info
+    - name: configure (issue \#${{matrix.issue}})
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_CXX_COMPILER=g++-${{matrix.gcc}} \
+          -DCMAKE_C_COMPILER=gcc-${{matrix.gcc}} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_FLAGS_DEBUG="${{matrix.cxxflags}}" \
+          -DCMAKE_CXX_FLAGS_RELEASE="${{matrix.cxxflags}}" \
+          -DRYML_BUILD_TESTS=ON \
+          -DRYML_DBG=ON
+    - name: build (issue \#${{matrix.issue}})
+      run: cmake --build build --target ryml-test-build --parallel --verbose
+    - name: run (issue \#${{matrix.issue}})
+      run: |
+        source .github/setenv.sh
+        export CTEST_PARALLEL_LEVEL=`_c4getnumcores`
+        cmake --build build --target ryml-test-run
+
+  #----------------------------------------------------------------------------
   misbuild:
     :: setup-job('gcc' 'misbuild')
     name: misbuild#${{matrix.issue}}/gcc${{matrix.gcc}}/c++${{matrix.std}}
@@ -89,7 +131,7 @@ jobs:
         cmake --build build --target ryml-test-run
 
   #----------------------------------------------------------------------------
-  # with valgrind too slow: only latest gcc
+  # with valgrind: it's too slow; only latest gcc
 
   strategy-latest-gcc =::
       fail-fast: false
@@ -104,6 +146,7 @@ jobs:
           - {std: 11, cxx: 14, bits: 64, vg: ON , img: 22.04}
           - {std: 11, cxx: 14, bits: 32, vg: ON , img: 22.04}
 
+  # split these two valgrind jobs to make them faster
   vg1:
     :: setup-job('gcc' 'vg1')
     name: extended/${{matrix.cxx}}/${{matrix.bits}}bit/c++${{matrix.std}}/vg/D_O1_O2
@@ -118,7 +161,6 @@ jobs:
     - :: run-gcc-manual-with-flags('Debug'                '-m${{matrix.bits}}')
     - :: run-gcc-manual-with-flags('Release' '-O1 -DNDEBUG -m${{matrix.bits}}')
     - :: run-gcc-manual-with-flags('Release' '-O2 -DNDEBUG -m${{matrix.bits}}')
-
   vg2:
     :: setup-job('gcc' 'vg2')
     name: extended/${{matrix.cxx}}/${{matrix.bits}}bit/c++${{matrix.std}}/vg/O3_Os


### PR DESCRIPTION
The coverage run for RYML_DBG in 32 bit was consistently failing to build in the runner, due to memory usage from what I guess was a combination of the coverage compilation flags and the RYML_DBG print calls. This commit disables this particular coverage run, and ensures it is now tested in the gcc workflow.