### PR TITLE
Improve `scalar_style_choose()` to account for flow/block mode:

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -88,12 +88,8 @@ jobs:
     - name: check doxygen docs
       run: |
         export PATH=$DOXY_DIR:$PATH
-        # put doxygen to fail if there are warnings
-        sed "s/WARN_AS_ERROR.*= .*/WARN_AS_ERROR = FAIL_ON_WARNINGS_PRINT/g" -i doc/Doxyfile
-        make -C doc doxy
+        make -C doc doxy_test
     - name: check sphinx
       run: |
-        # put doxygen to not fail if there are warnings.
-        sed "s/WARN_AS_ERROR.*= .*/WARN_AS_ERROR = NO/g" -i doc/Doxyfile
         export PATH=$DOXY_DIR:$PATH
         make -C doc html

--- a/.github/workflows/infra.ys
+++ b/.github/workflows/infra.ys
@@ -70,12 +70,8 @@ jobs:
       - name: check doxygen docs
         run: |
           export PATH=$DOXY_DIR:$PATH
-          # put doxygen to fail if there are warnings
-          sed "s/WARN_AS_ERROR.*= .*/WARN_AS_ERROR = FAIL_ON_WARNINGS_PRINT/g" -i doc/Doxyfile
-          make -C doc doxy
+          make -C doc doxy_test
       - name: check sphinx
         run: |
-          # put doxygen to not fail if there are warnings.
-          sed "s/WARN_AS_ERROR.*= .*/WARN_AS_ERROR = NO/g" -i doc/Doxyfile
           export PATH=$DOXY_DIR:$PATH
           make -C doc html

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -3,19 +3,29 @@
 - [PR#604](https://github.com/biojppm/rapidyaml/pull/604): add string_view and span to the `c4/yml/std/std.hpp` interop umbrella header.
 - [PR#605](https://github.com/biojppm/rapidyaml/pull/605): fix parse errors:
   - `:` and `#` on continuation lines of multiline plain scalars:
-     ```
+     ```yaml
      [plain
       :scalar] # leading colon belongs to the scalar
      ```
   - Tabs inside quoted scalars opening a map were being mistook for indentation tabs:
-    ```
+    ```yaml
     foo:
       '\ta': b
     ```
+- [PR#606](https://github.com/biojppm/rapidyaml/pull/606): scalar style utilities now are specific to flow/block mode. This enables stable-style roundtrips of block-mode plain scalars with characters invalid in flow mode:
+  ```yaml
+  # these scalars were previously emitted as single-quoted style
+  - doe: a deer, a female deer
+  - (10,11)
+  - also scalars containing [] and {}
+  ```
+  - `scalar_style_choose()` was split into `scalar_style_choose_{flow,block}()`
+  - `scalar_style_query_plain()` was split into `scalar_style_query_plain_{flow,block}()`
+  - `NodeType::type_str(NodeType,flags)`: remove zero-termination, use common approach of returning required size
+  - Add `NodeType::type_str_sub()`
 
 
 ### Thanks
 
  - @GabrielBarrantes
  - @musicinmybrain
-

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1229,7 +1229,7 @@ REFERENCED_BY_RELATION = NO
 # all documented entities called/used by that function will be listed.
 # The default value is: NO.
 
-REFERENCES_RELATION    = YES
+REFERENCES_RELATION    = NO
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
 # to YES then the hyperlinks from functions in REFERENCES_RELATION and

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -37,6 +37,13 @@ doxy:
 	## finally, run doxygen
 	$(DOXYGEN) $(DOXYGEN_OPTS) Doxyfile
 
+doxy_test:
+	$(MAKE) --keep-going _doxy_warnfail doxy _doxy_warnpass
+_doxy_warnfail:
+	sed "s/WARN_AS_ERROR\(.*\)= .*/WARN_AS_ERROR\1= FAIL_ON_WARNINGS_PRINT/g" -i Doxyfile
+_doxy_warnpass:
+	sed "s/WARN_AS_ERROR\(.*\)= .*/WARN_AS_ERROR\1= NO/g" -i Doxyfile
+
 clean:
 	rm -rf doxygen/
 	if [ ! -z "$(BUILDDIR)" ] ; then rm -rf "$(BUILDDIR)" ; fi

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -2326,7 +2326,7 @@ void sample_create_trees()
     xmas5["turtle-doves"] = "two";
     root["cars"] = "GTO";
 
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(doe: 'a deer, a female deer'
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(doe: a deer, a female deer
 ray: a drop of golden sun
 pi: 3.14159
 xmas: true
@@ -3231,12 +3231,12 @@ void sample_base64()
         tree.rootref().append_child() << ryml::key(ryml::fmt::base64(c.text)) << c.text;
         CHECK(tree[c.base64].val() == c.text);
     }
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"('Love all, trust a few, do wrong to none.': TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==
-'The fool doth think he is wise, but the wise man knows himself to be a fool.': VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(Love all, trust a few, do wrong to none.: TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==
+The fool doth think he is wise, but the wise man knows himself to be a fool.: VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==
 Brevity is the soul of wit.: QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu
 All that glitters is not gold.: QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu
-TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==: 'Love all, trust a few, do wrong to none.'
-VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==: 'The fool doth think he is wise, but the wise man knows himself to be a fool.'
+TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==: Love all, trust a few, do wrong to none.
+VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==: The fool doth think he is wise, but the wise man knows himself to be a fool.
 QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu: Brevity is the soul of wit.
 QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu: All that glitters is not gold.
 )");
@@ -3620,9 +3620,9 @@ void sample_user_scalar_types()
     CHECK(v4in.y == v4out.y);
     CHECK(v4in.z == v4out.z);
     CHECK(v4in.w == v4out.w);
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: '(10,11)'
-v3: '(100,101,102)'
-v4: '(1000,1001,1002,1003)'
+    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (10,11)
+v3: (100,101,102)
+v4: (1000,1001,1002,1003)
 )");
 
     // note that only the used functions are needed:
@@ -3648,9 +3648,9 @@ v4: '(1000,1001,1002,1003)'
     CHECK(eov4in.x == pov4out.x);
     CHECK(eov4in.y == pov4out.y);
     CHECK(eov4in.z == pov4out.z);
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: '(20,21)'
-v3: '(30,31,32)'
-v4: '(40,41,42,43)'
+    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (20,21)
+v3: (30,31,32)
+v4: (40,41,42,43)
 )");
 }
 
@@ -3824,9 +3824,9 @@ void sample_user_container_types()
         CHECK(mt_out.map.map_member.find(kv.first) != mt_out.map.map_member.end());
         CHECK(mt_out.map.map_member[kv.first] == kv.second);
     }
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: '(20,21)'
-v3: '(30,31,32)'
-v4: '(40,41,42,43)'
+    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (20,21)
+v3: (30,31,32)
+v4: (40,41,42,43)
 seq:
   - 101
   - 102
@@ -3851,9 +3851,9 @@ map:
   @see also the STL section in @ref doc_serialization */
 void sample_std_types()
 {
-    std::string yml_std_string = R"(- v2: '(20,21)'
-  v3: '(30,31,32)'
-  v4: '(40,41,42,43)'
+    std::string yml_std_string = R"(- v2: (20,21)
+  v3: (30,31,32)
+  v4: (40,41,42,43)
   seq:
     - 101
     - 102
@@ -3866,9 +3866,9 @@ void sample_std_types()
     1001: 2001
     1002: 2002
     1003: 2003
-- v2: '(120,121)'
-  v3: '(130,131,132)'
-  v4: '(140,141,142,143)'
+- v2: (120,121)
+  v3: (130,131,132)
+  v4: (140,141,142,143)
   seq:
     - 1101
     - 1102
@@ -3881,9 +3881,9 @@ void sample_std_types()
     11001: 12001
     11002: 12002
     11003: 12003
-- v2: '(220,221)'
-  v3: '(230,231,232)'
-  v4: '(240,241,242,243)'
+- v2: (220,221)
+  v3: (230,231,232)
+  v4: (240,241,242,243)
   seq:
     - 2101
     - 2102
@@ -4497,14 +4497,14 @@ block seq:
   - block val 1
   - block val 2
   - quoted
-'flow map, singleline':
+flow map, singleline:
   flow key: flow val
-'flow seq, singleline':
+flow seq, singleline:
   - flow val
   - flow val
-'flow map, multiline':
+flow map, multiline:
   flow key: flow val
-'flow seq, multiline':
+flow seq, multiline:
   - flow val
   - flow val
 )");
@@ -4522,14 +4522,14 @@ block seq:
   - block val 1
   - block val 2
   - quoted
-'flow map, singleline':
+flow map, singleline:
   flow key: flow val
-'flow seq, singleline':
+flow seq, singleline:
   - flow val
   - flow val
-'flow map, multiline':
+flow map, multiline:
   flow key: flow val
-'flow seq, multiline':
+flow seq, multiline:
   - flow val
   - flow val
 )");
@@ -4808,9 +4808,9 @@ void sample_json()
     // so now when emitting you will get this:
     // (the scalars with a comma are single-quote)
     CHECK(ryml::emitrs_yaml<std::string>(json_tree) ==
-          R"(doe: 'a deer, a female deer'
+          R"(doe: a deer, a female deer
 ray: a drop of golden sun
-me: 'a name, I call myself'
+me: a name, I call myself
 far: a long long way to go
 )");
     // you can do custom style changes based on a type mask. this

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -18,6 +18,13 @@
  *
  * Happy ryml'ing!
  *
+ * ### Note on use of raw strings
+ *
+ * This sample uses C strings instead of C++11 R"(raw strings)"
+ * because the doxygen parser is badly broken when handling raw
+ * strings.
+ *
+ *
  * ### Some guidance on building
  *
  * The directories that exist side-by-side with this file contain
@@ -186,6 +193,7 @@ int main(int argc, const char* argv[])
     sample_style_flow_ml_filter();
     sample_json();
     sample_anchors_and_aliases();
+    sample_anchors_and_aliases_create();
     sample_tags();
     sample_tag_directives();
     sample_docs();
@@ -296,10 +304,9 @@ bool report_check(int line, const char *predicate, bool result);
 #   define CHECK(predicate) assert(predicate)  // enable doxygen to link to the functions called inside CHECK()
 #else
 #   if !(defined(__GNUC__) && (__GNUC__ == 4 && __GNUC_MINOR__ >= 8))
-    /// a quick'n'dirty assertion to verify a predicate
+        /// a quick'n'dirty assertion to verify a predicate
 #       define CHECK(predicate) do { if(!report_check(__LINE__, #predicate, (predicate))) { RYML_DEBUG_BREAK(); } } while(0)
 #   else // GCC 4.8 has a problem with the CHECK() macro
-/// a quick'n'dirty assertion to verify a predicate
 #       define CHECK CheckPredicate{__FILE__, __LINE__}
         struct CheckPredicate
         {
@@ -382,15 +389,16 @@ void sample_lightning_overview()
 void sample_quick_overview()
 {
     // Parse YAML code in place, potentially mutating the buffer:
-    char yml_buf[] = R"(
-foo: 1
-bar: [2, 3]
-john: doe)";
+    char yml_buf[] = ""
+        "foo: 1"         "\n"
+        "bar: [2, 3]"    "\n"
+        "john: doe"      "\n"
+        "";
     ryml::Tree tree = ryml::parse_in_place(yml_buf);
 
     // The resulting tree contains only views to the parsed string. If
     // the string was parsed in place, then the string must outlive
-    // the tree! This works in this case because both `yml_buf` and `tree`
+    // the tree! This works here because both `yml_buf` and `tree`
     // live on the same scope, so have the same lifetime.
 
     // It is also possible to:
@@ -859,8 +867,8 @@ john: doe)";
         // using .at() reliably produces an error:
         CHECK(errh.check_error_occurs([&]{
             return seed_node.at("is").at("an").at("invalid").at("operation");
-            //              ^
-            //              error occurs here because it is unreadable
+            //               ^
+            //               error occurs here because it is unreadable
         }));
         // ... but using [] fails only when RYML_USE_ASSERT is
         // defined. otherwise, it's the dreaded Undefined Behavior:
@@ -875,19 +883,20 @@ john: doe)";
     //------------------------------------------------------------------
     // Emitting:
 
-    ryml::csubstr expected_result = R"(foo: says who
-bar: [20,30,oh so nice,oh so nice (serialized)]
-john: in_scope
-float: 2.4
-digits: 2.400000
-newkeyval: shiny and new
-newkeyval (serialized): shiny and new (serialized)
-newseq: []
-newseq (serialized): []
-newmap: {}
-newmap (serialized): {}
-I am something: indeed
-)";
+    ryml::csubstr expected_result =
+        "foo: says who"                                         "\n"
+        "bar: [20,30,oh so nice,oh so nice (serialized)]"       "\n"
+        "john: in_scope"                                        "\n"
+        "float: 2.4"                                            "\n"
+        "digits: 2.400000"                                      "\n"
+        "newkeyval: shiny and new"                              "\n"
+        "newkeyval (serialized): shiny and new (serialized)"    "\n"
+        "newseq: []"                                            "\n"
+        "newseq (serialized): []"                               "\n"
+        "newmap: {}"                                            "\n"
+        "newmap (serialized): {}"                               "\n"
+        "I am something: indeed"                                "\n"
+        "";
 
     // emit to a FILE*
     ryml::emit_yaml(tree, stdout);
@@ -965,19 +974,23 @@ I am something: indeed
 
     //------------------------------------------------------------------
     // Dealing with UTF8
-    ryml::Tree langs = ryml::parse_in_arena(R"(
-en: Planet (Gas)
-fr: Planète (Gazeuse)
-ru: Планета (Газ)
-ja: 惑星（ガス）
-zh: 行星（气体）
-# UTF8 decoding only happens in double-quoted strings,
-# as per the YAML standard
-decode this: "\u263A c\x61f\xE9"
-and this as well: "\u2705 \U0001D11E"
-not decoded: '\u263A \xE2\x98\xBA'
-neither this: '\u2705 \U0001D11E'
-)");
+    ryml::Tree langs = ryml::parse_in_arena(""
+        "#"                                                       "\n"
+        "# UTF8/16/32 can be placed directly in any scalar:"      "\n"
+        "#"                                                       "\n"
+        "en: Planet (Gas)"                                        "\n"
+        "fr: Planète (Gazeuse)"                                   "\n"
+        "ru: Планета (Газ)"                                      "\n"
+        "ja: 惑星（ガス）"                                        "\n"
+        "zh: 行星（气体）"                                        "\n"
+        "#"                                                       "\n"
+        "# UTF8 decoding only happens in double-quoted strings,"  "\n"
+        "# as per the YAML standard"                              "\n"
+        "#"                                                       "\n"
+        "decode this: \"\\u263A c\\x61f\\xE9\""                   "\n"
+        "and this as well: \"\\u2705 \\U0001D11E\""               "\n"
+        "not decoded: '\\u263A \\xE2\\x98\\xBA'"                  "\n"
+        "neither this: '\\u2705 \\U0001D11E'"                     "\n");
     // in-place UTF8 just works:
     CHECK(langs["en"].val() == "Planet (Gas)");
     CHECK(langs["fr"].val() == "Planète (Gazeuse)");
@@ -1394,8 +1407,8 @@ void sample_substr()
 
     // unquoted():
     {
-        CHECK(ryml::csubstr(R"('this is is single quoted')").unquoted() == "this is is single quoted");
-        CHECK(ryml::csubstr(R"("this is is double quoted")").unquoted() == "this is is double quoted");
+        CHECK(ryml::csubstr( "'this is is single quoted'" ).unquoted() == "this is is single quoted");
+        CHECK(ryml::csubstr("\"this is is double quoted\"").unquoted() == "this is is double quoted");
     }
 
     // stripl(): remove pattern from the left
@@ -1780,24 +1793,24 @@ void sample_substr()
         CHECK(ryml::csubstr(  "0/1/2/"  ). pop_right('/', skip_empty) ==   "2/"   );
         CHECK(ryml::csubstr(  "0/1/2//" ). pop_right('/', skip_empty) ==   "2//"  );
         // gpop_right(): pop all but the first element (greedy pop)
-        CHECK(ryml::csubstr(  "0/1/2"   ).gpop_right('/'            ) ==     "1/2");
-        CHECK(ryml::csubstr(  "0/1/2/"  ).gpop_right('/'            ) ==     "1/2/"  );
-        CHECK(ryml::csubstr(  "0/1/2//" ).gpop_right('/'            ) ==     "1/2//"  );
-        CHECK(ryml::csubstr( "/0/1/2"   ).gpop_right('/'            ) ==   "0/1/2");
-        CHECK(ryml::csubstr( "/0/1/2/"  ).gpop_right('/'            ) ==   "0/1/2/"  );
-        CHECK(ryml::csubstr( "/0/1/2//" ).gpop_right('/'            ) ==   "0/1/2//"  );
-        CHECK(ryml::csubstr("//0/1/2"   ).gpop_right('/'            ) ==  "/0/1/2");
-        CHECK(ryml::csubstr("//0/1/2/"  ).gpop_right('/'            ) ==  "/0/1/2/"  );
-        CHECK(ryml::csubstr("//0/1/2//" ).gpop_right('/'            ) ==  "/0/1/2//"  );
-        CHECK(ryml::csubstr(  "0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2");
-        CHECK(ryml::csubstr(  "0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/"  );
-        CHECK(ryml::csubstr(  "0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//"  );
-        CHECK(ryml::csubstr( "/0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2");
-        CHECK(ryml::csubstr( "/0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/"  );
-        CHECK(ryml::csubstr( "/0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//"  );
-        CHECK(ryml::csubstr("//0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2");
-        CHECK(ryml::csubstr("//0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/"  );
-        CHECK(ryml::csubstr("//0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//"  );
+        CHECK(ryml::csubstr(  "0/1/2"   ).gpop_right('/'            ) ==     "1/2"  );
+        CHECK(ryml::csubstr(  "0/1/2/"  ).gpop_right('/'            ) ==     "1/2/" );
+        CHECK(ryml::csubstr(  "0/1/2//" ).gpop_right('/'            ) ==     "1/2//");
+        CHECK(ryml::csubstr( "/0/1/2"   ).gpop_right('/'            ) ==   "0/1/2"  );
+        CHECK(ryml::csubstr( "/0/1/2/"  ).gpop_right('/'            ) ==   "0/1/2/" );
+        CHECK(ryml::csubstr( "/0/1/2//" ).gpop_right('/'            ) ==   "0/1/2//");
+        CHECK(ryml::csubstr("//0/1/2"   ).gpop_right('/'            ) ==  "/0/1/2"  );
+        CHECK(ryml::csubstr("//0/1/2/"  ).gpop_right('/'            ) ==  "/0/1/2/" );
+        CHECK(ryml::csubstr("//0/1/2//" ).gpop_right('/'            ) ==  "/0/1/2//");
+        CHECK(ryml::csubstr(  "0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2"  );
+        CHECK(ryml::csubstr(  "0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/" );
+        CHECK(ryml::csubstr(  "0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//");
+        CHECK(ryml::csubstr( "/0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2"  );
+        CHECK(ryml::csubstr( "/0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/" );
+        CHECK(ryml::csubstr( "/0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//");
+        CHECK(ryml::csubstr("//0/1/2"   ).gpop_right('/', skip_empty) ==     "1/2"  );
+        CHECK(ryml::csubstr("//0/1/2/"  ).gpop_right('/', skip_empty) ==     "1/2/" );
+        CHECK(ryml::csubstr("//0/1/2//" ).gpop_right('/', skip_empty) ==     "1/2//");
     }
 }
 
@@ -1821,16 +1834,15 @@ void sample_substr()
 void sample_parse_file()
 {
     const char filename[] = "ryml_example.yml";
-
+    ryml::csubstr yaml = ""
+        "foo: 1"  "\n"
+        "bar:"    "\n"
+        "- 2"     "\n"
+        "- 3"     "\n";
     // because this is a minimal sample, it assumes nothing on the
     // environment/OS (other than that it can read/write files). So we
     // create the file on the fly:
-    file_put_contents(filename, ryml::csubstr(R"(
-foo: 1
-bar:
-- 2
-- 3
-)"));
+    file_put_contents(filename, yaml);
 
     // now we can load it into a std::string (for example):
     {
@@ -1975,9 +1987,10 @@ void sample_parse_reuse_tree()
     tree.reserve_arena(256); // reserve 256 characters (good enough for this sample)
 
     // now parse into the tree:
-    ryml::csubstr yaml = R"(foo: 1
-bar: [2, 3]
-)";
+    ryml::csubstr yaml = ""
+        "foo: 1"        "\n"
+        "bar: [2,3]"    "\n"
+        "";
     ryml::parse_in_arena(yaml, &tree);
 
     ryml::ConstNodeRef root = tree.crootref();
@@ -1991,17 +2004,16 @@ bar: [2, 3]
     CHECK(root["bar"].key() == "bar");
     CHECK(root["bar"][0].val() == "2");
     CHECK(root["bar"][1].val() == "3");
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(foo: 1
-bar: [2,3]
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == yaml);
 
     // WATCHOUT: parsing into an existing tree will APPEND to it:
     ryml::parse_in_arena("{foo2: 12, bar2: [22, 32]}", &tree);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(foo: 1
-bar: [2,3]
-foo2: 12
-bar2: [22,32]
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "foo: 1"         "\n"
+          "bar: [2,3]"     "\n"
+          "foo2: 12"       "\n"
+          "bar2: [22,32]"  "\n"
+          "");
     CHECK(root.num_children() == 4);
     CHECK(root["foo2"].is_keyval());
     CHECK(root["foo2"].key() == "foo2");
@@ -2012,7 +2024,8 @@ bar2: [22,32]
     CHECK(root["bar2"][0].val() == "22");
     CHECK(root["bar2"][1].val() == "32");
 
-    // clear first before parsing into an existing tree.
+    // if you want to fully replace the tree, you need to clear first
+    // before parsing into an existing tree:
     tree.clear();
     tree.clear_arena();  // you may or may not want to clear the arena
     ryml::parse_in_arena("- a\n- b\n- {x0: 1, x1: 2}", &tree);
@@ -2027,12 +2040,13 @@ bar2: [22,32]
     // we can parse directly into a node nested deep in an existing tree:
     ryml::NodeRef mroot = tree.rootref(); // modifiable root
     ryml::parse_in_arena("champagne: Dom Perignon\ncoffee: Arabica", mroot.append_child());
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- a
-- b
-- {x0: 1,x1: 2}
-- champagne: Dom Perignon
-  coffee: Arabica
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "- a"                              "\n"
+          "- b"                              "\n"
+          "- {x0: 1,x1: 2}"                  "\n"
+          "- champagne: Dom Perignon"        "\n"
+          "  coffee: Arabica"                "\n"
+          "");
     CHECK(root.is_seq());
     CHECK(root[0].val() == "a");
     CHECK(root[1].val() == "b");
@@ -2051,63 +2065,68 @@ bar2: [22,32]
     ryml::parse_in_arena("{vinho verde: Soalheiro, vinho tinto: Redoma 2017}", more);
     ryml::parse_in_arena("- Rochefort 10\n- Busch\n- Leffe Rituel", beer);
     ryml::parse_in_arena("lots\nof\nwater", always);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- a
-- b
-- {x0: 1,x1: 2}
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-  always: lots of water
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "- a"                              "\n"
+          "- b"                              "\n"
+          "- {x0: 1,x1: 2}"                  "\n"
+          "- champagne: Dom Perignon"        "\n"
+          "  coffee: Arabica"                "\n"
+          // note these were added:
+          "  more:"                          "\n"
+          "    vinho verde: Soalheiro"       "\n"
+          "    vinho tinto: Redoma 2017"     "\n"
+          "  beer:"                          "\n"
+          "    - Rochefort 10"               "\n"
+          "    - Busch"                      "\n"
+          "    - Leffe Rituel"               "\n"
+          "  always: lots of water"          "\n"
+          "");
 
     // can append at the top:
     ryml::parse_in_arena("- foo\n- bar\n- baz\n- bat", mroot);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- a
-- b
-- {x0: 1,x1: 2}
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-  always: lots of water
-- foo
-- bar
-- baz
-- bat
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "- a"                              "\n"
+          "- b"                              "\n"
+          "- {x0: 1,x1: 2}"                  "\n"
+          "- champagne: Dom Perignon"        "\n"
+          "  coffee: Arabica"                "\n"
+          "  more:"                          "\n"
+          "    vinho verde: Soalheiro"       "\n"
+          "    vinho tinto: Redoma 2017"     "\n"
+          "  beer:"                          "\n"
+          "    - Rochefort 10"               "\n"
+          "    - Busch"                      "\n"
+          "    - Leffe Rituel"               "\n"
+          "  always: lots of water"          "\n"
+          // note these were added
+          "- foo"                            "\n"
+          "- bar"                            "\n"
+          "- baz"                            "\n"
+          "- bat"                            "\n"
+          "");
 
     // or nested:
     ryml::parse_in_arena("[Kasteel Donker]", beer);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- a
-- b
-- {x0: 1,x1: 2}
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-    - Kasteel Donker
-  always: lots of water
-- foo
-- bar
-- baz
-- bat
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) ==
+          "- a"                              "\n"
+          "- b"                              "\n"
+          "- {x0: 1,x1: 2}"                  "\n"
+          "- champagne: Dom Perignon"        "\n"
+          "  coffee: Arabica"                "\n"
+          "  more:"                          "\n"
+          "    vinho verde: Soalheiro"       "\n"
+          "    vinho tinto: Redoma 2017"     "\n"
+          "  beer:"                          "\n"
+          "    - Rochefort 10"               "\n"
+          "    - Busch"                      "\n"
+          "    - Leffe Rituel"               "\n"
+          "    - Kasteel Donker"             "\n"  // added this
+          "  always: lots of water"          "\n"
+          "- foo"                            "\n"
+          "- bar"                            "\n"
+          "- baz"                            "\n"
+          "- bat"                            "\n"
+          "");
 }
 
 
@@ -2130,11 +2149,13 @@ void sample_parse_reuse_parser()
     parser.reserve_stack(20); // But this will cause an allocation
                               // because it is above 16.
 
-    ryml::Tree champagnes = parse_in_arena(&parser, "champagnes.yml", "[Dom Perignon, Gosset Grande Reserve, Jacquesson 742]");
-    CHECK(ryml::emitrs_yaml<std::string>(champagnes) == "[Dom Perignon,Gosset Grande Reserve,Jacquesson 742]");
+    ryml::csubstr yaml = "[Dom Perignon,Gosset Grande Reserve,Jacquesson 742]";
+    ryml::Tree champagnes = parse_in_arena(&parser, "champagnes.yml", yaml);
+    CHECK(ryml::emitrs_yaml<std::string>(champagnes) == yaml);
 
-    ryml::Tree beers = parse_in_arena(&parser, "beers.yml", "[Rochefort 10, Busch, Leffe Rituel, Kasteel Donker]");
-    CHECK(ryml::emitrs_yaml<std::string>(beers) == "[Rochefort 10,Busch,Leffe Rituel,Kasteel Donker]");
+    yaml = "[Rochefort 10,Busch,Leffe Rituel,Kasteel Donker]";
+    ryml::Tree beers = parse_in_arena(&parser, "beers.yml", yaml);
+    CHECK(ryml::emitrs_yaml<std::string>(beers) == yaml);
 }
 
 
@@ -2164,34 +2185,46 @@ void sample_parse_reuse_tree_and_parser()
     parser.reserve_stack(20); // But this will cause an allocation
                               // because it is above 16.
 
-    ryml::csubstr champagnes = "- Dom Perignon\n- Gosset Grande Reserve\n- Jacquesson 742";
-    ryml::csubstr beers = "- Rochefort 10\n- Busch\n- Leffe Rituel\n- Kasteel Donker";
-    ryml::csubstr wines = "- Soalheiro\n- Niepoort Redoma 2017\n- Vina Esmeralda";
+    ryml::csubstr champagnes = ""
+        "- Dom Perignon\n"
+        "- Gosset Grande Reserve\n"
+        "- Jacquesson 742\n"
+        "";
+    ryml::csubstr beers = ""
+        "- Rochefort 10\n"
+        "- Busch\n"
+        "- Leffe Rituel\n"
+        "- Kasteel Donker\n"
+        "";
+    ryml::csubstr wines = ""
+        "- Soalheiro\n"
+        "- Niepoort Redoma 2017\n"
+        "- Vina Esmeralda\n"
+        "";
 
     parse_in_arena(&parser, "champagnes.yml", champagnes, &tree);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- Dom Perignon
-- Gosset Grande Reserve
-- Jacquesson 742
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == champagnes);
 
     // watchout: this will APPEND to the given tree:
     parse_in_arena(&parser, "beers.yml", beers, &tree);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- Dom Perignon
-- Gosset Grande Reserve
-- Jacquesson 742
-- Rochefort 10
-- Busch
-- Leffe Rituel
-- Kasteel Donker
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "- Dom Perignon\n"
+          "- Gosset Grande Reserve\n"
+          "- Jacquesson 742\n"
+          "- Rochefort 10\n"
+          "- Busch\n"
+          "- Leffe Rituel\n"
+          "- Kasteel Donker\n"
+          "");
 
     // if you don't wish to append, clear the tree first:
     tree.clear();
     parse_in_arena(&parser, "wines.yml", wines, &tree);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(- Soalheiro
-- Niepoort Redoma 2017
-- Vina Esmeralda
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+        "- Soalheiro\n"
+        "- Niepoort Redoma 2017\n"
+        "- Vina Esmeralda\n"
+        "");
 }
 
 
@@ -2203,26 +2236,27 @@ void sample_parse_reuse_tree_and_parser()
  */
 void sample_iterate_trees()
 {
-    const ryml::Tree tree = ryml::parse_in_arena(R"(doe: "a deer, a female deer"
-ray: "a drop of golden sun"
-pi: 3.14159
-xmas: true
-french-hens: 3
-calling-birds:
-   - huey
-   - dewey
-   - louie
-   - fred
-xmas-fifth-day:
-  calling-birds: four
-  french-hens: 3
-  golden-rings: 5
-  partridges:
-    count: 1
-    location: a pear tree
-  turtle-doves: two
-cars: GTO
-)");
+    const ryml::Tree tree = ryml::parse_in_arena(
+        "doe: a deer, a female deer"      "\n"
+        "ray: a drop of golden sun"       "\n"
+        "pi: 3.14159"                     "\n"
+        "xmas: true"                      "\n"
+        "french-hens: 3"                  "\n"
+        "calling-birds:"                  "\n"
+        "   - huey"                       "\n"
+        "   - dewey"                      "\n"
+        "   - louie"                      "\n"
+        "   - fred"                       "\n"
+        "xmas-fifth-day:"                 "\n"
+        "  calling-birds: four"           "\n"
+        "  french-hens: 3"                "\n"
+        "  golden-rings: 5"               "\n"
+        "  partridges:"                   "\n"
+        "    count: 1"                    "\n"
+        "    location: a pear tree"       "\n"
+        "  turtle-doves: two"             "\n"
+        "cars: GTO"                       "\n"
+        "");
     ryml::ConstNodeRef root = tree.crootref();
 
     // iterate children
@@ -2326,26 +2360,27 @@ void sample_create_trees()
     xmas5["turtle-doves"] = "two";
     root["cars"] = "GTO";
 
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(doe: a deer, a female deer
-ray: a drop of golden sun
-pi: 3.14159
-xmas: true
-french-hens: 3
-calling-birds:
-  - huey
-  - dewey
-  - louie
-  - fred
-xmas-fifth-day:
-  calling-birds: four
-  french-hens: 3
-  golden-rings: 5
-  partridges:
-    count: 1
-    location: a pear tree
-  turtle-doves: two
-cars: GTO
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "doe: a deer, a female deer"       "\n"
+          "ray: a drop of golden sun"        "\n"
+          "pi: 3.14159"                      "\n"
+          "xmas: true"                       "\n"
+          "french-hens: 3"                   "\n"
+          "calling-birds:"                   "\n"
+          "  - huey"                         "\n"
+          "  - dewey"                        "\n"
+          "  - louie"                        "\n"
+          "  - fred"                         "\n"
+          "xmas-fifth-day:"                  "\n"
+          "  calling-birds: four"            "\n"
+          "  french-hens: 3"                 "\n"
+          "  golden-rings: 5"                "\n"
+          "  partridges:"                    "\n"
+          "    count: 1"                     "\n"
+          "    location: a pear tree"        "\n"
+          "  turtle-doves: two"              "\n"
+          "cars: GTO"                        "\n"
+          "");
 }
 
 
@@ -2614,15 +2649,15 @@ void sample_fundamental_types()
 void sample_empty_null_values()
 {
     // reading empty/null values - see also sample_formatting()
-    ryml::Tree tree = ryml::parse_in_arena(R"(
-plain:
-squoted: ''
-dquoted: ""
-literal: |
-folded: >
-all_null: [~, null, Null, NULL]
-non_null: [nULL, non_null, non null, null it is not]
-)");
+    ryml::Tree tree = ryml::parse_in_arena(""
+        "plain:"                                                  "\n"
+        "squoted: ''"                                             "\n"
+        "dquoted: \"\""                                           "\n"
+        "literal: |"                                              "\n"
+        "folded: >"                                               "\n"
+        "all_null: [~, null, Null, NULL]"                         "\n"
+        "non_null: [nULL, non_null, non null, null it is not]"    "\n"
+        "");
     // first, remember that .has_val() is a structural predicate
     // indicating the node is a leaf, and not a container.
     CHECK(tree["plain"].has_val()); // has a val, even if it's empty!
@@ -2713,11 +2748,12 @@ non_null: [nULL, non_null, non null, null it is not]
     // serializes as the normal '~' string:
     tree["str_tilde"] << tilde; CHECK(tree.arena() == "null~");
     // this is the resulting yaml:
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(empty_null: 
-empty_nonnull: ''
-str_null: null
-str_tilde: ~
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "empty_null: "         "\n"
+          "empty_nonnull: ''"    "\n"
+          "str_null: null"       "\n"
+          "str_tilde: ~"         "\n"
+          "");
     // To enforce a particular concept of what is a null string, you
     // can use the appropriate condition based on pointer nulity or
     // other appropriate criteria.
@@ -2731,11 +2767,12 @@ str_tilde: ~
     tree["str_null"] << null_if_nullptr(strnull);
     tree["str_tilde"] << null_if_nullptr(tilde);
     // this is the resulting yaml:
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(empty_null: null
-empty_nonnull: ''
-str_null: null
-str_tilde: ~
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "empty_null: null"    "\n"
+          "empty_nonnull: ''"   "\n"
+          "str_null: null"      "\n"
+          "str_tilde: ~"        "\n"
+          "");
     //
     // As another example, nulity check based on the YAML nulity
     // predicate:
@@ -2747,11 +2784,12 @@ str_tilde: ~
     tree["str_null"] << null_if_predicate(strnull);
     tree["str_tilde"] << null_if_predicate(tilde);
     // this is the resulting yaml:
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(empty_null: null
-empty_nonnull: ''
-str_null: null
-str_tilde: null
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "empty_null: null"    "\n"
+          "empty_nonnull: ''"   "\n"
+          "str_null: null"      "\n"
+          "str_tilde: null"     "\n"
+          "");
     //
     // As another example, nulity check based on the YAML nulity
     // predicate, but returning "~" to simbolize nulity:
@@ -2763,11 +2801,12 @@ str_tilde: null
     tree["str_null"] << tilde_if_predicate(strnull);
     tree["str_tilde"] << tilde_if_predicate(tilde);
     // this is the resulting yaml:
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(empty_null: ~
-empty_nonnull: ''
-str_null: ~
-str_tilde: ~
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "empty_null: ~"         "\n"
+          "empty_nonnull: ''"     "\n"
+          "str_null: ~"           "\n"
+          "str_tilde: ~"          "\n"
+          "");
 }
 
 
@@ -3157,7 +3196,7 @@ void sample_formatting()
         CHECK("0x1.2d53ap+20" == cat_sub(buf, fmt::real(1234234.234234234, 5, FTOA_HEXA)));   // AKA %a
 
         // --------------------------------------------------------------
-        // fmt::raw(): dump data in machine format (respecting alignment)
+        // fmt::raw(): dump data in raw (binary) machine format (respecting alignment)
         // --------------------------------------------------------------
         {
             C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wcast-align")  // we're casting the values directly, so alignment is strictly respected.
@@ -3183,14 +3222,11 @@ void sample_formatting()
                 CHECK(0 == memcmp(expected.str, actual.str, expected.len));
                 //
                 // read back:
-                uint32_t result;
-                auto reader = fmt::raw(result); // keeps a reference to result
-                CHECK(&result == (uint32_t*)reader.buf);
-                CHECK(reader.len == sizeof(uint32_t));
-                uncat(actual, reader);
+                uint32_t result = 0;
+                auto reader = fmt::raw(result);
+                CHECK(uncat(actual, reader));
                 // and compare:
                 // (vs2017/release/32bit does not reload result from cache, so force it)
-                result = *(uint32_t*)reader.buf;
                 CHECK(result == value); // roundtrip completed successfully
             }
             C4_SUPPRESS_WARNING_GCC_CLANG_POP
@@ -3206,16 +3242,14 @@ void sample_formatting()
 //-----------------------------------------------------------------------------
 
 /** demonstrates how to read and write base64-encoded blobs.
- @see @ref doc_base64
- */
+ * @see @ref doc_base64 */
 void sample_base64()
 {
     ryml::Tree tree;
     tree.rootref() |= ryml::MAP;
     struct text_and_base64 { ryml::csubstr text, base64; };
     text_and_base64 cases[] = {
-        {{"Love all, trust a few, do wrong to none."}, {"TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg=="}},
-        {{"The fool doth think he is wise, but the wise man knows himself to be a fool."}, {"VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg=="}},
+        {{"Hello, World!"}, {"SGVsbG8sIFdvcmxkIQ=="}},
         {{"Brevity is the soul of wit."}, {"QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu"}},
         {{"All that glitters is not gold."}, {"QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu"}},
     };
@@ -3231,15 +3265,14 @@ void sample_base64()
         tree.rootref().append_child() << ryml::key(ryml::fmt::base64(c.text)) << c.text;
         CHECK(tree[c.base64].val() == c.text);
     }
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(Love all, trust a few, do wrong to none.: TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==
-The fool doth think he is wise, but the wise man knows himself to be a fool.: VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==
-Brevity is the soul of wit.: QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu
-All that glitters is not gold.: QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu
-TG92ZSBhbGwsIHRydXN0IGEgZmV3LCBkbyB3cm9uZyB0byBub25lLg==: Love all, trust a few, do wrong to none.
-VGhlIGZvb2wgZG90aCB0aGluayBoZSBpcyB3aXNlLCBidXQgdGhlIHdpc2UgbWFuIGtub3dzIGhpbXNlbGYgdG8gYmUgYSBmb29sLg==: The fool doth think he is wise, but the wise man knows himself to be a fool.
-QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu: Brevity is the soul of wit.
-QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu: All that glitters is not gold.
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "Hello, World!: SGVsbG8sIFdvcmxkIQ=="                                         "\n"
+          "Brevity is the soul of wit.: QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu"           "\n"
+          "All that glitters is not gold.: QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu"    "\n"
+          "SGVsbG8sIFdvcmxkIQ==: Hello, World!"                                         "\n"
+          "QnJldml0eSBpcyB0aGUgc291bCBvZiB3aXQu: Brevity is the soul of wit."           "\n"
+          "QWxsIHRoYXQgZ2xpdHRlcnMgaXMgbm90IGdvbGQu: All that glitters is not gold."    "\n"
+          "");
     char buf1_[128], buf2_[128];
     ryml::substr buf1 = buf1_;  // this is where we will write the result (using >>)
     ryml::substr buf2 = buf2_;  // this is where we will write the result (using deserialize_val()/deserialize_key())
@@ -3620,10 +3653,11 @@ void sample_user_scalar_types()
     CHECK(v4in.y == v4out.y);
     CHECK(v4in.z == v4out.z);
     CHECK(v4in.w == v4out.w);
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (10,11)
-v3: (100,101,102)
-v4: (1000,1001,1002,1003)
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+          "v2: (10,11)"                 "\n"
+          "v3: (100,101,102)"           "\n"
+          "v4: (1000,1001,1002,1003)"   "\n"
+          "");
 
     // note that only the used functions are needed:
     //   - if a type is only parsed, then only from_chars() is needed
@@ -3648,10 +3682,11 @@ v4: (1000,1001,1002,1003)
     CHECK(eov4in.x == pov4out.x);
     CHECK(eov4in.y == pov4out.y);
     CHECK(eov4in.z == pov4out.z);
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (20,21)
-v3: (30,31,32)
-v4: (40,41,42,43)
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+          "v2: (20,21)"        "\n"
+          "v3: (30,31,32)"     "\n"
+          "v4: (40,41,42,43)"  "\n"
+          "");
 }
 
 
@@ -3824,22 +3859,23 @@ void sample_user_container_types()
         CHECK(mt_out.map.map_member.find(kv.first) != mt_out.map.map_member.end());
         CHECK(mt_out.map.map_member[kv.first] == kv.second);
     }
-    CHECK(ryml::emitrs_yaml<std::string>(t) == R"(v2: (20,21)
-v3: (30,31,32)
-v4: (40,41,42,43)
-seq:
-  - 101
-  - 102
-  - 103
-  - 104
-  - 105
-  - 106
-  - 107
-map:
-  1001: 2001
-  1002: 2002
-  1003: 2003
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+          "v2: (20,21)"         "\n"
+          "v3: (30,31,32)"      "\n"
+          "v4: (40,41,42,43)"   "\n"
+          "seq:"                "\n"
+          "  - 101"             "\n"
+          "  - 102"             "\n"
+          "  - 103"             "\n"
+          "  - 104"             "\n"
+          "  - 105"             "\n"
+          "  - 106"             "\n"
+          "  - 107"             "\n"
+          "map:"                "\n"
+          "  1001: 2001"        "\n"
+          "  1002: 2002"        "\n"
+          "  1003: 2003"        "\n"
+          "");
 }
 
 
@@ -3847,56 +3883,57 @@ map:
 
 /** demonstrates usage with the std implementations provided by ryml
     in the ryml_std.hpp header
-  @see @ref doc_sample_container_types
-  @see also the STL section in @ref doc_serialization */
+    @see @ref doc_sample_container_types
+    @see also the STL section in @ref doc_serialization */
 void sample_std_types()
 {
-    std::string yml_std_string = R"(- v2: (20,21)
-  v3: (30,31,32)
-  v4: (40,41,42,43)
-  seq:
-    - 101
-    - 102
-    - 103
-    - 104
-    - 105
-    - 106
-    - 107
-  map:
-    1001: 2001
-    1002: 2002
-    1003: 2003
-- v2: (120,121)
-  v3: (130,131,132)
-  v4: (140,141,142,143)
-  seq:
-    - 1101
-    - 1102
-    - 1103
-    - 1104
-    - 1105
-    - 1106
-    - 1107
-  map:
-    11001: 12001
-    11002: 12002
-    11003: 12003
-- v2: (220,221)
-  v3: (230,231,232)
-  v4: (240,241,242,243)
-  seq:
-    - 2101
-    - 2102
-    - 2103
-    - 2104
-    - 2105
-    - 2106
-    - 2107
-  map:
-    21001: 22001
-    21002: 22002
-    21003: 22003
-)";
+    std::string yml_std_string = ""
+        "- v2: (20,21)"              "\n"
+        "  v3: (30,31,32)"           "\n"
+        "  v4: (40,41,42,43)"        "\n"
+        "  seq:"                     "\n"
+        "    - 101"                  "\n"
+        "    - 102"                  "\n"
+        "    - 103"                  "\n"
+        "    - 104"                  "\n"
+        "    - 105"                  "\n"
+        "    - 106"                  "\n"
+        "    - 107"                  "\n"
+        "  map:"                     "\n"
+        "    1001: 2001"             "\n"
+        "    1002: 2002"             "\n"
+        "    1003: 2003"             "\n"
+        "- v2: (120,121)"            "\n"
+        "  v3: (130,131,132)"        "\n"
+        "  v4: (140,141,142,143)"    "\n"
+        "  seq:"                     "\n"
+        "    - 1101"                 "\n"
+        "    - 1102"                 "\n"
+        "    - 1103"                 "\n"
+        "    - 1104"                 "\n"
+        "    - 1105"                 "\n"
+        "    - 1106"                 "\n"
+        "    - 1107"                 "\n"
+        "  map:"                     "\n"
+        "    11001: 12001"           "\n"
+        "    11002: 12002"           "\n"
+        "    11003: 12003"           "\n"
+        "- v2: (220,221)"            "\n"
+        "  v3: (230,231,232)"        "\n"
+        "  v4: (240,241,242,243)"    "\n"
+        "  seq:"                     "\n"
+        "    - 2101"                 "\n"
+        "    - 2102"                 "\n"
+        "    - 2103"                 "\n"
+        "    - 2104"                 "\n"
+        "    - 2105"                 "\n"
+        "    - 2106"                 "\n"
+        "    - 2107"                 "\n"
+        "  map:"                     "\n"
+        "    21001: 22001"           "\n"
+        "    21002: 22002"           "\n"
+        "    21003: 22003"           "\n"
+        "";
     // parse in-place using the std::string above
     ryml::Tree tree = ryml::parse_in_place(ryml::to_substr(yml_std_string));
     // my_type is a container-of-containers type. see above its
@@ -3922,12 +3959,12 @@ void sample_float_precision()
     const double precision_safe = 1.e-14;
     const size_t num_digits_safe = 14;
     const size_t num_digits_original = 17;
-    auto get_num_digits = [](ryml::csubstr number){ return number.sub(2).len; };
+    auto get_num_digits = [](ryml::csubstr number){ return number.len - 2u; };
     //
     // no significant precision is lost when reading
     // floating point numbers:
     {
-        ryml::Tree tree = ryml::parse_in_arena(R"([1.23234412342131234, 2.12323123143434237, 3.67847983572591234])");
+        ryml::Tree tree = ryml::parse_in_arena("[1.23234412342131234, 2.12323123143434237, 3.67847983572591234]");
         std::vector<double> output;
         tree.rootref() >> output;
         CHECK(output.size() == reference.size());
@@ -3946,17 +3983,20 @@ void sample_float_precision()
         serialized.rootref() << reference;
         std::cout << serialized;
         // Without std::to_chars() there is a loss of precision:
-        #if (!C4CORE_HAVE_STD_TOCHARS) // This macro is defined when std::to_chars() is available.
-        CHECK(ryml::emitrs_yaml<std::string>(serialized) == R"(- 1.23234
-- 2.12323
-- 3.67848
-)" || (bool)"this is indicative; the exact results will vary from platform to platform.");
+        #if (!C4CORE_HAVE_STD_TOCHARS) // check if std::to_chars() is available.
+        CHECK((ryml::emitrs_yaml<std::string>(serialized) == ""
+              "- 1.23234"   "\n"
+              "- 2.12323"   "\n"
+              "- 3.67848"   "\n"
+              "") || (bool)"this is indicative; the exact results will vary from platform to platform.");
         C4_UNUSED(num_digits_safe);
-        #else  // ... but when using C++17 and above, the results are eminently equal:
-        CHECK((ryml::emitrs_yaml<std::string>(serialized) == R"(- 1.2323441234213124
-- 2.1232312314343424
-- 3.6784798357259123
-)") || (bool)"this is indicative; the exact results will vary from platform to platform.");
+        // ... but when using C++17 and above, the results are eminently equal:
+        #else
+        CHECK((ryml::emitrs_yaml<std::string>(serialized) == ""
+               "- 1.2323441234213124"   "\n"
+               "- 2.1232312314343424"   "\n"
+               "- 3.6784798357259123"   "\n"
+               "") || (bool)"this is indicative; the exact results will vary from platform to platform.");
         size_t pos = 0;
         for(ryml::ConstNodeRef child : serialized.rootref().children())
         {
@@ -3997,10 +4037,11 @@ void sample_float_precision()
     auto check_precision = [&](ryml::Tree const& serialized){
         std::cout << serialized;
         // now it works!
-        CHECK((ryml::emitrs_yaml<std::string>(serialized) == R"(- 1.23234412342131239
-- 2.12323123143434245
-- 3.67847983572591231
-)") || (bool)"this is indicative; the exact results will vary from platform to platform.");
+        CHECK((ryml::emitrs_yaml<std::string>(serialized) == ""
+               "- 1.23234412342131239"   "\n"
+               "- 2.12323123143434245"   "\n"
+               "- 3.67847983572591231"   "\n"
+               "") || (bool)"this is indicative; the exact results will vary from platform to platform.");
         size_t pos = 0;
         for(ryml::ConstNodeRef child : serialized.rootref().children())
         {
@@ -4048,30 +4089,35 @@ void sample_float_precision()
 /** demonstrates how to emit to a linear container of char */
 void sample_emit_to_container()
 {
-    // it is possible to emit to any linear container of char.
 
-    ryml::csubstr ymla = "- 1\n- 2\n";
-    ryml::csubstr ymlb = R"(- a
-- b
-- x0: 1
-  x1: 2
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-- foo
-- bar
-- baz
-- bat
-)";
+    ryml::csubstr ymla =
+        "- 1\n"
+        "- 2\n"
+        "";
+    ryml::csubstr ymlb =
+        "- a"                           "\n"
+        "- b"                           "\n"
+        "- x0: 1"                       "\n"
+        "  x1: 2"                       "\n"
+        "- champagne: Dom Perignon"     "\n"
+        "  coffee: Arabica"             "\n"
+        "  more:"                       "\n"
+        "    vinho verde: Soalheiro"    "\n"
+        "    vinho tinto: Redoma 2017"  "\n"
+        "  beer:"                       "\n"
+        "    - Rochefort 10"            "\n"
+        "    - Busch"                   "\n"
+        "    - Leffe Rituel"            "\n"
+        "- foo"                         "\n"
+        "- bar"                         "\n"
+        "- baz"                         "\n"
+        "- bat"                         "\n"
+        "";
     const ryml::Tree treea = ryml::parse_in_arena(ymla);
     const ryml::Tree treeb = ryml::parse_in_arena(ymlb);
 
+    // it is possible to emit to any linear container of char.
+    //
     // eg, std::vector<char>
     {
         // do a blank call on an empty buffer to find the required size.
@@ -4110,10 +4156,11 @@ void sample_emit_to_container()
 
         // you can also emit nested nodes:
         another = ryml::emitrs_yaml<std::vector<char>>(treeb[3][2]);
-        CHECK(ryml::to_csubstr(another) == R"(more:
-  vinho verde: Soalheiro
-  vinho tinto: Redoma 2017
-)");
+        CHECK(ryml::to_csubstr(another) == ""
+              "more:"                           "\n"
+              "  vinho verde: Soalheiro"        "\n"
+              "  vinho tinto: Redoma 2017"      "\n"
+              "");
     }
 
 
@@ -4156,10 +4203,11 @@ void sample_emit_to_container()
 
         // you can also emit nested nodes:
         another = ryml::emitrs_yaml<std::string>(treeb[3][2]);
-        CHECK(ryml::to_csubstr(another) == R"(more:
-  vinho verde: Soalheiro
-  vinho tinto: Redoma 2017
-)");
+        CHECK(ryml::to_csubstr(another) == ""
+              "more:"                           "\n"
+              "  vinho verde: Soalheiro"        "\n"
+              "  vinho tinto: Redoma 2017"      "\n"
+              "");
     }
 }
 
@@ -4169,24 +4217,25 @@ void sample_emit_to_container()
 /** demonstrates how to emit to a stream-like structure */
 void sample_emit_to_stream()
 {
-    ryml::csubstr ymlb = R"(- a
-- b
-- x0: 1
-  x1: 2
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-- foo
-- bar
-- baz
-- bat
-)";
+    ryml::csubstr ymlb =
+        "- a"                           "\n"
+        "- b"                           "\n"
+        "- x0: 1"                       "\n"
+        "  x1: 2"                       "\n"
+        "- champagne: Dom Perignon"     "\n"
+        "  coffee: Arabica"             "\n"
+        "  more:"                       "\n"
+        "    vinho verde: Soalheiro"    "\n"
+        "    vinho tinto: Redoma 2017"  "\n"
+        "  beer:"                       "\n"
+        "    - Rochefort 10"            "\n"
+        "    - Busch"                   "\n"
+        "    - Leffe Rituel"            "\n"
+        "- foo"                         "\n"
+        "- bar"                         "\n"
+        "- baz"                         "\n"
+        "- bat"                         "\n"
+        "";
     const ryml::Tree tree = ryml::parse_in_arena(ymlb);
 
     std::string s;
@@ -4204,32 +4253,33 @@ void sample_emit_to_stream()
         std::stringstream ss;
         ss << ryml::as_json(tree); // works with any stream having .operator<<() and .write()
         s = ss.str();
-        CHECK(ryml::to_csubstr(s) == R"([
-  "a",
-  "b",
-  {
-    "x0": 1,
-    "x1": 2
-  },
-  {
-    "champagne": "Dom Perignon",
-    "coffee": "Arabica",
-    "more": {
-      "vinho verde": "Soalheiro",
-      "vinho tinto": "Redoma 2017"
-    },
-    "beer": [
-      "Rochefort 10",
-      "Busch",
-      "Leffe Rituel"
-    ]
-  },
-  "foo",
-  "bar",
-  "baz",
-  "bat"
-]
-)");
+        CHECK(ryml::to_csubstr(s) ==
+              "["                                        "\n"
+              "  \"a\","                                 "\n"
+              "  \"b\","                                 "\n"
+              "  {"                                      "\n"
+              "    \"x0\": 1,"                           "\n"
+              "    \"x1\": 2"                            "\n"
+              "  },"                                     "\n"
+              "  {"                                      "\n"
+              "    \"champagne\": \"Dom Perignon\","     "\n"
+              "    \"coffee\": \"Arabica\","             "\n"
+              "    \"more\": {"                          "\n"
+              "      \"vinho verde\": \"Soalheiro\","    "\n"
+              "      \"vinho tinto\": \"Redoma 2017\""   "\n"
+              "    },"                                   "\n"
+              "    \"beer\": ["                          "\n"
+              "      \"Rochefort 10\","                  "\n"
+              "      \"Busch\","                         "\n"
+              "      \"Leffe Rituel\""                   "\n"
+              "    ]"                                    "\n"
+              "  },"                                     "\n"
+              "  \"foo\","                               "\n"
+              "  \"bar\","                               "\n"
+              "  \"baz\","                               "\n"
+              "  \"bat\""                                "\n"
+              "]"                                        "\n"
+              "");
     }
 
     // emit a nested node
@@ -4237,10 +4287,11 @@ void sample_emit_to_stream()
         std::stringstream ss;
         ss << tree[3][2]; // works with any stream having .operator<<() and .write()
         s = ss.str();
-        CHECK(ryml::to_csubstr(s) == R"(more:
-  vinho verde: Soalheiro
-  vinho tinto: Redoma 2017
-)");
+        CHECK(ryml::to_csubstr(s) == ""
+              "more:"                             "\n"
+              "  vinho verde: Soalheiro"          "\n"
+              "  vinho tinto: Redoma 2017"        "\n"
+              "");
     }
 
     // emit a nested node as json
@@ -4248,11 +4299,12 @@ void sample_emit_to_stream()
         std::stringstream ss;
         ss << ryml::as_json(tree[3][2]); // works with any stream having .operator<<() and .write()
         s = ss.str();
-        CHECK(ryml::to_csubstr(s) == R"("more": {
-  "vinho verde": "Soalheiro",
-  "vinho tinto": "Redoma 2017"
-}
-)");
+        CHECK(ryml::to_csubstr(s) ==
+              "\"more\": {"                           "\n"
+              "  \"vinho verde\": \"Soalheiro\","     "\n"
+              "  \"vinho tinto\": \"Redoma 2017\""    "\n"
+              "}"                                     "\n"
+              "");
     }
 }
 
@@ -4262,24 +4314,25 @@ void sample_emit_to_stream()
 /** demonstrates how to emit to a FILE* */
 void sample_emit_to_file()
 {
-    ryml::csubstr yml = R"(- a
-- b
-- x0: 1
-  x1: 2
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-- foo
-- bar
-- baz
-- bat
-)";
+    ryml::csubstr yml = ""
+        "- a"                           "\n"
+        "- b"                           "\n"
+        "- x0: 1"                       "\n"
+        "  x1: 2"                       "\n"
+        "- champagne: Dom Perignon"     "\n"
+        "  coffee: Arabica"             "\n"
+        "  more:"                       "\n"
+        "    vinho verde: Soalheiro"    "\n"
+        "    vinho tinto: Redoma 2017"  "\n"
+        "  beer:"                       "\n"
+        "    - Rochefort 10"            "\n"
+        "    - Busch"                   "\n"
+        "    - Leffe Rituel"            "\n"
+        "- foo"                         "\n"
+        "- bar"                         "\n"
+        "- baz"                         "\n"
+        "- bat"                         "\n"
+        "";
     const ryml::Tree tree = ryml::parse_in_arena(yml);
     // this is emitting to stdout, but of course you can pass in any
     // FILE* obtained from fopen()
@@ -4295,40 +4348,43 @@ void sample_emit_to_file()
 /** just like parsing into a nested node, you can also emit from a nested node. */
 void sample_emit_nested_node()
 {
-    const ryml::Tree tree = ryml::parse_in_arena(R"(- a
-- b
-- x0: 1
-  x1: 2
-- champagne: Dom Perignon
-  coffee: Arabica
-  more:
-    vinho verde: Soalheiro
-    vinho tinto: Redoma 2017
-  beer:
-    - Rochefort 10
-    - Busch
-    - Leffe Rituel
-    - - and so
-      - many other
-      - wonderful beers
-- more
-- seq
-- members
-- here
-)");
-    CHECK(ryml::emitrs_yaml<std::string>(tree[3]["beer"]) == R"(beer:
-  - Rochefort 10
-  - Busch
-  - Leffe Rituel
-  - - and so
-    - many other
-    - wonderful beers
-)");
+    const ryml::Tree tree = ryml::parse_in_arena(""
+        "- a"                            "\n"
+        "- b"                            "\n"
+        "- x0: 1"                        "\n"
+        "  x1: 2"                        "\n"
+        "- champagne: Dom Perignon"      "\n"
+        "  coffee: Arabica"              "\n"
+        "  more:"                        "\n"
+        "    vinho verde: Soalheiro"     "\n"
+        "    vinho tinto: Redoma 2017"   "\n"
+        "  beer:"                        "\n"
+        "    - Rochefort 10"             "\n"
+        "    - Busch"                    "\n"
+        "    - Leffe Rituel"             "\n"
+        "    - - and so"                 "\n"
+        "      - many other"             "\n"
+        "      - wonderful beers"        "\n"
+        "- more"                         "\n"
+        "- seq"                          "\n"
+        "- members"                      "\n"
+        "- here"                         "\n"
+        "");
+    CHECK(ryml::emitrs_yaml<std::string>(tree[3]["beer"]) == ""
+          "beer:"                    "\n"
+          "  - Rochefort 10"         "\n"
+          "  - Busch"                "\n"
+          "  - Leffe Rituel"         "\n"
+          "  - - and so"             "\n"
+          "    - many other"         "\n"
+          "    - wonderful beers"    "\n"
+          "");
     CHECK(ryml::emitrs_yaml<std::string>(tree[3]["beer"][0]) == "Rochefort 10");
-    CHECK(ryml::emitrs_yaml<std::string>(tree[3]["beer"][3]) == R"(- and so
-- many other
-- wonderful beers
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree[3]["beer"][3]) == ""
+          "- and so"                 "\n"
+          "- many other"             "\n"
+          "- wonderful beers"        "\n"
+          "");
 }
 
 
@@ -4341,22 +4397,23 @@ void sample_style()
     // we will be using this helper throughout this function
     auto tostr = [](ryml::ConstNodeRef n) { return ryml::emitrs_yaml<std::string>(n); };
     // let's parse this yaml:
-    ryml::csubstr yaml = R"(block map:
-  block key: block val
-block seq:
-  - block val 1
-  - block val 2
-  - 'quoted'
-flow map, singleline: {flow key: flow val}
-flow seq, singleline: [flow val,flow val]
-flow map, multiline: {
-    flow key: flow val
-  }
-flow seq, multiline: [
-    flow val,
-    flow val
-  ]
-)";
+    ryml::csubstr yaml = ""
+        "block map:"                                   "\n"
+        "  block key: block val"                       "\n"
+        "block seq:"                                   "\n"
+        "  - block val 1"                              "\n"
+        "  - block val 2"                              "\n"
+        "  - 'quoted'"                                 "\n"
+        "flow map, singleline: {flow key: flow val}"   "\n"
+        "flow seq, singleline: [flow val,flow val]"    "\n"
+        "flow map, multiline: {"                       "\n"
+        "    flow key: flow val"                       "\n"
+        "  }"                                          "\n"
+        "flow seq, multiline: ["                       "\n"
+        "    flow val,"                                "\n"
+        "    flow val"                                 "\n"
+        "  ]"                                          "\n"
+        "";
     ryml::Tree tree = ryml::parse_in_arena(yaml);
     // while parsing, ryml marks parsed nodes with their original style:
     CHECK(tree.rootref().is_block());
@@ -4392,21 +4449,36 @@ flow seq, multiline: [
     {
         ryml::NodeRef n = tree["block map"]; // Let's look at one node
         // It looks like this originally:
-        CHECK(tostr(n) == "block map:\n  block key: block val\n");
+        CHECK(tostr(n) ==
+              "block map:\n"
+              "  block key: block val\n"
+              "");
         // let's modify its style:
         n.set_key_style(ryml::KEY_SQUO);      // scalar style: to single-quoted scalar
         n.set_container_style(ryml::FLOW_SL); // container style: to flow singleline
         // now it looks like this:
-        CHECK(tostr(n) == "'block map': {block key: block val}\n");
+        CHECK(tostr(n) ==
+              "'block map': {block key: block val}\n"
+              "");
     }
     // next example
     {
         ryml::NodeRef n = tree["block seq"];
-        CHECK(tostr(n) == "block seq:\n  - block val 1\n  - block val 2\n  - 'quoted'\n");
+        CHECK(tostr(n) == ""
+              "block seq:\n"
+              "  - block val 1\n"
+              "  - block val 2\n"
+              "  - 'quoted'\n"
+              "");
         n.set_key_style(ryml::KEY_DQUO);       // scalar style: to double-quoted scalar
         n.set_container_style(ryml::FLOW_ML);  // container style: to flow multiline
         n[2].set_val_style(ryml::VAL_PLAIN);   // scalar style: to plain
-        CHECK(tostr(n) == "\"block seq\": [\n    block val 1,\n    block val 2,\n    quoted\n  ]\n");
+        CHECK(tostr(n) == ""
+              "\"block seq\": [\n"
+              "    block val 1,\n"
+              "    block val 2,\n"
+              "    quoted\n"
+              "  ]\n");
     }
     // next example
     {
@@ -4414,14 +4486,25 @@ flow seq, multiline: [
         CHECK(tostr(n) == "flow map, singleline: {flow key: flow val}\n");
         n.set_container_style(ryml::BLOCK);
         n["flow key"].set_val_style(ryml::VAL_LITERAL);
-        CHECK(tostr(n) == "flow map, singleline:\n  flow key: |-\n    flow val\n");
+        CHECK(tostr(n) == ""
+              "flow map, singleline:\n"
+              "  flow key: |-\n"
+              "    flow val\n"
+              "");
     }
     // next example
     {
         ryml::NodeRef n = tree["flow map, multiline"];
-        CHECK(tostr(n) == "flow map, multiline: {\n    flow key: flow val\n  }\n");
+        CHECK(tostr(n) == ""
+              "flow map, multiline: {\n"
+              "    flow key: flow val\n"
+              "  }\n"
+              "");
         n.set_container_style(ryml::BLOCK);
-        CHECK(tostr(n) == "flow map, multiline:\n  flow key: flow val\n");
+        CHECK(tostr(n) == ""
+              "flow map, multiline:\n"
+              "  flow key: flow val\n"
+              "");
     }
     // next example
     {
@@ -4431,58 +4514,69 @@ flow seq, multiline: [
         n.set_container_style(ryml::BLOCK);
         n[0].set_val_style(ryml::VAL_SQUO);
         n[1].set_val_style(ryml::VAL_DQUO);
-        CHECK(tostr(n) == "? >-\n  flow seq, singleline\n:\n  - 'flow val'\n  - \"flow val\"\n");
+        CHECK(tostr(n) == ""
+              "? >-\n"
+              "  flow seq, singleline\n"
+              ":\n"
+              "  - 'flow val'\n"
+              "  - \"flow val\"\n"
+              "");
     }
     // next example
     {
         ryml::NodeRef n = tree["flow seq, multiline"];
-        CHECK(tostr(n) == "flow seq, multiline: [\n    flow val,\n    flow val\n  ]\n");
+        CHECK(tostr(n) == ""
+              "flow seq, multiline: [\n"
+              "    flow val,\n"
+              "    flow val\n"
+              "  ]\n"
+              "");
         n.set_container_style(ryml::FLOW_SL);
         CHECK(tostr(n) == "flow seq, multiline: [flow val,flow val]\n");
     }
     // note the full tree now:
     CHECK(tostr(tree) != yaml);
     CHECK(tostr(tree) ==
-          R"('block map': {block key: block val}
-"block seq": [
-    block val 1,
-    block val 2,
-    quoted
-  ]
-flow map, singleline:
-  flow key: |-
-    flow val
-? >-
-  flow seq, singleline
-:
-  - 'flow val'
-  - "flow val"
-flow map, multiline:
-  flow key: flow val
-flow seq, multiline: [flow val,flow val]
-)");
+          "'block map': {block key: block val}"         "\n"
+          "\"block seq\": ["                            "\n"
+          "    block val 1,"                            "\n"
+          "    block val 2,"                            "\n"
+          "    quoted"                                  "\n"
+          "  ]"                                         "\n"
+          "flow map, singleline:"                       "\n"
+          "  flow key: |-"                              "\n"
+          "    flow val"                                "\n"
+          "? >-"                                        "\n"
+          "  flow seq, singleline"                      "\n"
+          ":"                                           "\n"
+          "  - 'flow val'"                              "\n"
+          "  - \"flow val\""                            "\n"
+          "flow map, multiline:"                        "\n"
+          "  flow key: flow val"                        "\n"
+          "flow seq, multiline: [flow val,flow val]"    "\n"
+          "");
     // you can clear the style of single nodes:
     tree["block map"].clear_style();
     tree["block seq"].clear_style();
     CHECK(tostr(tree) ==
-          R"(block map:
-  block key: block val
-block seq:
-  - block val 1
-  - block val 2
-  - quoted
-flow map, singleline:
-  flow key: |-
-    flow val
-? >-
-  flow seq, singleline
-:
-  - 'flow val'
-  - "flow val"
-flow map, multiline:
-  flow key: flow val
-flow seq, multiline: [flow val,flow val]
-)");
+          "block map:"                                    "\n"
+          "  block key: block val"                        "\n"
+          "block seq:"                                    "\n"
+          "  - block val 1"                               "\n"
+          "  - block val 2"                               "\n"
+          "  - quoted"                                    "\n"
+          "flow map, singleline:"                         "\n"
+          "  flow key: |-"                                "\n"
+          "    flow val"                                  "\n"
+          "? >-"                                          "\n"
+          "  flow seq, singleline"                        "\n"
+          ":"                                             "\n"
+          "  - 'flow val'"                                "\n"
+          "  - \"flow val\""                              "\n"
+          "flow map, multiline:"                          "\n"
+          "  flow key: flow val"                          "\n"
+          "flow seq, multiline: [flow val,flow val]"      "\n"
+          "");
     // you can clear the style recursively:
     tree.rootref().clear_style(/*recurse*/true);
     // when emitting nodes which have no style set, ryml will default
@@ -4491,23 +4585,23 @@ flow seq, multiline: [flow val,flow val]
     // (at the cost of a scan over each scalar). Note that ryml picks
     // single-quoted for scalars containing commas:
     CHECK(tostr(tree) ==
-          R"(block map:
-  block key: block val
-block seq:
-  - block val 1
-  - block val 2
-  - quoted
-flow map, singleline:
-  flow key: flow val
-flow seq, singleline:
-  - flow val
-  - flow val
-flow map, multiline:
-  flow key: flow val
-flow seq, multiline:
-  - flow val
-  - flow val
-)");
+          "block map:"              "\n"
+          "  block key: block val"  "\n"
+          "block seq:"              "\n"
+          "  - block val 1"         "\n"
+          "  - block val 2"         "\n"
+          "  - quoted"              "\n"
+          "flow map, singleline:"   "\n"
+          "  flow key: flow val"    "\n"
+          "flow seq, singleline:"   "\n"
+          "  - flow val"            "\n"
+          "  - flow val"            "\n"
+          "flow map, multiline:"    "\n"
+          "  flow key: flow val"    "\n"
+          "flow seq, multiline:"    "\n"
+          "  - flow val"            "\n"
+          "  - flow val"            "\n"
+          "");
     // you can set the style based on type conditions:
     //
     // eg, set a single key to single-quoted
@@ -4516,23 +4610,23 @@ flow seq, multiline:
                                               /*addflags*/ryml::KEY_SQUO,
                                               /*recurse*/false);
     CHECK(tostr(tree) ==
-          R"('block map':
-  block key: block val
-block seq:
-  - block val 1
-  - block val 2
-  - quoted
-flow map, singleline:
-  flow key: flow val
-flow seq, singleline:
-  - flow val
-  - flow val
-flow map, multiline:
-  flow key: flow val
-flow seq, multiline:
-  - flow val
-  - flow val
-)");
+          "'block map':"             "\n"
+          "  block key: block val"   "\n"
+          "block seq:"               "\n"
+          "  - block val 1"          "\n"
+          "  - block val 2"          "\n"
+          "  - quoted"               "\n"
+          "flow map, singleline:"    "\n"
+          "  flow key: flow val"     "\n"
+          "flow seq, singleline:"    "\n"
+          "  - flow val"             "\n"
+          "  - flow val"             "\n"
+          "flow map, multiline:"     "\n"
+          "  flow key: flow val"     "\n"
+          "flow seq, multiline:"     "\n"
+          "  - flow val"             "\n"
+          "  - flow val"             "\n"
+          "");
     // change all keys to single-quoted:
     tree.rootref().set_style_conditionally(/*type_mask*/ryml::KEY,
                                            /*remflags*/ryml::KEY_STYLE,
@@ -4554,35 +4648,35 @@ flow seq, multiline:
                                            /*addflags*/ryml::BLOCK,
                                            /*recurse*/true);
     // done!
-    CHECK(tostr(tree) ==
-          R"('block map':
-  'block key': "block val"
-'block seq': ["block val 1","block val 2","quoted"]
-'flow map, singleline':
-  'flow key': "flow val"
-'flow seq, singleline': ["flow val","flow val"]
-'flow map, multiline':
-  'flow key': "flow val"
-'flow seq, multiline': ["flow val","flow val"]
-)");
+    CHECK(tostr(tree) == ""
+          "'block map':"                                               "\n"
+          "  'block key': \"block val\""                               "\n"
+          "'block seq': [\"block val 1\",\"block val 2\",\"quoted\"]"  "\n"
+          "'flow map, singleline':"                                    "\n"
+          "  'flow key': \"flow val\""                                 "\n"
+          "'flow seq, singleline': [\"flow val\",\"flow val\"]"        "\n"
+          "'flow map, multiline':"                                     "\n"
+          "  'flow key': \"flow val\""                                 "\n"
+          "'flow seq, multiline': [\"flow val\",\"flow val\"]"         "\n"
+          "");
     // you can also set a conditional style in a single node (or its branch if recurse is true):
     tree["flow seq, singleline"].set_style_conditionally(/*type_mask*/ryml::SEQ,
                                                          /*remflags*/ryml::CONTAINER_STYLE,
                                                          /*addflags*/ryml::BLOCK,
                                                          /*recurse*/false);
-    CHECK(tostr(tree) ==
-          R"('block map':
-  'block key': "block val"
-'block seq': ["block val 1","block val 2","quoted"]
-'flow map, singleline':
-  'flow key': "flow val"
-'flow seq, singleline':
-  - "flow val"
-  - "flow val"
-'flow map, multiline':
-  'flow key': "flow val"
-'flow seq, multiline': ["flow val","flow val"]
-)");
+    CHECK(tostr(tree) == ""
+          "'block map':"                                                   "\n"
+          "  'block key': \"block val\""                                   "\n"
+          "'block seq': [\"block val 1\",\"block val 2\",\"quoted\"]"      "\n"
+          "'flow map, singleline':"                                        "\n"
+          "  'flow key': \"flow val\""                                     "\n"
+          "'flow seq, singleline':"                                        "\n"
+          "  - \"flow val\""                                               "\n"
+          "  - \"flow val\""                                               "\n"
+          "'flow map, multiline':"                                         "\n"
+          "  'flow key': \"flow val\""                                     "\n"
+          "'flow seq, multiline': [\"flow val\",\"flow val\"]"             "\n"
+        "");
     // see also:
     //  - ryml::scalar_style_choose()
     //  - ryml::scalar_style_json_choose()
@@ -4612,71 +4706,71 @@ void sample_style_flow_ml_indent()
     tree["map"]["seq"][4].set_container_style(ryml::FLOW_ML);
     // by default FLOW_ML prints one value per line, indented:
     CHECK(tostr(tree, defaults) ==
-          R"({
-  map: {
-    seq: [
-      0,
-      1,
-      2,
-      3,
-      [
-        40,
-        41
-      ]
-    ]
-  }
-}
-)");
+          "{"              "\n"
+          "  map: {"       "\n"
+          "    seq: ["     "\n"
+          "      0,"       "\n"
+          "      1,"       "\n"
+          "      2,"       "\n"
+          "      3,"       "\n"
+          "      ["        "\n"
+          "        40,"    "\n"
+          "        41"     "\n"
+          "      ]"        "\n"
+          "    ]"          "\n"
+          "  }"            "\n"
+          "}"              "\n"
+          "");
     // if we use the noindent options, then each value is put at the
     // beginning of the line
     CHECK(tostr(tree, noindent) ==
-          R"({
-map: {
-seq: [
-0,
-1,
-2,
-3,
-[
-40,
-41
-]
-]
-}
-}
-)");
+          "{"            "\n"
+          "map: {"       "\n"
+          "seq: ["       "\n"
+          "0,"           "\n"
+          "1,"           "\n"
+          "2,"           "\n"
+          "3,"           "\n"
+          "["            "\n"
+          "40,"          "\n"
+          "41"           "\n"
+          "]"            "\n"
+          "]"            "\n"
+          "}"            "\n"
+          "}"            "\n"
+          "");
     // Note that the noindent option will safely respect any prior
     // indent level from enclosing block containers! For example:
     tree.rootref().set_container_style(ryml::BLOCK);
-    CHECK(tostr(tree, noindent) == // notice it is indented at the map level
-          R"(map: {
-  seq: [
-  0,
-  1,
-  2,
-  3,
-  [
-  40,
-  41
-  ]
-  ]
-  }
-)");
+    CHECK(tostr(tree, noindent) == ""// notice it is indented at the map level
+          "map: {"       "\n"
+          "  seq: ["     "\n"
+          "  0,"         "\n"
+          "  1,"         "\n"
+          "  2,"         "\n"
+          "  3,"         "\n"
+          "  ["          "\n"
+          "  40,"        "\n"
+          "  41"         "\n"
+          "  ]"          "\n"
+          "  ]"          "\n"
+          "  }"          "\n"
+          "");
     // Let's set it one BLOCK level further:
     tree["map"].set_container_style(ryml::BLOCK);
     CHECK(tostr(tree, noindent) == // notice it is indented one more level
-          R"(map:
-  seq: [
-    0,
-    1,
-    2,
-    3,
-    [
-    40,
-    41
-    ]
-    ]
-)");
+          "map:"         "\n"
+          "  seq: ["     "\n"
+          "    0,"       "\n"
+          "    1,"       "\n"
+          "    2,"       "\n"
+          "    3,"       "\n"
+          "    ["        "\n"
+          "    40,"      "\n"
+          "    41"       "\n"
+          "    ]"        "\n"
+          "    ]"        "\n"
+          "");
 }
 
 
@@ -4686,36 +4780,38 @@ seq: [
  * container being parsed is FLOW_ML */
 void sample_style_flow_ml_filter()
 {
-    ryml::csubstr yaml = R"({
-  map: {
-    seq: [
-      0,
-      1,
-      2,
-      3,
-      [
-        40,
-        41
-      ]
-    ]
-  }
-}
-)";
-    ryml::csubstr yaml_not_indented = R"({
-map: {
-seq: [
-0,
-1,
-2,
-3,
-[
-40,
-41
-]
-]
-}
-}
-)";
+    ryml::csubstr yaml = ""
+        "{"              "\n"
+        "  map: {"       "\n"
+        "    seq: ["     "\n"
+        "      0,"       "\n"
+        "      1,"       "\n"
+        "      2,"       "\n"
+        "      3,"       "\n"
+        "      ["        "\n"
+        "        40,"    "\n"
+        "        41"     "\n"
+        "      ]"        "\n"
+        "    ]"          "\n"
+        "  }"            "\n"
+        "}"              "\n"
+        "";
+    ryml::csubstr yaml_not_indented = ""
+        "{"              "\n"
+        "map: {"         "\n"
+        "seq: ["         "\n"
+        "0,"             "\n"
+        "1,"             "\n"
+        "2,"             "\n"
+        "3,"             "\n"
+        "["              "\n"
+        "40,"            "\n"
+        "41"             "\n"
+        "]"              "\n"
+        "]"              "\n"
+        "}"              "\n"
+        "}"              "\n"
+        "";
     // note that the parser defaults to detect multiline flow
     // (FLOW_ML) containers:
     {
@@ -4753,13 +4849,14 @@ seq: [
  * info on clearing the style flags (example below). */
 void sample_json()
 {
-    ryml::csubstr json = R"({
-  "doe": "a deer, a female deer",
-  "ray": "a drop of golden sun",
-  "me": "a name, I call myself",
-  "far": "a long long way to go"
-}
-)";
+    ryml::csubstr json = ""
+        "{"                                         "\n"
+        "  \"doe\": \"a deer, a female deer\","     "\n"
+        "  \"ray\": \"a drop of golden sun\","      "\n"
+        "  \"me\": \"a name, I call myself\","      "\n"
+        "  \"far\": \"a long long way to go\""      "\n"
+        "}"                                         "\n"
+        "";
     // Since JSON is a subset of YAML, parsing JSON is just the
     // same as YAML:
     ryml::Tree tree = ryml::parse_in_arena(json);
@@ -4795,24 +4892,24 @@ void sample_json()
     // If you want to avoid this, you will need to clear the style.
     json_tree.rootref().clear_style(); // clear the style of the map, but do not recurse
     // note that this is now block mode. That is because when no
-    // style is set, the YAML emit function will default to block mode.
-    CHECK(ryml::emitrs_yaml<std::string>(json_tree) ==
-          R"("doe": "a deer, a female deer"
-"ray": "a drop of golden sun"
-"me": "a name, I call myself"
-"far": "a long long way to go"
-)");
+    // style is set, ryml defaults to emitting in block mode.
+    CHECK(ryml::emitrs_yaml<std::string>(json_tree) == ""
+          "\"doe\": \"a deer, a female deer\""   "\n"
+          "\"ray\": \"a drop of golden sun\""    "\n"
+          "\"me\": \"a name, I call myself\""    "\n"
+          "\"far\": \"a long long way to go\""   "\n"
+          "");
     // if you don't want the double quotes in the scalar, you can
     // recurse:
     json_tree.rootref().clear_style(/*recurse*/true);
     // so now when emitting you will get this:
     // (the scalars with a comma are single-quote)
-    CHECK(ryml::emitrs_yaml<std::string>(json_tree) ==
-          R"(doe: a deer, a female deer
-ray: a drop of golden sun
-me: a name, I call myself
-far: a long long way to go
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(json_tree) == ""
+          "doe: a deer, a female deer"      "\n"
+          "ray: a drop of golden sun"       "\n"
+          "me: a name, I call myself"       "\n"
+          "far: a long long way to go"      "\n"
+          "");
     // you can do custom style changes based on a type mask. this
     // will change set the style of all scalar values to single-quoted
     json_tree.rootref().set_style_conditionally(ryml::VAL,
@@ -4820,11 +4917,11 @@ far: a long long way to go
                                                 /*addflags*/ryml::VAL_SQUO,
                                                 /*recurse*/true);
     CHECK(ryml::emitrs_yaml<std::string>(json_tree) ==
-          R"(doe: 'a deer, a female deer'
-ray: 'a drop of golden sun'
-me: 'a name, I call myself'
-far: 'a long long way to go'
-)");
+          "doe: 'a deer, a female deer'"    "\n"
+          "ray: 'a drop of golden sun'"     "\n"
+          "me: 'a name, I call myself'"     "\n"
+          "far: 'a long long way to go'"    "\n"
+          "");
     // see in particular sample_style() for more examples
 }
 
@@ -4853,47 +4950,49 @@ every node has an alias/anchor). This potential cost is the reason for
 requiring an explicit call to @ref c4::yml::Tree::resolve() */
 void sample_anchors_and_aliases()
 {
-    std::string unresolved = R"(base: &base
-  name: Everyone has same name
-foo: &foo
-  <<: *base
-  age: 10
-bar: &bar
-  <<: *base
-  age: 20
-bill_to: &id001
-  street: |-
-    123 Tornado Alley
-    Suite 16
-  city: East Centerville
-  state: KS
-ship_to: *id001
-&keyref key: &valref val
-*valref : *keyref
-)";
-    std::string resolved = R"(base:
-  name: Everyone has same name
-foo:
-  name: Everyone has same name
-  age: 10
-bar:
-  name: Everyone has same name
-  age: 20
-bill_to:
-  street: |-
-    123 Tornado Alley
-    Suite 16
-  city: East Centerville
-  state: KS
-ship_to:
-  street: |-
-    123 Tornado Alley
-    Suite 16
-  city: East Centerville
-  state: KS
-key: val
-val: key
-)";
+    std::string unresolved = ""
+        "base: &base"                       "\n"
+        "  name: Everyone has same name"    "\n"
+        "foo: &foo"                         "\n"
+        "  <<: *base"                       "\n"
+        "  age: 10"                         "\n"
+        "bar: &bar"                         "\n"
+        "  <<: *base"                       "\n"
+        "  age: 20"                         "\n"
+        "bill_to: &id001"                   "\n"
+        "  street: |-"                      "\n"
+        "    123 Tornado Alley"             "\n"
+        "    Suite 16"                      "\n"
+        "  city: East Centerville"          "\n"
+        "  state: KS"                       "\n"
+        "ship_to: *id001"                   "\n"
+        "&keyref key: &valref val"          "\n"
+        "*valref : *keyref"                 "\n"
+        "";
+    std::string resolved = ""
+        "base:"                             "\n"
+        "  name: Everyone has same name"    "\n"
+        "foo:"                              "\n"
+        "  name: Everyone has same name"    "\n"
+        "  age: 10"                         "\n"
+        "bar:"                              "\n"
+        "  name: Everyone has same name"    "\n"
+        "  age: 20"                         "\n"
+        "bill_to:"                          "\n"
+        "  street: |-"                      "\n"
+        "    123 Tornado Alley"             "\n"
+        "    Suite 16"                      "\n"
+        "  city: East Centerville"          "\n"
+        "  state: KS"                       "\n"
+        "ship_to:"                          "\n"
+        "  street: |-"                      "\n"
+        "    123 Tornado Alley"             "\n"
+        "    Suite 16"                      "\n"
+        "  city: East Centerville"          "\n"
+        "  state: KS"                       "\n"
+        "key: val"                          "\n"
+        "val: key"                          "\n"
+        "";
 
     ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(unresolved));
     // by default, references are not resolved when parsing:
@@ -4940,69 +5039,78 @@ void sample_anchors_and_aliases_create()
         t["kref"].set_val_ref("kanchor");
         t["vref"].set_val_ref("vanchor");
         t["nref"] = "*vanchor";  // NOTE: this is not set as a reference in the tree!
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(&kanchor kanchor: 2
-vanchor: &vanchor 3
-kref: *kanchor
-vref: *vanchor
-nref: '*vanchor'
-)"); // note that ryml emits nref with quotes to disambiguate (because no style was set)
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "&kanchor kanchor: 2"  "\n"
+              "vanchor: &vanchor 3"  "\n"
+              "kref: *kanchor"       "\n"
+              "vref: *vanchor"       "\n"
+              // note that ryml emits nref with quotes to disambiguate
+              // (because no style was set)
+              "nref: '*vanchor'"     "\n"
+              "");
         t.resolve();
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(kanchor: 2
-vanchor: 3
-kref: kanchor
-vref: 3
-nref: '*vanchor'
-)"); // note that nref was not resolved
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "kanchor: 2"           "\n"
+              "vanchor: 3"           "\n"
+              "kref: kanchor"        "\n"
+              "vref: 3"              "\n"
+              // note that nref was not resolved
+              "nref: '*vanchor'"     "\n"
+              "");
     }
 
     // part 2: simple inheritance (ie, adding `<<: *anchor` nodes)
     {
-        ryml::Tree t = ryml::parse_in_arena(R"(
-orig: &orig {foo: bar, baz: bat}
-copy: {}
-notcopy: {}
-notref: {}
-)");
+        ryml::Tree t = ryml::parse_in_arena(""
+            "orig: &orig {foo: bar, baz: bat}"  "\n"
+            "copy: {}"                          "\n"
+            "notcopy: {}"                       "\n"
+            "notref: {}"                        "\n"
+            "");
         t["copy"]["<<"].set_val_ref("orig");
         t["notcopy"]["test"].set_val_ref("orig");
         t["notcopy"]["<<"].set_val_ref("orig");
         t["notref"]["<<"] = "*orig"; // not a reference! .set_val_ref() was not called
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(orig: &orig {foo: bar,baz: bat}
-copy: {<<: *orig}
-notcopy: {test: *orig,<<: *orig}
-notref: {<<: '*orig'}
-)");
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "orig: &orig {foo: bar,baz: bat}"      "\n"
+              "copy: {<<: *orig}"                    "\n"
+              "notcopy: {test: *orig,<<: *orig}"     "\n"
+              "notref: {<<: '*orig'}"                "\n"
+              "");
         t.resolve();
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(orig: {foo: bar,baz: bat}
-copy: {foo: bar,baz: bat}
-notcopy: {test: {foo: bar,baz: bat},foo: bar,baz: bat}
-notref: {<<: '*orig'}
-)");
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "orig: {foo: bar,baz: bat}"                                "\n"
+              "copy: {foo: bar,baz: bat}"                                "\n"
+              "notcopy: {test: {foo: bar,baz: bat},foo: bar,baz: bat}"   "\n"
+              "notref: {<<: '*orig'}"                                    "\n"
+              "");
     }
 
     // part 3: multiple inheritance (ie, `<<: [*ref1,*ref2,*etc]`)
     {
-        ryml::Tree t = ryml::parse_in_arena(R"(orig1: &orig1 {foo: bar}
-orig2: &orig2 {baz: bat}
-orig3: &orig3 {and: more}
-copy: {}
-)");
+        ryml::Tree t = ryml::parse_in_arena(""
+            "orig1: &orig1 {foo: bar}"       "\n"
+            "orig2: &orig2 {baz: bat}"       "\n"
+            "orig3: &orig3 {and: more}"      "\n"
+            "copy: {}"                       "\n"
+            "");
         ryml::NodeRef seq = t["copy"]["<<"];
         seq |= ryml::SEQ;
         seq.append_child().set_val_ref("orig1");
         seq.append_child().set_val_ref("orig2");
         seq.append_child().set_val_ref("orig3");
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(orig1: &orig1 {foo: bar}
-orig2: &orig2 {baz: bat}
-orig3: &orig3 {and: more}
-copy: {<<: [*orig1,*orig2,*orig3]}
-)");
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "orig1: &orig1 {foo: bar}"                  "\n"
+              "orig2: &orig2 {baz: bat}"                  "\n"
+              "orig3: &orig3 {and: more}"                 "\n"
+              "copy: {<<: [*orig1,*orig2,*orig3]}"        "\n"
+              "");
         t.resolve();
-        CHECK(ryml::emitrs_yaml<std::string>(t) == R"(orig1: {foo: bar}
-orig2: {baz: bat}
-orig3: {and: more}
-copy: {foo: bar,baz: bat,and: more}
-)");
+        CHECK(ryml::emitrs_yaml<std::string>(t) == ""
+              "orig1: {foo: bar}"                        "\n"
+              "orig2: {baz: bat}"                        "\n"
+              "orig3: {and: more}"                       "\n"
+              "copy: {foo: bar,baz: bat,and: more}"      "\n");
     }
 }
 
@@ -5011,27 +5119,28 @@ copy: {foo: bar,baz: bat,and: more}
 
 void sample_tags()
 {
-    const std::string yaml = R"(--- !!map
-a: 0
-b: 1
---- !map
-a: b
---- !!seq
-- a
-- b
---- !!str a b
---- !!str 'a: b'
----
-!!str a: b
---- !!set
-? a
-? b
---- !!set
-a:
---- !!seq
-- !!int 0
-- !!str 1
-)";
+    const std::string yaml = ""
+        "--- !!map"           "\n"
+        "a: 0"                "\n"
+        "b: 1"                "\n"
+        "--- !map"            "\n"
+        "a: b"                "\n"
+        "--- !!seq"           "\n"
+        "- a"                 "\n"
+        "- b"                 "\n"
+        "--- !!str a b"       "\n"
+        "--- !!str 'a: b'"    "\n"
+        "---"                 "\n"
+        "!!str a: b"          "\n"
+        "--- !!set"           "\n"
+        "? a"                 "\n"
+        "? b"                 "\n"
+        "--- !!set"           "\n"
+        "a:"                  "\n"
+        "--- !!seq"           "\n"
+        "- !!int 0"           "\n"
+        "- !!str 1"           "\n"
+        "";
     const ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(yaml));
     const ryml::ConstNodeRef root = tree.rootref();
     CHECK(root.is_stream());
@@ -5100,50 +5209,52 @@ a:
     // with a key and/or val tag:
     ryml::Tree normalized_tree = tree;
     normalized_tree.normalize_tags(); // normalize all tags in short form
-    CHECK(ryml::emitrs_yaml<std::string>(normalized_tree) == R"(--- !!map
-a: 0
-b: 1
---- !map
-a: b
---- !!seq
-- a
-- b
---- !!str a b
---- !!str 'a: b'
----
-!!str a: b
---- !!set
-a: 
-b: 
---- !!set
-a: 
---- !!seq
-- !!int 0
-- !!str 1
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(normalized_tree) == ""
+          "--- !!map"          "\n"
+          "a: 0"               "\n"
+          "b: 1"               "\n"
+          "--- !map"           "\n"
+          "a: b"               "\n"
+          "--- !!seq"          "\n"
+          "- a"                "\n"
+          "- b"                "\n"
+          "--- !!str a b"      "\n"
+          "--- !!str 'a: b'"   "\n"
+          "---"                "\n"
+          "!!str a: b"         "\n"
+          "--- !!set"          "\n"
+          "a: "                "\n"
+          "b: "                "\n"
+          "--- !!set"          "\n"
+          "a: "                "\n"
+          "--- !!seq"          "\n"
+          "- !!int 0"          "\n"
+          "- !!str 1"          "\n"
+          "");
     ryml::Tree normalized_tree_long = tree;
     normalized_tree_long.normalize_tags_long(); // normalize all tags in short form
-    CHECK(ryml::emitrs_yaml<std::string>(normalized_tree_long) == R"(--- !<tag:yaml.org,2002:map>
-a: 0
-b: 1
---- !map
-a: b
---- !<tag:yaml.org,2002:seq>
-- a
-- b
---- !<tag:yaml.org,2002:str> a b
---- !<tag:yaml.org,2002:str> 'a: b'
----
-!<tag:yaml.org,2002:str> a: b
---- !<tag:yaml.org,2002:set>
-a: 
-b: 
---- !<tag:yaml.org,2002:set>
-a: 
---- !<tag:yaml.org,2002:seq>
-- !<tag:yaml.org,2002:int> 0
-- !<tag:yaml.org,2002:str> 1
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(normalized_tree_long) == ""
+          "--- !<tag:yaml.org,2002:map>"          "\n"
+          "a: 0"                                  "\n"
+          "b: 1"                                  "\n"
+          "--- !map"                              "\n"
+          "a: b"                                  "\n"
+          "--- !<tag:yaml.org,2002:seq>"          "\n"
+          "- a"                                   "\n"
+          "- b"                                   "\n"
+          "--- !<tag:yaml.org,2002:str> a b"      "\n"
+          "--- !<tag:yaml.org,2002:str> 'a: b'"   "\n"
+          "---"                                   "\n"
+          "!<tag:yaml.org,2002:str> a: b"         "\n"
+          "--- !<tag:yaml.org,2002:set>"          "\n"
+          "a: "                                   "\n"
+          "b: "                                   "\n"
+          "--- !<tag:yaml.org,2002:set>"          "\n"
+          "a: "                                   "\n"
+          "--- !<tag:yaml.org,2002:seq>"          "\n"
+          "- !<tag:yaml.org,2002:int> 0"          "\n"
+          "- !<tag:yaml.org,2002:str> 1"          "\n"
+          "");
 }
 
 
@@ -5151,42 +5262,46 @@ a:
 
 void sample_tag_directives()
 {
-    const std::string yaml = R"(
-%TAG !m! !my-
---- # Bulb here
-!m!light fluorescent
-...
-%TAG !m! !meta-
---- # Color here
-!m!light green
-)";
+    const std::string yaml = ""
+        "%TAG !m! !my-"             "\n"
+        "--- # Bulb here"           "\n"
+        "!m!light fluorescent"      "\n"
+        "..."                       "\n"
+        "%TAG !m! !meta-"           "\n"
+        "--- # Color here"          "\n"
+        "!m!light green"            "\n"
+        "";
+    // tags are not resolved by default:
     ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(yaml));
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(%TAG !m! !my-
---- !m!light fluorescent
-...
-%TAG !m! !meta-
---- !m!light green
-)");
-    // tags are not resolved by default. Use Tree::resolve_tags()
-    // to accomplish this in an existing tree:
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "%TAG !m! !my-"               "\n"
+          "--- !m!light fluorescent"    "\n"
+          "..."                         "\n"
+          "%TAG !m! !meta-"             "\n"
+          "--- !m!light green"          "\n"
+          "");
+    // Use Tree::resolve_tags() to accomplish this in an existing
+    // tree:
     ryml::TagCache tag_cache; // reduces memory requirements by reusing resolved tags
     tree.resolve_tags(tag_cache);
-    CHECK(ryml::emitrs_yaml<std::string>(tree) == R"(%TAG !m! !my-
---- !<!my-light> fluorescent
-...
-%TAG !m! !meta-
---- !<!meta-light> green
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
+          "%TAG !m! !my-"                    "\n"
+          "--- !<!my-light> fluorescent"     "\n"
+          "..."                              "\n"
+          "%TAG !m! !meta-"                  "\n"
+          "--- !<!meta-light> green"         "\n"
+          "");
     // You can also Use ParserOptions to force resolution of tags
     // while parsing:
     ryml::ParserOptions opts = ryml::ParserOptions{}.resolve_tags(true);
     ryml::Tree resolved_tree = ryml::parse_in_arena(ryml::to_csubstr(yaml), opts);
-    CHECK(ryml::emitrs_yaml<std::string>(resolved_tree) == R"(%TAG !m! !my-
---- !<!my-light> fluorescent
-...
-%TAG !m! !meta-
---- !<!meta-light> green
-)");
+    CHECK(ryml::emitrs_yaml<std::string>(resolved_tree) == ""
+          "%TAG !m! !my-"                      "\n"
+          "--- !<!my-light> fluorescent"       "\n"
+          "..."                                "\n"
+          "%TAG !m! !meta-"                    "\n"
+          "--- !<!meta-light> green"           "\n"
+          "");
     // see also tree.normalize_tags()
     // see also tree.normalize_tags_long()
 }
@@ -5196,18 +5311,19 @@ void sample_tag_directives()
 
 void sample_docs()
 {
-    std::string yml = R"(---
-a: 0
-b: 1
----
-c: 2
-d: 3
----
-- 4
-- 5
-- 6
-- 7
-)";
+    std::string yml = ""
+        "---"        "\n"
+        "a: 0"       "\n"
+        "b: 1"       "\n"
+        "---"        "\n"
+        "c: 2"       "\n"
+        "d: 3"       "\n"
+        "---"        "\n"
+        "- 4"        "\n"
+        "- 5"        "\n"
+        "- 6"        "\n"
+        "- 7"        "\n"
+        "";
     ryml::Tree tree = ryml::parse_in_place(ryml::to_substr(yml));
     CHECK(ryml::emitrs_yaml<std::string>(tree) == yml);
 
@@ -5230,7 +5346,9 @@ d: 3
         CHECK(tree.is_stream(stream_id));
         CHECK(!tree.is_doc(stream_id));
         CHECK(tree.num_children(stream_id) == 3);
-        for(ryml::id_type doc_id = tree.first_child(stream_id); doc_id != ryml::NONE; doc_id = tree.next_sibling(stream_id))
+        for(ryml::id_type doc_id = tree.first_child(stream_id);
+            doc_id != ryml::NONE;
+            doc_id = tree.next_sibling(stream_id))
             CHECK(tree.is_doc(doc_id));
         CHECK(tree.doc(0) == tree.child(stream_id, 0));
         CHECK(tree.doc(1) == tree.child(stream_id, 1));
@@ -5286,9 +5404,23 @@ d: 3
     // them separately:
     {
         const std::string expected_json[] = {
-            "{\n  \"a\": 0,\n  \"b\": 1\n}\n",
-            "{\n  \"c\": 2,\n  \"d\": 3\n}\n",
-            "[\n  4,\n  5,\n  6,\n  7\n]\n",
+            "{"            "\n"
+            "  \"a\": 0,"  "\n"
+            "  \"b\": 1"   "\n"
+            "}"            "\n"
+            "",
+            "{"            "\n"
+            "  \"c\": 2,"  "\n"
+            "  \"d\": 3"   "\n"
+            "}"            "\n"
+            "",
+            "["            "\n"
+            "  4,"         "\n"
+            "  5,"         "\n"
+            "  6,"         "\n"
+            "  7"          "\n"
+            "]"            "\n"
+            "",
         };
         // using the node API
         {
@@ -5305,7 +5437,9 @@ d: 3
             ryml::id_type count = 0;
             const ryml::id_type stream_id = tree.root_id();
             CHECK(tree.num_children(stream_id) == (ryml::id_type)C4_COUNTOF(expected_json));
-            for(ryml::id_type doc_id = tree.first_child(stream_id); doc_id != ryml::NONE; doc_id = tree.next_sibling(doc_id))
+            for(ryml::id_type doc_id = tree.first_child(stream_id);
+                doc_id != ryml::NONE;
+                doc_id = tree.next_sibling(doc_id))
             {
                 CHECK(ryml::emitrs_json<std::string>(tree, doc_id) == expected_json[count++]);
             }
@@ -5383,12 +5517,14 @@ void sample_error_basic()
 #endif
 }
 
+
 void sample_error_parse()
 {
-    ryml::csubstr ymlsrc = R"({
-  a: b
-   [
-)";
+    ryml::csubstr ymlsrc = ""
+        "{"       "\n"
+        "  a: b"  "\n"
+        "   ["    "\n"
+        "";
     ryml::csubstr ymlfile = "file.yml";
     auto cause_parse_error = [&]{
         return ryml::parse_in_arena(ymlfile, ymlsrc);
@@ -5417,20 +5553,21 @@ void sample_error_parse()
             msg_ctx.append(s.str, s.len);
         }, errh.saved_parse_loc, ymlsrc, "err");
         CHECK(ryml::to_csubstr(msg_ctx).begins_with("file.yml:3: col=4 (12B): ERROR: [parse] invalid character: '['"));
-        CHECK(ryml::to_csubstr(msg_ctx).ends_with(R"(file.yml:3: col=4 (12B): err:
-err:
-err:        [
-err:         |
-err:         (here)
-err:
-err: see region:
-err:
-err:     {
-err:       a: b
-err:        [
-err:         |
-err:         (here)
-)"));
+        CHECK(ryml::to_csubstr(msg_ctx).ends_with(
+                  "file.yml:3: col=4 (12B): err:"     "\n"
+                  "err:"                              "\n"
+                  "err:        ["                     "\n"
+                  "err:         |"                    "\n"
+                  "err:         (here)"               "\n"
+                  "err:"                              "\n"
+                  "err: see region:"                  "\n"
+                  "err:"                              "\n"
+                  "err:     {"                        "\n"
+                  "err:       a: b"                   "\n"
+                  "err:        ["                     "\n"
+                  "err:         |"                    "\n"
+                  "err:         (here)"               "\n"
+                  ""));
         //
         // Let's now check the location (see the message above):
         CHECK(errh.saved_parse_loc.name == ymlfile);
@@ -5497,20 +5634,21 @@ err:         (here)
         full += '\n';
         ryml::location_format_with_context(dumpfn, exc.errdata_parse.ymlloc, ymlsrc, "err", 3);
         CHECK(ryml::to_csubstr(full).begins_with("file.yml:3: col=4 (12B): ERROR: [parse] invalid character: '['"));
-        CHECK(ryml::to_csubstr(full).ends_with(R"(file.yml:3: col=4 (12B): err:
-err:
-err:        [
-err:         |
-err:         (here)
-err:
-err: see region:
-err:
-err:     {
-err:       a: b
-err:        [
-err:         |
-err:         (here)
-)"));
+        CHECK(ryml::to_csubstr(full).ends_with(
+                  "file.yml:3: col=4 (12B): err:"      "\n"
+                  "err:"                               "\n"
+                  "err:        ["                      "\n"
+                  "err:         |"                     "\n"
+                  "err:         (here)"                "\n"
+                  "err:"                               "\n"
+                  "err: see region:"                   "\n"
+                  "err:"                               "\n"
+                  "err:     {"                         "\n"
+                  "err:       a: b"                    "\n"
+                  "err:        ["                      "\n"
+                  "err:         |"                     "\n"
+                  "err:         (here)"                "\n"
+                  ""));
     }
     CHECK(gotit);
     gotit = false;
@@ -5649,11 +5787,12 @@ void sample_error_visit_location()
     ryml::EventHandlerTree evt_handler{};
     ryml::Parser parser(&evt_handler, opts);
     ryml::csubstr ymlfile = "file.yml";
-    ryml::csubstr ymlsrc = R"(foo: bar
-char: a
-int: a
-float: 123.456
-)";
+    ryml::csubstr ymlsrc = ""
+        "foo: bar"           "\n"
+        "char: a"            "\n"
+        "int: a"             "\n"
+        "float: 123.456"     "\n"
+        "";
     const ryml::Tree tree = ryml::parse_in_arena(&parser, ymlfile, ymlsrc);
     // This function will cause a visit error when being called:
     auto cause_visit_error = [&]{
@@ -5692,21 +5831,22 @@ float: 123.456
         ryml::location_format_with_context([&msg](ryml::csubstr s){
             msg.append(s.str, s.len);
         }, ymlloc, ymlsrc, "err", /*number of lines to show before the error*/3);
-        CHECK(ryml::to_csubstr(msg).ends_with(R"(file.yml:3: col=0 (24B): err:
-err:
-err:     float: 123.456
-err:     |
-err:     (here)
-err:
-err: see region:
-err:
-err:     foo: bar
-err:     char: a
-err:     int: a
-err:     float: 123.456
-err:     |
-err:     (here)
-)"));
+        CHECK(ryml::to_csubstr(msg).ends_with(
+                  "file.yml:3: col=0 (24B): err:"     "\n"
+                  "err:"                              "\n"
+                  "err:     float: 123.456"           "\n"
+                  "err:     |"                        "\n"
+                  "err:     (here)"                   "\n"
+                  "err:"                              "\n"
+                  "err: see region:"                  "\n"
+                  "err:"                              "\n"
+                  "err:     foo: bar"                 "\n"
+                  "err:     char: a"                  "\n"
+                  "err:     int: a"                   "\n"
+                  "err:     float: 123.456"           "\n"
+                  "err:     |"                        "\n"
+                  "err:     (here)"                   "\n"
+                  ""));
     }
 }
 
@@ -5996,10 +6136,12 @@ void sample_location_tracking()
     // NOTE: locations are zero-based. If you intend to show the
     // location to a human user, you may want to pre-increment the line
     // and column by 1.
-    ryml::csubstr yaml = R"({
-aa: contents,
-foo: [one, [two, three]]
-})";
+    ryml::csubstr yaml = ""
+        "{"                          "\n"
+        "aa: contents,"              "\n"
+        "foo: [one, [two, three]]"   "\n"
+        "}"                          "\n"
+        "";
     // A parser is needed to track locations, and it has to be
     // explicitly set to do it. Location tracking is disabled by
     // default.
@@ -6079,22 +6221,23 @@ foo: [one, [two, three]]
     CHECK(loc.col == 0u);
 
     // NOTES ABOUT CONTAINER LOCATIONS
-    ryml::Tree tree2 = parse_in_arena(&parser, "containers.yaml", R"(
-a new: buffer
-to: be parsed
-map with key:
-  first: value
-  second: value
-seq with key:
-  - first value
-  - second value
-  -
-    - nested first value
-    - nested second value
-  -
-    nested first: value
-    nested second: value
-)");
+    ryml::Tree tree2 = parse_in_arena(&parser, "containers.yaml",
+        ""                            "\n"
+        "a new: buffer"               "\n"
+        "to: be parsed"               "\n"
+        "map with key:"               "\n"
+        "  first: value"              "\n"
+        "  second: value"             "\n"
+        "seq with key:"               "\n"
+        "  - first value"             "\n"
+        "  - second value"            "\n"
+        "  -"                         "\n"
+        "    - nested first value"    "\n"
+        "    - nested second value"   "\n"
+        "  -"                         "\n"
+        "    nested first: value"     "\n"
+        "    nested second: value"    "\n"
+        "");
     // (Likewise, the docval tree can no longer be used to query.)
     //
     // For key-less block-style maps, the location of the container
@@ -6524,7 +6667,6 @@ void file_put_contents(const char *filename, const char *buf, size_t sz, const c
 }
 C4_SUPPRESS_WARNING_CLANG_POP
 C4_SUPPRESS_WARNING_MSVC_POP
-
 /** @} */ // doc_sample_helpers
 
 /** @} */ // doc_quickstart

--- a/src/c4/yml/detail/print.hpp
+++ b/src/c4/yml/detail/print.hpp
@@ -85,7 +85,7 @@ inline C4_NO_INLINE id_type print_node(Tree const& p, id_type node, int level, i
     if(print_address) printf(" %p", (void const*)p.get(node));
     if(p.is_root(node)) printf(" [ROOT]");
     char typebuf[128];
-    csubstr typestr = type.type_str(typebuf);
+    csubstr typestr = type.type_str_sub(typebuf);
     _RYML_CHECK_BASIC(typestr.str);
     printf(" %.*s", (int)typestr.len, typestr.str);
     if(p.has_key(node))

--- a/src/c4/yml/emit.def.hpp
+++ b/src/c4/yml/emit.def.hpp
@@ -231,7 +231,7 @@ void Emitter<Writer>::_visit_doc_val(id_type id)
     // appear at 0-indentation
     NodeType ty = m_tree->type(id);
     const csubstr val = m_tree->val(id);
-    const type_bits val_style = ty & VAL_STYLE;
+    type_bits val_style = ty & VAL_STYLE;
     const bool is_ambiguous = ((ty & VAL_PLAIN) || !val_style)
         && (val.begins_with("...") || val.begins_with("---"));
     if(is_ambiguous)
@@ -250,7 +250,7 @@ void Emitter<Writer>::_visit_doc_val(id_type id)
     else
     {
         if(!val_style)
-            ty = scalar_style_choose(val);
+            val_style = scalar_style_choose_block(val);
         _blck_write_scalar(val, val_style);
     }
     if(is_ambiguous)
@@ -381,7 +381,7 @@ void Emitter<Writer>::_flow_map_open_entry(id_type node)
         _write_pws_and_pend(_PWS_NONE);
         csubstr key = m_tree->key(node);
         if(!(ty & (NodeType_e)_styles_flow_key))
-            ty |= scalar_style_choose(key) & (NodeType_e)_styles_flow_key;
+            ty |= scalar_style_choose_flow(key) & (NodeType_e)_styles_flow_key;
         _flow_write_scalar(key, ty & (NodeType_e)_styles_flow_key);
     }
     _write_pws_and_pend(_PWS_SPACE);
@@ -478,7 +478,7 @@ void Emitter<Writer>::_blck_map_open_entry(id_type node)
     NodeType ty = m_tree->type(node);
     csubstr key = m_tree->key(node);
     if(!(ty & (KEY_STYLE|KEYREF)))
-        ty |= (scalar_style_choose(key) & KEY_STYLE);
+        ty |= (scalar_style_choose_block(key) & KEY_STYLE);
     _write_pws_and_pend(_PWS_NONE);
     if(ty & KEYANCH)
     {
@@ -564,7 +564,7 @@ void Emitter<Writer>::_visit_blck_seq(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & VAL_STYLE))
-                    ty |= (scalar_style_choose(val) & VAL_STYLE);
+                    ty |= (scalar_style_choose_block(val) & VAL_STYLE);
                 _blck_write_scalar(val, ty & VAL_STYLE);
             }
             else
@@ -610,7 +610,7 @@ void Emitter<Writer>::_visit_blck_map(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & VAL_STYLE))
-                    ty |= (scalar_style_choose(val) & VAL_STYLE);
+                    ty |= (scalar_style_choose_block(val) & VAL_STYLE);
                 _blck_write_scalar(val, ty & VAL_STYLE);
             }
             else
@@ -655,7 +655,7 @@ void Emitter<Writer>::_visit_flow_sl_seq(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & (NodeType_e)_styles_flow_val))
-                    ty |= (scalar_style_choose(val) & (NodeType_e)_styles_flow_val);
+                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)_styles_flow_val);
                 _flow_write_scalar(val, ty & (NodeType_e)_styles_flow_val);
             }
             else
@@ -696,7 +696,7 @@ void Emitter<Writer>::_visit_flow_ml_seq(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & (NodeType_e)_styles_flow_val))
-                    ty |= (scalar_style_choose(val) & (NodeType_e)_styles_flow_val);
+                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)_styles_flow_val);
                 _flow_write_scalar(val, ty & (NodeType_e)_styles_flow_val);
             }
             else
@@ -737,7 +737,7 @@ void Emitter<Writer>::_visit_flow_sl_map(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & (NodeType_e)_styles_flow_val))
-                    ty |= (scalar_style_choose(val) & (NodeType_e)_styles_flow_val);
+                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)_styles_flow_val);
                 _flow_write_scalar(val, ty & (NodeType_e)_styles_flow_val);
             }
             else
@@ -779,7 +779,7 @@ void Emitter<Writer>::_visit_flow_ml_map(id_type node)
             if(!ty.is_val_ref())
             {
                 if(!(ty & (NodeType_e)_styles_flow_val))
-                    ty |= (scalar_style_choose(val) & (NodeType_e)_styles_flow_val);
+                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)_styles_flow_val);
                 _flow_write_scalar(val, ty & (NodeType_e)_styles_flow_val);
             }
             else
@@ -1433,7 +1433,7 @@ void Emitter<Writer>::_json_writev(id_type id, NodeType ty)
     {
         // use double quoted style if the style is marked quoted
         bool dquoted = ((ty & VALQUO)
-                        || (scalar_style_json_choose(val) & SCALAR_DQUO)); // choose the style
+                        || (scalar_style_choose_json(val) & SCALAR_DQUO)); // choose the style
         if(dquoted)
             _json_write_scalar_dquo(val);
         else if(_json_maybe_write_naninf(val))

--- a/src/c4/yml/node_type.cpp
+++ b/src/c4/yml/node_type.cpp
@@ -1,4 +1,10 @@
+#ifndef _C4_YML_NODE_TYPE_HPP_
 #include "c4/yml/node_type.hpp"
+#endif
+#ifndef _C4_YML_ERROR_HPP_
+#include "c4/yml/error.hpp"
+#endif
+
 
 namespace c4 {
 namespace yml {
@@ -60,7 +66,7 @@ const char* NodeType::type_str(NodeType_e ty) noexcept
     }
 }
 
-csubstr NodeType::type_str(substr buf, NodeType_e flags) noexcept
+size_t NodeType::type_str(substr buf, NodeType_e flags) noexcept
 {
     size_t pos = 0;
     bool gotone = false;
@@ -122,18 +128,7 @@ csubstr NodeType::type_str(substr buf, NodeType_e flags) noexcept
 
     #undef _prflag
 
-    if(pos < buf.len)
-    {
-        buf[pos] = '\0';
-        return buf.first(pos);
-    }
-    else
-    {
-        csubstr failed;
-        failed.len = pos + 1;
-        failed.str = nullptr;
-        return failed;
-    }
+    return pos;
 }
 
 
@@ -142,86 +137,229 @@ csubstr NodeType::type_str(substr buf, NodeType_e flags) noexcept
 // see https://www.yaml.info/learn/quote.html#noplain
 bool scalar_style_query_squo(csubstr s) noexcept
 {
-    return ! s.first_of_any("\n ", "\n\t");
+    // cannot have leading whitespace after a newline
+    for(size_t i = 0; i < s.len; ++i)
+    {
+        if(s.str[i] == '\n' && i + 1 < s.len)
+        {
+            char next = s.str[i + 1];
+            if(next == ' ' || next == '\t')
+                return false;
+        }
+    }
+    return true;
 }
 
-// see https://www.yaml.info/learn/quote.html#noplain
-bool scalar_style_query_plain(csubstr s) noexcept
+namespace {
+bool _is_wsnl(char c) noexcept
 {
-    if(s.begins_with("-."))
+    return c == ' ' || c == '\n' || c == '\t' || c == '\r';
+}
+bool _is_valid_bulk(csubstr s, size_t i)
+{
+    C4_ASSERT(i >= 1 && i+1 < s.len);
+    C4_ASSERT(s.str[i] == ':' || s.str[i] == '#');
+    switch(s.str[i])
     {
-        if(s == "-.inf" || s == "-.INF")
-            return true;
-        else if(s.sub(2).is_number())
-            return true;
+    case ':': return !_is_wsnl(s.str[i+1]);
+    case '#': return !_is_wsnl(s.str[i-1]);
     }
-    else if(s.begins_with_any("0123456789.-+") && s.is_number())
+    C4_UNREACHABLE(); // LCOV_EXCL_LINE
+}
+} // namespace
+// see https://www.yaml.info/learn/quote.html#noplain
+bool scalar_style_query_plain_flow(csubstr s) noexcept
+{
+    if(!s.len)
+        return !s.str;
+    // first
+    switch(s.str[0])
     {
-        return true;
+    case ' ': case '\n': case '\t': case '\r':
+    case '!': case '&': case '*': case ',':
+    case '"': case '\'': case '|': case '>':
+    case '{': case '}': case '[': case ']':
+    case '#': case '`': case '%': case '@':
+        return false;
+    case '-': case ':': case '?':
+        if(s.len == 1 || (s.str[1] == ' ' || s.str[1] == '\t'))
+            return false;
+        break;
     }
-    return ( ! s.begins_with_any("-:?*&,'\"{}[]|>%#@`\r")) // @ and ` are reserved characters
-        && ( ! s.ends_with_any(":#"))
-             // make this check in the last place, as it has linear
-             // complexity, while the previous ones are
-             // constant-time
-        && (s.first_of("\n#:[]{},") == npos);
+    // bulk
+    for(size_t i = 1; i + 1 < s.len; ++i)
+    {
+        switch(s.str[i])
+        {
+        case ',': case '{': case '}': case '[': case ']':
+            return false;
+        case ':': case '#':
+            if(!_is_valid_bulk(s, i))
+                return false;
+            break;
+        }
+    }
+    // last
+    if(s.len > 1)
+    {
+        switch(s.back())
+        {
+        case ' ': case '\n': case '\t': case '\r':
+        case ',':
+        case '{': case '}':
+        case '[': case ']':
+        case '#':
+        case ':':
+            return false;
+        }
+    }
+    return true;
 }
 
-NodeType_e scalar_style_choose(csubstr s) noexcept
+bool scalar_style_query_plain_block(csubstr s) noexcept
+{
+    if(!s.len)
+        return !s.str;
+    // first
+    switch(s.str[0])
+    {
+    case ' ': case '\n': case '\t': case '\r':
+    case '!': case '&': case '*': case ',':
+    case '"': case '\'': case '|': case '>':
+    case '{': case '}': case '[': case ']':
+    case '#': case '`': case '%': case '@':
+        return false;
+    case '-': case ':': case '?':
+        if (s.len == 1 || (s.str[1] == ' ' || s.str[1] == '\t'))
+            return false;
+        break;
+    }
+    // bulk
+    for(size_t i = 1; i + 1 < s.len; ++i)
+    {
+        switch(s.str[i])
+        {
+        case ':': case '#':
+            if(!_is_valid_bulk(s, i))
+                return false;
+            break;
+        }
+    }
+    // last
+    if(s.len > 1)
+    {
+        switch(s.back())
+        {
+        case ' ': case '\n': case '\t': case '\r':
+        case '#':
+        case ':':
+            return false;
+        }
+    }
+    return true;
+}
+
+NodeType_e scalar_style_choose_flow(csubstr s) noexcept
 {
     if(s.len)
     {
-        if(s.begins_with_any(" \n\t")
-           ||
-           s.ends_with_any(" \n\t"))
-        {
-            return SCALAR_DQUO;
-        }
-        else if( ! scalar_style_query_plain(s))
-        {
-            return scalar_style_query_squo(s) ? SCALAR_SQUO : SCALAR_DQUO;
-        }
-        // nothing remarkable - use plain
-        return SCALAR_PLAIN;
+        if(scalar_style_query_plain_flow(s))
+            return SCALAR_PLAIN;
+        else if(scalar_style_query_squo(s))
+            return SCALAR_SQUO;
+        return SCALAR_DQUO;
     }
     return s.str ? SCALAR_SQUO : SCALAR_PLAIN;
 }
 
-NodeType_e scalar_style_json_choose(csubstr s) noexcept
+NodeType_e scalar_style_choose_block(csubstr s) noexcept
 {
-    // do not quote special cases
-    bool plain = (
-        (s == "true" || s == "false" || s == "null")
-        ||
+    if(s.len)
+    {
+        if(scalar_style_query_plain_block(s))
+            return SCALAR_PLAIN;
+        _RYML_ASSERT_BASIC(scalar_style_query_squo(s)
+                           && "if this assertion fires, please submit an issue!");
+        return SCALAR_SQUO;
+    }
+    return s.str ? SCALAR_SQUO : SCALAR_PLAIN;
+}
+
+
+bool scalar_is_null(csubstr s) noexcept
+{
+    return s.str == nullptr ||
+        (s.len == 1 && (s.str[0] == '~')) ||
+        (s.len == 4 && ((0 == memcmp("null", s.str, 4))
+                        || (0 == memcmp("Null", s.str, 4))
+                        || (0 == memcmp("NULL", s.str, 4))));
+}
+
+
+//-----------------------------------------------------------------------------
+
+namespace {
+
+#define rest_is(c1, c2) ((s.str[1] == (c1)) && (s.str[2] == (c2)))
+bool is_inf_or_nan(csubstr s) noexcept
+{
+    _RYML_ASSERT_BASIC(!s.begins_with("-."));
+    _RYML_ASSERT_BASIC(!s.begins_with("+."));
+    _RYML_ASSERT_BASIC(!s.begins_with("."));
+    _RYML_ASSERT_BASIC(s.len == 3);
+    switch(s.str[0])
+    {
+    case 'i': return rest_is('n', 'f');
+    case 'I': return rest_is('n', 'f') || rest_is('N', 'F');
+    case 'n': return rest_is('a', 'n');
+    case 'N': return rest_is('a', 'n') || rest_is('A', 'N') || rest_is('a', 'N');
+    }
+    return false;
+}
+bool is_inf(csubstr s) noexcept
+{
+    _RYML_ASSERT_BASIC(!s.begins_with("-."));
+    _RYML_ASSERT_BASIC(!s.begins_with("+."));
+    _RYML_ASSERT_BASIC(!s.begins_with("."));
+    _RYML_ASSERT_BASIC(s.len == 3);
+    switch(s.str[0])
+    {
+    case 'i': return rest_is('n', 'f');
+    case 'I': return rest_is('n', 'f') || rest_is('N', 'F');
+    }
+    return false;
+}
+#undef rest_is
+
+bool json_is_plain_number(csubstr s) noexcept
+{
+    return s.is_number()
+        &&
         (
-            // do not quote numbers
-            s.is_number()
-            &&
-            (
-                (
-                    // quote integral numbers if they have a leading 0
-                    // https://github.com/biojppm/rapidyaml/issues/291
-                    (!(s.len > 1 && s.begins_with('0')))
-                    // do not quote reals with leading 0
-                    // https://github.com/biojppm/rapidyaml/issues/313
-                    || (s.find('.') != csubstr::npos)
-                )
-            )
-        )
-        ||
-        (
-            (s.len > 3)
-            &&
-            (
-                (s[0] == '.' && (s == ".inf" || s == ".Inf" || s == ".INF"
-                                 ||
-                                 s == ".nan" || s == ".NaN" || s == ".NAN"))
-                ||
-                (s[0] == '-' && (s == "-.inf" || s == "-.Inf" || s == "-.INF"))
-            )
-        )
-    );
-    return plain ? SCALAR_PLAIN : SCALAR_DQUO;
+            // quote integral numbers if they have a leading 0
+            // https://github.com/biojppm/rapidyaml/issues/291
+            (!(s.len > 1 && s.begins_with('0')))
+            // do not quote reals with leading 0
+            // https://github.com/biojppm/rapidyaml/issues/313
+            || (s.find('.') != csubstr::npos)
+        );
+}
+bool json_is_special_scalar(csubstr s)  noexcept
+{
+    if(s.len == 4)
+        return 0 == memcmp("true", s.str, 4)
+            || 0 == memcmp("null", s.str, 4)
+            || (s[0] == '.' && is_inf_or_nan(s.sub(1)));
+    else if(s.len == 5)
+        return 0 == memcmp("false", s.str, 5)
+            || ((s[0] == '-' || s[0] == '+') && s[1] == '.' && is_inf(s.sub(2)));
+    return false;
+}
+} // namespace
+NodeType_e scalar_style_choose_json(csubstr s) noexcept
+{
+    // do not quote numbers or special scalars
+    return json_is_plain_number(s) || json_is_special_scalar(s) ? SCALAR_PLAIN : SCALAR_DQUO;
 }
 
 } // namespace yml

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -155,10 +155,21 @@ public:
     /** return a preset string based on the node type */
     static const char* type_str(NodeType_e t) noexcept;
 
+    /** fill a string with the node type flags. */
+    C4_ALWAYS_INLINE size_t type_str(substr buf) const noexcept { return type_str(buf, type); }
+    /** fill a string with the node type flags. */
+    static size_t type_str(substr buf, NodeType_e t) noexcept;
+
     /** fill a string with the node type flags. If the string is small, returns {null, len} */
-    C4_ALWAYS_INLINE csubstr type_str(substr buf) const noexcept { return type_str(buf, type); }
+    C4_ALWAYS_INLINE csubstr type_str_sub(substr buf) const noexcept { return type_str_sub(buf, type); }
     /** fill a string with the node type flags. If the string is small, returns {null, len}  */
-    static csubstr type_str(substr buf, NodeType_e t) noexcept;
+    static csubstr type_str_sub(substr buf, NodeType_e t) noexcept
+    {
+        csubstr ret;
+        ret.len = type_str(buf, t);
+        ret.str = ret.len < buf.len ? buf.str : nullptr;
+        return ret;
+    }
 
 public:
 
@@ -242,32 +253,73 @@ public:
 /** @name scalar style helpers
  * @{ */
 
-/** choose a YAML emitting style based on the scalar's contents */
-RYML_EXPORT NodeType_e scalar_style_choose(csubstr scalar) noexcept;
+/** choose a YAML scalar style based on the scalar's contents, while
+ * in flow mode. Plain scalars [have more constraints in flow mode
+ * than in block
+ * mode](https://www.yaml.info/learn/quote.html#noplain). @ref
+ * scalar_style_choose_block() is the block mode analogous
+ * function. */
+RYML_EXPORT NodeType_e scalar_style_choose_flow(csubstr scalar) noexcept;
+/** choose a YAML scalar style based on the scalar's contents, while
+ * in block mode. Plain scalars [have more constraints in flow mode
+ * than in block
+ * mode](https://www.yaml.info/learn/quote.html#noplain). @ref
+ * scalar_style_choose_block() is the flow mode analogous function. */
+RYML_EXPORT NodeType_e scalar_style_choose_block(csubstr scalar) noexcept;
+/** choose a YAML emitting style based on the scalar's
+ * contents. Legacy compatibility function: assumes flow mode which is
+ * more constraining, and delegates to either @ref
+ * scalar_style_choose_flow() or @ref scalar_style_choose_block(). */
+inline NodeType_e scalar_style_choose(csubstr s, bool flow=true) noexcept
+{
+    return flow ? scalar_style_choose_flow(s) : scalar_style_choose_block(s);
+}
 
-/** choose a json style based on the scalar's contents */
-RYML_EXPORT NodeType_e scalar_style_json_choose(csubstr scalar) noexcept;
+
+/** choose a json scalar style based on the scalar's contents */
+RYML_EXPORT NodeType_e scalar_style_choose_json(csubstr scalar) noexcept;
+/** @cond dev */
+// LCOV_EXCL_START
+RYML_DEPRECATED("use scalar_style_choose_json()")
+inline NodeType_e scalar_style_json_choose(csubstr scalar) noexcept
+{
+    return scalar_style_choose_json(scalar);
+}
+// LCOV_EXCL_STOP
+/** @endcond */
+
 
 /** query whether a scalar can be encoded using single quotes.
  * It may not be possible, notably when there is leading
  * whitespace after a newline. */
 RYML_EXPORT bool scalar_style_query_squo(csubstr s) noexcept;
 
-/** query whether a scalar can be encoded using plain style (no
- * quotes, not a literal/folded block scalar). */
-RYML_EXPORT bool scalar_style_query_plain(csubstr s) noexcept;
+/** query whether a scalar can be encoded using plain style while in
+ * flow mode. Plain scalars [have more constraints in flow mode than
+ * in block
+ * mode](https://www.yaml.info/learn/quote.html#noplain). @ref
+ * scalar_style_query_plain_block() is the block mode analogous function.*/
+RYML_EXPORT bool scalar_style_query_plain_flow(csubstr s) noexcept;
+/** query whether a scalar can be encoded using plain style while in
+ * block mode. Plain scalars [have more constraints in flow mode than
+ * in block
+ * mode](https://www.yaml.info/learn/quote.html#noplain). @ref
+ * scalar_style_query_plain_flow() is the flow mode analogous function.*/
+RYML_EXPORT bool scalar_style_query_plain_block(csubstr s) noexcept;
+/** query whether a scalar can be encoded using plain style. Legacy
+ * compatibility function: assumes flow mode which is more
+ * constraining, and delegates to either @ref
+ * scalar_style_query_plain_flow() or @ref
+ * scalar_style_query_plain_block(). */
+inline bool scalar_style_query_plain(csubstr s, bool flow=true) noexcept
+{
+    return flow ? scalar_style_query_plain_flow(s) : scalar_style_query_plain_block(s);
+}
 
 /** YAML-sense query of nullity. returns true if the scalar points
  * to `nullptr` or is otherwise equal to one of the strings
  * `"~"`,`"null"`,`"Null"`,`"NULL"` */
-inline bool scalar_is_null(csubstr s) noexcept
-{
-    return s.str == nullptr ||
-        s == "~" ||
-        s == "null" ||
-        s == "Null" ||
-        s == "NULL";
-}
+RYML_EXPORT bool scalar_is_null(csubstr s) noexcept;
 
 /** @} */
 

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -656,10 +656,11 @@ public:
     /** @name tags and tag directives */
     /** @{ */
 
-    /** Resolve tags in the tree such as `!!str` ->
-     * `<tag:yaml.org,2002:str>`, `!foo` -> `<!foo>` and custom tags
-     * as well, ie tags of the form `!handle!tag` for which there is a
-     * corresponding `%TAG` directive
+    /** Resolve tags in the tree such as `"!!str"` ->
+     * `"<tag:yaml.org,2002:str>"`, `"!foo"` ->
+     * `"<!foo>"` and custom tags as well, ie tags of the form
+     * `"!handle!tag"` for which there is a corresponding `"%%TAG"`
+     * directive
      *
      * @param cache an object of type @ref TagCache to minimize memory
      *        usage by avoiding repeated instantiation of the resolved
@@ -667,7 +668,7 @@ public:
      *
      * @param all if true, resolve all tags; if false resolve only
      *        custom tags, ie those that have a prefix such as
-     *        `!m!tag` with a matching `%TAG` directive */
+     *        `"!m!tag"` with a matching `"%TAG"` directive */
     void resolve_tags(TagCache &cache, bool all=true);
     void normalize_tags();
     void normalize_tags_long();
@@ -688,8 +689,10 @@ public:
 
     c4::yml::TagDirectiveRange tag_directives() const { return m_tag_directives.directives(); }
 
+    /** @cond dev */
     RYML_DEPRECATED("use c4::yml::tag_directive_const_iterator") typedef TagDirective const* tag_directive_const_iterator;
     RYML_DEPRECATED("use c4::yml::TagDirectiveRange") typedef c4::yml::TagDirectiveRange TagDirectiveProxy;
+    /** @endcond */
 
     /** @} */
 

--- a/test/test_emit.cpp
+++ b/test/test_emit.cpp
@@ -238,10 +238,14 @@ TEST(emit_nested, basic)
 
 TEST(emit_block_seq, ambiguous_plain_emitted_as_squo)
 {
-    EXPECT_EQ(scalar_style_query_plain(": odd"), false);
-    EXPECT_EQ(scalar_style_query_plain(":\todd"), false);
-    EXPECT_EQ(scalar_style_choose(": odd"), SCALAR_SQUO);
-    EXPECT_EQ(scalar_style_choose(":\todd"), SCALAR_SQUO);
+    EXPECT_EQ(scalar_style_query_plain_flow(": odd"), false);
+    EXPECT_EQ(scalar_style_query_plain_flow(":\todd"), false);
+    EXPECT_EQ(scalar_style_choose_flow(": odd"), SCALAR_SQUO);
+    EXPECT_EQ(scalar_style_choose_flow(":\todd"), SCALAR_SQUO);
+    EXPECT_EQ(scalar_style_query_plain_block(": odd"), false);
+    EXPECT_EQ(scalar_style_query_plain_block(":\todd"), false);
+    EXPECT_EQ(scalar_style_choose_block(": odd"), SCALAR_SQUO);
+    EXPECT_EQ(scalar_style_choose_block(":\todd"), SCALAR_SQUO);
     {
         Tree t;
         NodeRef r = t.rootref();

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -59,19 +59,23 @@
         {                                                               \
             char ltypebuf[256];                                         \
             char rtypebuf[256];                                         \
-            csubstr ltype = NodeType::type_str(ltypebuf, (NodeType_e)lhs); \
-            csubstr rtype = NodeType::type_str(rtypebuf, (NodeType_e)rhs); \
+            csubstr ltype = NodeType::type_str_sub(ltypebuf, (NodeType_e)lhs); \
+            csubstr rtype = NodeType::type_str_sub(rtypebuf, (NodeType_e)rhs); \
+            EXPECT_##testop(lhs, rhs);                                  \
+            std::cout << __FILE__  << ":" << __LINE__ << ": ...\n";     \
             if(ltype.str && rtype.str)                                  \
             {                                                           \
-                EXPECT_##testop(lhs, rhs)                               \
-                    << "  " << ltype.str << " (" << (lhs)  << ")" << "=" << #lhs \
+                std::cout                                               \
+                    << "  " << ltype << " (" << (lhs)  << ")" << "=" << #lhs \
                     << "\n"                                             \
-                    << "  " << rtype.str << " (" << (rhs)  << ")" << "=" << #rhs; \
+                    << "  " << rtype << " (" << (rhs)  << ")" << "=" << #rhs \
+                    << "\n";                                            \
             }                                                           \
             else                                                        \
             {                                                           \
-                EXPECT_##testop(lhs, rhs)                               \
-                    << "(type too large to fit print buffer)";          \
+                std::cout                                               \
+                    << "(type too large to fit print buffer)"           \
+                    << "\n";                                            \
             }                                                           \
         }                                                               \
     } while(0)

--- a/test/test_node_type.cpp
+++ b/test/test_node_type.cpp
@@ -5,6 +5,8 @@
 #include <c4/format.hpp>
 #include <c4/yml/detail/checks.hpp>
 #include <c4/yml/detail/print.hpp>
+#include <c4/yml/detail/dbgprint.hpp>
+#include <c4/yml/escape_scalar.hpp>
 #endif
 #include "./test_lib/test_case.hpp"
 
@@ -79,24 +81,23 @@ TEST(NodeType, type_str)
 {
     {
         char bufsmall[2];
-        EXPECT_EQ(NodeType().type_str(bufsmall).len, 1 + 6); // NOTYPE
-        EXPECT_EQ(NodeType().type_str(bufsmall).str, nullptr); // NOTYPE
-        EXPECT_EQ(NodeType(VAL).type_str(bufsmall).len, 1 + 3);
-        EXPECT_EQ(NodeType(VAL).type_str(bufsmall).str, nullptr);
-        EXPECT_EQ(NodeType(KEYVAL).type_str(bufsmall).len, 1 + 7);
-        EXPECT_EQ(NodeType(KEYVAL|KEYANCH|VALANCH).type_str(bufsmall).len, 1 + 19);
-        EXPECT_EQ(NodeType(KEYVAL|KEYANCH|VALANCH).type_str(bufsmall).str, nullptr);
+        EXPECT_EQ(NodeType().type_str_sub(bufsmall).len, 6); // NOTYPE
+        EXPECT_EQ(NodeType().type_str_sub(bufsmall).str, nullptr); // NOTYPE
+        EXPECT_EQ(NodeType(VAL).type_str_sub(bufsmall).len, 3);
+        EXPECT_EQ(NodeType(VAL).type_str_sub(bufsmall).str, nullptr);
+        EXPECT_EQ(NodeType(KEYVAL).type_str_sub(bufsmall).len, 7);
+        EXPECT_EQ(NodeType(KEYVAL|KEYANCH|VALANCH).type_str_sub(bufsmall).len, 19);
+        EXPECT_EQ(NodeType(KEYVAL|KEYANCH|VALANCH).type_str_sub(bufsmall).str, nullptr);
     }
 #define teststr(bits, str)                                        \
     {                                                             \
         char buf[128] = {0};                                      \
         memset(buf, 1, sizeof(buf));                              \
         csubstr expected = str;                                   \
-        csubstr actual = NodeType(bits).type_str(buf);            \
-        ASSERT_LT(actual.len + 1, C4_COUNTOF(buf));               \
+        csubstr actual = NodeType(bits).type_str_sub(buf);        \
+        ASSERT_LT(actual.len, C4_COUNTOF(buf));                   \
         EXPECT_EQ(actual, expected);                              \
-        EXPECT_EQ(NodeType(bits).type_str(buf), expected);        \
-        EXPECT_EQ(buf[expected.len], '\0');                       \
+        EXPECT_EQ(NodeType(bits).type_str_sub(buf), expected);    \
     }
     teststr(0, "NOTYPE")
     teststr(NOTYPE, "NOTYPE")
@@ -134,135 +135,6 @@ TEST(NodeType, type_str)
     teststr(KEYVAL|KEYANCH|VALANCH, "KEY|KANCH|VAL|VANCH")
 #undef teststr
 }
-
-TEST(NodeType, scalar_style_choose_json)
-{
-    EXPECT_EQ(scalar_style_json_choose("true"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("false"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("null"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("+0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("+.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("01"), SCALAR_DQUO);
-    EXPECT_EQ(scalar_style_json_choose("foo"), SCALAR_DQUO);
-    EXPECT_EQ(scalar_style_json_choose("bar"), SCALAR_DQUO);
-}
-
-TEST(NodeType, scalar_style_choose)
-{
-    EXPECT_EQ(scalar_style_choose(" \n\t"), SCALAR_DQUO);
-    EXPECT_EQ(scalar_style_choose("-.inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-.INF"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-.034"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-.034x"), SCALAR_SQUO);
-    EXPECT_EQ(scalar_style_choose("2.35e-10"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-2.35e-10"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+2.35e-10"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0.1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0x1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0o1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0b1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0B1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("0B1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0B1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-0B1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+01"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0B1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0X1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0O1"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+0B1"), SCALAR_PLAIN);
-}
-
-TEST(NodeType, scalar_style_query_plain)
-{
-    EXPECT_TRUE(scalar_style_query_plain("-.inf"));
-    EXPECT_TRUE(scalar_style_query_plain("-.INF"));
-    EXPECT_TRUE(scalar_style_query_plain("-.034"));
-    EXPECT_FALSE(scalar_style_query_plain("-.034x"));
-    EXPECT_TRUE(scalar_style_query_plain("2.35e-10"));
-    EXPECT_TRUE(scalar_style_query_plain("-2.35e-10"));
-    EXPECT_TRUE(scalar_style_query_plain("+2.35e-10"));
-    EXPECT_TRUE(scalar_style_query_plain("0.1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0.1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0.1"));
-    EXPECT_TRUE(scalar_style_query_plain("01"));
-    EXPECT_TRUE(scalar_style_query_plain("0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("+01"));
-    EXPECT_TRUE(scalar_style_query_plain("+0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("-01"));
-    EXPECT_TRUE(scalar_style_query_plain("-0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0x1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0o1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0b1"));
-    EXPECT_TRUE(scalar_style_query_plain("0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("0B1"));
-    EXPECT_TRUE(scalar_style_query_plain("0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("0B1"));
-    EXPECT_TRUE(scalar_style_query_plain("+01"));
-    EXPECT_TRUE(scalar_style_query_plain("+0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0B1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("+0B1"));
-    EXPECT_TRUE(scalar_style_query_plain("-01"));
-    EXPECT_TRUE(scalar_style_query_plain("-0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0B1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0X1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0O1"));
-    EXPECT_TRUE(scalar_style_query_plain("-0B1"));
-}
-
 
 TEST(NodeType, is_stream)
 {
@@ -473,6 +345,729 @@ TEST(NodeType, is_quoted)
     EXPECT_TRUE(NodeType(KEY|VALQUO).is_quoted());
     EXPECT_TRUE(NodeType(VAL|KEYQUO).is_quoted());
 }
+
+
+//-----------------------------------------------------------------------------
+
+#define RYML_COMPARE_NODE_TYPE_EQ(actual, expected) RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ)
+
+TEST(NodeType, scalar_style_choose_json)
+{
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("true"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("false"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("null"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("-0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("+0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json(".1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("+.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("-.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("01"), SCALAR_DQUO);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("foo"), SCALAR_DQUO);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose_json("bar"), SCALAR_DQUO);
+}
+
+TEST(NodeType, scalar_style_choose)
+{
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose(" \n\t"), SCALAR_DQUO);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-.inf"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-.INF"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-.034"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-.034x"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("2.35e-10"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-2.35e-10"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+2.35e-10"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0.1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0x1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0o1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0b1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0B1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("0B1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0B1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("-0B1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+01"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0B1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0X1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0O1"), SCALAR_PLAIN);
+    RYML_COMPARE_NODE_TYPE_EQ(scalar_style_choose("+0B1"), SCALAR_PLAIN);
+}
+
+TEST(NodeType, scalar_style_query_plain)
+{
+    EXPECT_TRUE(scalar_style_query_plain("-.inf"));
+    EXPECT_TRUE(scalar_style_query_plain("-.INF"));
+    EXPECT_TRUE(scalar_style_query_plain("-.034"));
+    EXPECT_TRUE(scalar_style_query_plain("-.034x"));
+    EXPECT_TRUE(scalar_style_query_plain("2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain("-2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain("+2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain("0.1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0.1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0.1"));
+    EXPECT_TRUE(scalar_style_query_plain("01"));
+    EXPECT_TRUE(scalar_style_query_plain("0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("+01"));
+    EXPECT_TRUE(scalar_style_query_plain("+0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("-01"));
+    EXPECT_TRUE(scalar_style_query_plain("-0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0x1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0o1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0b1"));
+    EXPECT_TRUE(scalar_style_query_plain("0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("0B1"));
+    EXPECT_TRUE(scalar_style_query_plain("0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("0B1"));
+    EXPECT_TRUE(scalar_style_query_plain("+01"));
+    EXPECT_TRUE(scalar_style_query_plain("+0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0B1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("+0B1"));
+    EXPECT_TRUE(scalar_style_query_plain("-01"));
+    EXPECT_TRUE(scalar_style_query_plain("-0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0B1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0X1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0O1"));
+    EXPECT_TRUE(scalar_style_query_plain("-0B1"));
+}
+
+
+//-----------------------------------------------------------------------------
+
+C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
+C4_SUPPRESS_WARNING_MSVC_PUSH
+C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
+C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
+
+namespace {
+struct scalar_style_spec
+{
+    csubstr scalar;
+    NodeType style_flow;
+    NodeType style_block;
+    NodeType style_json;
+    int elm;
+    int line;
+    int entry;
+};
+csubstr mknullstr() { csubstr s; s.str = nullptr; s.len = 0; return s; }
+const csubstr zerolen("", size_t(0));
+
+const NodeType P = SCALAR_PLAIN;
+const NodeType S = SCALAR_SQUO;
+const NodeType D = SCALAR_DQUO;
+int elmcount = 0;
+int entrycount = 0;
+const scalar_style_spec scalars[] = {
+    #define _(s, flow, block, json) scalar_style_spec{csubstr(s), flow, block, json, elmcount++, __LINE__, entrycount++}
+    #define __(s, flow, block, json) scalar_style_spec{csubstr(s), flow, block, json, elmcount++, __LINE__, (entrycount = 0, entrycount++)}
+    #define ___(s, flow, block, json) scalar_style_spec{s, flow, block, json, elmcount++, __LINE__, entrycount++}
+    // special
+    ___(mknullstr(), P, P, D),
+    ___(zerolen, S, S, D),
+    // regular scalar
+    __("foo", P, P, D),
+    __("foo", P, P, D),
+    __("bar", P, P, D),
+    __("foo space", P, P, D),
+    __("bar space", P, P, D),
+    // whitespace
+    __(" ", S, S, D),
+    __("\t", S, S, D),
+    __("\n", S, S, D),
+    // numbers
+    __("0", P, P, P), _("00", P, P, D), _("000", P, P, D),
+    __("1", P, P, P), _("01", P, P, D), _("001", P, P, D),
+    __("10", P, P, P), _("010", P, P, D), _("0010", P, P, D),
+    __("0.1", P, P, P), _("-0.1", P, P, P), _("+0.1", P, P, P),
+    __(".1", P, P, P), _("-.1", P, P, P), _("+.1", P, P, P),
+    __("01", P, P, D),  _("0x1", P, P, D), _("0o1", P, P, D), _("0b1", P, P, D), _("0x1", P, P, D), _("0o1", P, P, D), _("0b1", P, P, D),
+    __("01", P, P, D),  _("0X1", P, P, D), _("0O1", P, P, D), _("0B1", P, P, D), _("0X1", P, P, D), _("0O1", P, P, D), _("0B1", P, P, D),
+    __("-01", P, P, P), _("-0x1", P, P, P), _("-0o1", P, P, P), _("-0b1", P, P, P), _("-0x1", P, P, P), _("-0o1", P, P, P), _("-0b1", P, P, P),
+    __("-01", P, P, P), _("-0X1", P, P, P), _("-0O1", P, P, P), _("-0B1", P, P, P), _("-0X1", P, P, P), _("-0O1", P, P, P), _("-0B1", P, P, P),
+    __("+01", P, P, P), _("+0x1", P, P, P), _("+0o1", P, P, P), _("+0b1", P, P, P), _("+0x1", P, P, P), _("+0o1", P, P, P), _("+0b1", P, P, P),
+    __("+01", P, P, P), _("+0X1", P, P, P), _("+0O1", P, P, P), _("+0B1", P, P, P), _("+0X1", P, P, P), _("+0O1", P, P, P), _("+0B1", P, P, P),
+    __("2.35e-10", P, P, P),
+    __("-2.35e-10", P, P, P),
+    __("+2.35e-10", P, P, P),
+    __("0.034", P, P, P),
+    __("0.034", P, P, P),
+    __("-0.034", P, P, P),
+    __("-0.034", P, P, P),
+    __("+0.034", P, P, P),
+    __("+0.034", P, P, P),
+    __(".034x", P, P, D),
+    __("-.0123", P, P, P),
+    __("+.0123", P, P, P),
+    __("-.034x", P, P, D),
+    __("+.034x", P, P, D),
+    // inf
+    __(".inf", P, P, P), _(".INF", P, P, P), _(".Inf", P, P, P),
+    __("-.inf", P, P, P), _("-.INF", P, P, P), _("-.Inf", P, P, P),
+    __("+.inf", P, P, P), _("+.INF", P, P, P), _("+.Inf", P, P, P),
+    __(".infnot", P, P, D), _(".INFnot", P, P, D), _(".Infnot", P, P, D),
+    __("-.infnot", P, P, D), _("-.INFnot", P, P, D), _("-.Infnot", P, P, D),
+    __("+.infnot", P, P, D), _("+.INFnot", P, P, D), _("+.Infnot", P, P, D),
+    __(".notinf", P, P, D), _(".NOTINF", P, P, D), _(".NotInf", P, P, D),
+    __("-.notinf", P, P, D), _("-.NOTINF", P, P, D), _("-.NotInf", P, P, D),
+    __("+.notinf", P, P, D), _("+.NOTINF", P, P, D), _("+.NotInf", P, P, D),
+    __(".not", P, P, D), _(".NOT", P, P, D), _(".Not", P, P, D),
+    __(".oot", P, P, D), _(".OOT", P, P, D), _(".Oot", P, P, D),
+    // nan
+    __(".nan", P, P, P), _(".NAN", P, P, P), _(".Nan", P, P, P), _(".NaN", P, P, P),
+    __("-.nan", P, P, D), _("-.NAN", P, P, D), _("-.Nan", P, P, D), _("-.NaN", P, P, D),
+    __("+.nan", P, P, D), _("+.NAN", P, P, D), _("+.Nan", P, P, D), _("+.NaN", P, P, D),
+    __(".nannot", P, P, D), _(".NANnot", P, P, D), _(".Nannot", P, P, D),
+    __(".notnan", P, P, D), _(".NOTNAN", P, P, D), _(".NotNan", P, P, D), _(".NoTNaN", P, P, D),
+    __("-.notnan", P, P, D), _("-.NOTNAN", P, P, D), _("-.NotNan", P, P, D), _("-.NoTNaN", P, P, D),
+    __("+.notnan", P, P, D), _("+.NOTNAN", P, P, D), _("+.NotNan", P, P, D), _("+.NoTNaN", P, P, D),
+    // bool
+    __("true", P, P, P),
+    __("false", P, P, P),
+    __("True", P, P, D),
+    __("False", P, P, D),
+    // dubious
+    __("+.notinf", P, P, D), _("+.:", S, S, D),
+    __("-.notinf", P, P, D), _("-:", S, S, D),
+    __(":", S, S, D), _(": ", S, S, D), _(":\t", S, S, D), _(":\n", S, S, D), _(":\r\n", S, S, D),
+    __("-", S, S, D), _("- ", S, S, D), _("-\t", S, S, D), _("-\n", S, S, D), _("-\r\n", S, S, D),
+    __("?", S, S, D), _("? ", S, S, D), _("?\t", S, S, D), _("?\n", S, S, D), _("?\r\n", S, S, D),
+    __(":a", P, P, D), _(":ab", P, P, D), _(":a b", P, P, D), _(":a\tb", P, P, D),
+    __("-a", P, P, D), _("-ab", P, P, D), _("-a b", P, P, D), _("-a\tb", P, P, D),
+    __("?a", P, P, D), _("?ab", P, P, D), _("?a b", P, P, D), _("?a\tb", P, P, D),
+    __(":a,", S, P, D), _(":ab,", S, P, D), _(":a\tb,", S, P, D),
+    __("-a,", S, P, D), _("-ab,", S, P, D), _("-a\tb,", S, P, D),
+    __("?a,", S, P, D), _("?ab,", S, P, D), _("?a\tb,", S, P, D),
+    __("b[c]d", S, P, D), _("b{c}d", S, P, D), _("b,c,d", S, P, D),
+    __("(0,1)", S, P, D), _("-0,1", S, P, D),
+    __("::", S, S, D), _(":: ", S, S, D), _("::\t", S, S, D),
+    __("--", P, P, D), _("-- ", S, S, D), _("--\t", S, S, D),
+    __("??", P, P, D), _("?? ", S, S, D), _("??\t", S, S, D),
+    // tags
+    __("!!str", S, S, D),
+    __("!str", S, S, D),
+    __("!<!foo>", S, S, D),
+    __("<!foo>", P, P, D),
+    __("<!foo> scalar", P, P, D),
+    // anchors
+    __("&notanchor", S, S, D),
+    // invalid characters at beginning
+    __("%invalidplain", S, S, D), _("but%validplain", P, P, D),
+    __("`invalidplain", S, S, D), _("but`validplain", P, P, D),
+    __("@invalidplain", S, S, D), _("but@validplain", P, P, D),
+    __("#invalidplain", S, S, D), _("but#validplain", P, P, D),
+    __(",invalidplain", S, S, D), _("but,validplain", S, P, D),
+    __("- invalidplain", S, S, D), _("but- validplain",     P, P, D), _("and -validplain", P, P, D),
+    /*                          */__("but-\nvalidplain",    P, P, D), _("and\n-validplain", P, P, D),
+    __(": invalidplain", S, S, D), _("also: invalidplain",  S, S, D), _("while :validplain", P, P, D),
+    /*                          */__("also:\ninvalidplain", S, S, D), _("while\n:validplain", P, P, D),
+    __("? invalidplain", S, S, D), _("but? validplain",     P, P, D), _("also ?validplain", P, P, D),
+    /*                          */__("but?\nvalidplain",    P, P, D), _("also\n?validplain", P, P, D),
+    __("# invalidplain", S, S, D), _("but# validplain",     P, P, D), _("while #invalidplain", S, S, D),
+    /*                          */__("but#\nvalidplain",    P, P, D), _("while\n#invalidplain", S, S, D),
+};
+std::string namefor(scalar_style_spec const& param)
+{
+    return c4::formatrs<std::string>("elm{}__line{}__entry{}",
+                                     fmt::zpad(param.elm, 3),
+                                     fmt::zpad(param.line, 3),
+                                     param.entry);
+}
+template<class T>
+std::string namefor(testing::TestParamInfo<T> const& pinfo)
+{
+    return namefor(pinfo.param);
+}
+
+struct TestScalarStyle : public testing::TestWithParam<scalar_style_spec> {};
+
+INSTANTIATE_TEST_SUITE_P(_, TestScalarStyle, testing::ValuesIn(scalars), namefor<scalar_style_spec>);
+
+struct showtype_ { NodeType ty; };
+showtype_ showtype(NodeType ty) { return {ty}; }
+size_t to_chars(substr buf, showtype_ s)
+{
+    size_t pos = s.ty.type_str(buf);
+    buf = buf.sub(pos < buf.len ? pos : buf.len);
+    pos += format(buf, "({})", s.ty.type);
+    return pos;
+}
+
+const csubstr plain_flow_invalid_at_beginning[] = {
+    csubstr(" "), csubstr("\t"), csubstr("\r"), csubstr("\n"),
+    csubstr("!"), csubstr("&"), csubstr("*"), csubstr(","),
+    csubstr("\""), csubstr("'"), csubstr("{"), csubstr("}"),
+};
+const csubstr plain_flow_invalid_in_bulk[] = {
+    csubstr(": "), csubstr(":\t"), csubstr(":\n"), csubstr(":\r"),
+    csubstr(" #"), csubstr("\t#"), csubstr("\n#"), csubstr("\r#"),
+    csubstr(","), csubstr("{"), csubstr("}"), csubstr("["), csubstr("]"),
+};
+const csubstr plain_flow_valid_in_bulk[] = {
+    csubstr(" :"), csubstr("\t:"), csubstr("\n:"), csubstr("\r\n:"),
+    csubstr("# "), csubstr("#\t"), csubstr("#\n"), csubstr("#\r"),
+};
+const csubstr plain_flow_invalid_at_end[] = {
+    csubstr(" "), csubstr("\t"), csubstr("\r\n"), csubstr("\n"),
+    csubstr(","), csubstr("{"), csubstr("}"), csubstr("["), csubstr("]"),
+    csubstr("# "), csubstr("#\t"), csubstr("#"),
+    csubstr(": "), csubstr(":\t"), csubstr(":"),
+};
+
+const csubstr plain_block_invalid_at_beginning[] = {
+    csubstr(" "), csubstr("\t"), csubstr("\r"), csubstr("\n"),
+    csubstr("!"), csubstr("&"), csubstr("*"), csubstr(","),
+    csubstr("\""), csubstr("'"), csubstr("{"), csubstr("}"),
+};
+const csubstr plain_block_invalid_in_bulk[] = {
+    csubstr(": "), csubstr(":\t"), csubstr(":\n"), csubstr(":\r"),
+    csubstr(" #"), csubstr("\t#"), csubstr("\n#"), csubstr("\r#"),
+};
+const csubstr plain_block_valid_in_bulk[] = {
+    csubstr(" :"), csubstr("\t:"), csubstr("\n:"), csubstr("\r:"),
+    csubstr("# "), csubstr("#\t"), csubstr("#\n"), csubstr("#\r"),
+};
+const csubstr plain_block_invalid_at_end[] = {
+    csubstr(" "), csubstr("\t"), csubstr("\r"), csubstr("\n"),
+    csubstr("# "), csubstr("#\t"), csubstr("#"),
+    csubstr(": "), csubstr(":\t"), csubstr(":"),
+};
+
+
+using ScalarBuildFn = bool (*)(std::string *buf, csubstr str, csubstr scalar, bool expect_valid);
+
+bool make_case_at_beginning(std::string *buf, csubstr str, csubstr scalar, bool expect_valid)
+{
+    (void)expect_valid;
+    catrs(buf, str, scalar);
+    return true;
+}
+
+bool make_case_in_bulk(std::string *buf, csubstr str, csubstr scalar, bool expect_valid)
+{
+    (void)expect_valid;
+    catrs(buf, scalar, str, scalar);
+    return true;
+}
+
+bool make_case_at_end(std::string *buf, csubstr str, csubstr scalar, bool expect_valid)
+{
+    (void)expect_valid;
+    catrs(buf, scalar, str);
+    return true;
+}
+
+
+#define SHOWPARAM(p, fmt, ...)                                      \
+    RYML_TRACE_FMT("test\n"                                         \
+                   "{}:{}: scalar=[{}]~~~{}~~~\n"                   \
+                   "{}:{}: " fmt,                                   \
+                   to_csubstr(__FILE__), (p).line,                  \
+                   (p).scalar.len, escaped_scalar((p).scalar),      \
+                   to_csubstr(__FILE__), (p).line, __VA_ARGS__)
+
+void test_plain_valid(scalar_style_spec const& p, bool flow, cspan<csubstr> cases, bool expected, ScalarBuildFn fn)
+{
+    if(p.style_flow != P || !p.scalar.len || p.scalar.first_not_of(" \n\t\r") == npos)
+        return;
+    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.type));
+    std::string buf;
+    size_t i = 0;
+    for(csubstr c : cases)
+    {
+        if(!fn(&buf, c, p.scalar, expected))
+            continue;
+        csubstr str = to_csubstr(buf);
+        bool ok = (expected == flow ? scalar_style_query_plain_flow(str)
+                   : scalar_style_query_plain_block(str));
+        ok = ok && (expected == scalar_style_query_plain(str, flow));
+        if(ok)
+            continue;
+        RYML_TRACE_FMT("case[{}/{}]='{}' scalar='{}' str='{}'", i++, cases.size(), escaped_scalar(c), escaped_scalar(p.scalar), escaped_scalar(str));
+        if(flow)
+        {
+            EXPECT_EQ(scalar_style_query_plain_flow(str), expected);
+            EXPECT_EQ(scalar_style_query_plain_flow(str),
+                      scalar_style_query_plain(str, flow));
+        }
+        else
+        {
+            EXPECT_EQ(scalar_style_query_plain_block(str), expected);
+            EXPECT_EQ(scalar_style_query_plain_block(str),
+                      scalar_style_query_plain(str, !flow));
+        }
+        break;
+    }
+}
+
+substr erase(substr buf, char c)
+{
+    size_t len = 0;
+    bool skip = false;
+    for(size_t i = 0; i < buf.len; ++i)
+    {
+        if(buf.str[i] != c)
+        {
+            if(skip)
+                buf.str[len++] = buf.str[i];
+        }
+        else
+        {
+            len = i;
+            skip = true;
+        }
+    }
+    buf.len = len;
+    return buf;
+}
+
+void compare_scalar(csubstr expected, csubstr actual)
+{
+    if(expected != actual)
+    {
+        RYML_TRACE_FMT("actual  ={}", escaped_scalar(actual));
+        RYML_TRACE_FMT("expected={}", escaped_scalar(expected));
+        if(expected.find('\r') == csubstr::npos)
+        {
+            EXPECT_EQ(expected, actual);
+        }
+        else
+        {
+            std::string filtered_(expected.begin(), expected.end());
+            csubstr filtered = erase(to_substr(filtered_), '\r');
+            RYML_TRACE_FMT("filtered={}", escaped_scalar(filtered));
+            EXPECT_EQ(filtered, actual);
+        }
+    }
+}
+
+void test_scalar_roundtrip_as_root(scalar_style_spec const& p, NodeType expected_style)
+{
+    SHOWPARAM(p, "roundtrip_as_root", 0);
+    csubstr scalar = p.scalar;
+    if(!scalar.str || !scalar.len || scalar.first_not_of(" \n\t\r") == npos)
+        return;
+    Tree t;
+    t.rootref() = scalar;
+    std::string emitted = emitrs_yaml<std::string>(t);
+    const Tree parsed = parse_in_arena(to_csubstr(emitted));
+    ConstNodeRef r = parsed.rootref();
+    bool fail = false;
+    if(r.has_val())
+    {
+        compare_scalar(scalar, r.val());
+        EXPECT_TRUE(r.type().is_val_styled()); // style is set on the roundtrip
+        NodeType actual_style = r.type() & expected_style;
+        RYML_COMPARE_NODE_TYPE(expected_style, actual_style, ==, EQ);
+    }
+    else
+    {
+        fail = true;
+    }
+    if(fail || testing::Test::HasFailure())
+    {
+        printf("emitted=~~~\n%s\n~~~\n", emitted.c_str());
+        print_tree("orig", t);
+        print_tree("roundtrip", parsed);
+    }
+    if(fail)
+        FAIL() << "not a val: ~~~" << emitted << "~~~";
+}
+
+void test_scalar_roundtrip_on_seq(scalar_style_spec const& p, NodeType seq_style, NodeType expected_style)
+{
+    csubstr scalar = p.scalar;
+    if(!scalar.len)
+        return;
+    SHOWPARAM(p, "roundtrip_on_seq", 0);
+    Tree t;
+    NodeRef r = t.rootref();
+    r |= SEQ|seq_style;
+    for(size_t i = 0; i < 4; ++i)
+    {
+        r.append_child() = scalar;
+        EXPECT_FALSE(r.type().is_val_styled()); // no style is set
+    }
+    std::string emitted = emitrs_yaml<std::string>(t);
+    const Tree parsed = parse_in_arena(to_csubstr(emitted));
+    for(ConstNodeRef ch : parsed.rootref().children())
+    {
+        compare_scalar(scalar, ch.val());
+        EXPECT_TRUE(ch.type().is_val_styled()); // style is set on the roundtrip
+        NodeType actual_style = ch.type() & expected_style;
+        RYML_COMPARE_NODE_TYPE(expected_style, actual_style, ==, EQ);
+    }
+    if(testing::Test::HasFailure())
+    {
+        printf("emitted=~~~\n%s\n~~~\n", catrs<std::string>(escaped_scalar(to_csubstr(emitted))).c_str());
+        print_tree("orig", t);
+        print_tree("roundtrip", parsed);
+    }
+}
+
+void test_scalar_roundtrip_on_map(scalar_style_spec const& p, NodeType map_style, NodeType expected_style_key, NodeType expected_style_val)
+{
+    csubstr scalar = p.scalar;
+    if(!scalar.str)
+        return;
+    SHOWPARAM(p, "roundtrip_on_map", 0);
+    Tree t;
+    NodeRef r = t.rootref();
+    r |= MAP|map_style;
+    NodeRef vals = r["vals"];
+    NodeRef keys = r["keys"];
+    vals |= MAP|map_style;
+    keys |= MAP|map_style;
+    csubstr names[] = {"0", "1", "2", "3"};
+    bool valid_as_key = (npos == p.scalar.find('\n'));
+    for(csubstr name : names)
+    {
+        NodeRef k = keys.append_child();
+        NodeRef v = vals.append_child();
+        k.set_key(valid_as_key ? scalar : name);
+        v.set_key(name);
+        k.set_val(name);
+        v.set_val(scalar);
+        EXPECT_FALSE(k.type().is_key_styled()); // no style is set
+        EXPECT_FALSE(v.type().is_val_styled()); // no style is set
+    }
+    std::string emitted = emitrs_yaml<std::string>(t);
+    _c4dbgpf("scalar=~~~{}~~~", escaped_scalar(to_csubstr(scalar), true));
+    _c4dbgpf("emitted=~~~\n{}\n~~~", escaped_scalar(to_csubstr(emitted), true));
+    const Tree parsed = parse_in_arena(to_csubstr(emitted));
+    if(valid_as_key)
+    {
+        for(ConstNodeRef ch : parsed["keys"].children())
+        {
+            compare_scalar(scalar, ch.key());
+            EXPECT_TRUE(ch.type().is_key_styled()); // style is set on the roundtrip
+            NodeType actual_style = ch.type() & expected_style_key;
+            RYML_COMPARE_NODE_TYPE(expected_style_key, actual_style, ==, EQ);
+        }
+    }
+    for(ConstNodeRef ch : parsed["vals"].children())
+    {
+        compare_scalar(scalar, ch.val());
+        EXPECT_TRUE(ch.type().is_val_styled()); // style is set on the roundtrip
+        NodeType actual_style = ch.type() & expected_style_val;
+        RYML_COMPARE_NODE_TYPE(expected_style_val, actual_style, ==, EQ);
+    }
+    if(testing::Test::HasFailure())
+    {
+        printf("scalar=~~~\n%.*s\n~~~\n", (int)scalar.len, scalar.str);
+        printf("emitted=~~~\n%s\n~~~\n", emitted.c_str());
+        print_tree("orig", t);
+        print_tree("roundtrip", parsed);
+    }
+}
+
+bool flow = true;
+bool block = false;
+
+} // namespace
+
+TEST_P(TestScalarStyle, query_plain_flow)
+{
+    scalar_style_spec const& p = GetParam();
+    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.type));
+    EXPECT_EQ(scalar_style_query_plain_flow(p.scalar), p.style_flow == P);
+    EXPECT_EQ(scalar_style_query_plain_flow(p.scalar),
+              scalar_style_query_plain(p.scalar, flow));
+}
+
+TEST_P(TestScalarStyle, query_plain_flow_invalid_at_beginning)
+{
+    test_plain_valid(GetParam(), flow, plain_flow_invalid_at_beginning, false,
+                     make_case_at_beginning);
+}
+
+TEST_P(TestScalarStyle, query_plain_flow_invalid_in_bulk)
+{
+    test_plain_valid(GetParam(), flow, plain_flow_invalid_in_bulk, false,
+                     make_case_in_bulk);
+}
+
+TEST_P(TestScalarStyle, query_plain_flow_valid_in_bulk)
+{
+    test_plain_valid(GetParam(), flow, plain_flow_valid_in_bulk, true,
+                     make_case_in_bulk);
+}
+
+TEST_P(TestScalarStyle, query_plain_flow_invalid_at_end)
+{
+    test_plain_valid(GetParam(), flow, plain_flow_invalid_at_end, false,
+                     make_case_at_end);
+}
+
+
+//-----------------------------------------------------------------------------
+// block
+
+TEST_P(TestScalarStyle, query_plain_block)
+{
+    scalar_style_spec const& p = GetParam();
+    SHOWPARAM(p, "expected_block={}", showtype(p.style_block.type));
+    EXPECT_EQ(scalar_style_query_plain_block(p.scalar), p.style_block == P);
+    EXPECT_EQ(scalar_style_query_plain_block(p.scalar),
+              scalar_style_query_plain(p.scalar, block));
+}
+
+TEST_P(TestScalarStyle, query_plain_block_invalid_at_beginning)
+{
+    test_plain_valid(GetParam(), block, plain_block_invalid_at_beginning, false,
+                     make_case_at_beginning);
+}
+
+TEST_P(TestScalarStyle, query_plain_block_invalid_in_bulk)
+{
+    test_plain_valid(GetParam(), block, plain_block_invalid_in_bulk, false,
+                     make_case_in_bulk);
+}
+
+TEST_P(TestScalarStyle, query_plain_block_valid_in_bulk)
+{
+    test_plain_valid(GetParam(), block, plain_block_valid_in_bulk, true,
+                     make_case_in_bulk);
+}
+
+TEST_P(TestScalarStyle, query_plain_block_invalid_at_end)
+{
+    test_plain_valid(GetParam(), block, plain_block_invalid_at_end, false,
+                     make_case_at_end);
+}
+
+
+//-----------------------------------------------------------------------------
+// choose
+
+TEST_P(TestScalarStyle, choose_flow)
+{
+    scalar_style_spec const& p = GetParam();
+    NodeType actual = scalar_style_choose_flow(p.scalar);
+    NodeType expected = p.style_flow.type;
+    SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
+    RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
+}
+
+TEST_P(TestScalarStyle, choose_block)
+{
+    scalar_style_spec const& p = GetParam();
+    NodeType actual = scalar_style_choose_block(p.scalar);
+    NodeType expected = p.style_block.type;
+    SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
+    RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
+}
+
+TEST_P(TestScalarStyle, choose_json)
+{
+    scalar_style_spec const& p = GetParam();
+    NodeType actual = scalar_style_json_choose(p.scalar);
+    NodeType expected = p.style_json.type;
+    SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
+    RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
+}
+
+
+//-----------------------------------------------------------------------------
+
+TEST_P(TestScalarStyle, roundtrip_as_root)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_as_root(p, p.style_block & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_seq_flow_sl)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_seq(p, FLOW_SL, p.style_flow & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_seq_flow_ml)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_seq(p, FLOW_ML, p.style_flow & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_seq_block)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_seq(p, BLOCK, p.style_block & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_map_flow_sl)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_map(p, FLOW_SL,
+                                 p.style_flow & KEY_STYLE,
+                                 p.style_flow & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_map_flow_ml)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_map(p, FLOW_ML,
+                                 p.style_flow & KEY_STYLE,
+                                 p.style_flow & VAL_STYLE);
+}
+
+TEST_P(TestScalarStyle, roundtrip_map_block)
+{
+    scalar_style_spec const& p = GetParam();
+    test_scalar_roundtrip_on_map(p, BLOCK,
+                                 p.style_block & KEY_STYLE,
+                                 p.style_block & VAL_STYLE);
+}
+
+C4_SUPPRESS_WARNING_GCC_CLANG_POP
+C4_SUPPRESS_WARNING_MSVC_POP
 
 } // namespace yml
 } // namespace c4

--- a/test/test_number.cpp
+++ b/test/test_number.cpp
@@ -255,7 +255,8 @@ TEST(number, inf_0)
     EXPECT_EQ(t[1].val(), ".inf");
     EXPECT_EQ(t[2].val(), "-.inf");
     EXPECT_EQ(t[3].val(), "-.inf");
-    EXPECT_EQ(scalar_style_choose("-.inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_flow("-.inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_block("-.inf"), SCALAR_PLAIN);
     EXPECT_EQ(emitrs_yaml<std::string>(t),
               R"(- .inf
 - .inf
@@ -514,21 +515,21 @@ TEST(number, github_312__proposed_8e888_cannot_be_converted)
 
 TEST(number, github_312_535__json_styles_for_special_values)
 {
-    EXPECT_EQ(scalar_style_json_choose("nan"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("infinity"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-infinity"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".nan"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".NaN"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".NAN"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-.inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".Inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-.Inf"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose(".INF"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_json_choose("-.INF"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("nan"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("infinity"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("-infinity"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".nan"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".NaN"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".NAN"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("-inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("-.inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".Inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("-.Inf"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json(".INF"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_json("-.INF"), SCALAR_PLAIN);
 }
 
 TEST(number, github_312_535)

--- a/test/test_serialize.cpp
+++ b/test/test_serialize.cpp
@@ -84,9 +84,9 @@ TEST(serialize, type_as_str)
 
     char buf[256];
     c4::csubstr ret = c4::yml::emit_yaml(t, buf);
-    EXPECT_EQ(ret, R"(v2: '(10,11)'
-v3: '(100,101,102)'
-v4: '(1000,1001,1002,1003)'
+    EXPECT_EQ(ret, R"(v2: (10,11)
+v3: (100,101,102)
+v4: (1000,1001,1002,1003)
 )");
 }
 } // namespace foo
@@ -555,12 +555,18 @@ TEST(serialize, issue442_50)
 }
 TEST(serialize, issue442_60)
 {
-    EXPECT_TRUE(scalar_style_query_plain("123"));
-    EXPECT_TRUE(scalar_style_query_plain("-123"));
-    EXPECT_TRUE(scalar_style_query_plain("+123"));
-    EXPECT_EQ(scalar_style_choose("123"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-123"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+123"), SCALAR_PLAIN);
+    EXPECT_TRUE(scalar_style_query_plain_flow("123"));
+    EXPECT_TRUE(scalar_style_query_plain_flow("-123"));
+    EXPECT_TRUE(scalar_style_query_plain_flow("+123"));
+    EXPECT_EQ(scalar_style_choose_flow("123"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_flow("-123"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_flow("+123"), SCALAR_PLAIN);
+    EXPECT_TRUE(scalar_style_query_plain_block("123"));
+    EXPECT_TRUE(scalar_style_query_plain_block("-123"));
+    EXPECT_TRUE(scalar_style_query_plain_block("+123"));
+    EXPECT_EQ(scalar_style_choose_block("123"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_block("-123"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_block("+123"), SCALAR_PLAIN);
     {
         Tree tree;
         tree.rootref() << "123";
@@ -584,12 +590,18 @@ TEST(serialize, issue442_60)
 }
 TEST(serialize, issue442_61)
 {
-    EXPECT_TRUE(scalar_style_query_plain("2.35e-10"));
-    EXPECT_TRUE(scalar_style_query_plain("-2.35e-10"));
-    EXPECT_TRUE(scalar_style_query_plain("+2.35e-10"));
-    EXPECT_EQ(scalar_style_choose("2.35e-10"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("-2.35e-10"), SCALAR_PLAIN);
-    EXPECT_EQ(scalar_style_choose("+2.35e-10"), SCALAR_PLAIN);
+    EXPECT_TRUE(scalar_style_query_plain_flow("2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain_flow("-2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain_flow("+2.35e-10"));
+    EXPECT_EQ(scalar_style_choose_flow("2.35e-10"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_flow("-2.35e-10"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_flow("+2.35e-10"), SCALAR_PLAIN);
+    EXPECT_TRUE(scalar_style_query_plain_block("2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain_block("-2.35e-10"));
+    EXPECT_TRUE(scalar_style_query_plain_block("+2.35e-10"));
+    EXPECT_EQ(scalar_style_choose_block("2.35e-10"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_block("-2.35e-10"), SCALAR_PLAIN);
+    EXPECT_EQ(scalar_style_choose_block("+2.35e-10"), SCALAR_PLAIN);
     {
         Tree tree;
         tree.rootref() << 2.35e-10;


### PR DESCRIPTION
- this enables stable-style roundtrips of block-mode plain scalars with characters invalid in flow mode:
  ```yaml
  # these scalars were previously emitted as single-quoted style
  - doe: a deer, a female deer
  - (10,11)
  - also scalars containing [] and {}
  ```
  - `scalar_style_choose()` was split into `scalar_style_choose_{flow,block}()`
  - `scalar_style_query_plain()` was split into `scalar_style_query_plain_{flow,block}()`
  - `NodeType::type_str(NodeType,flags)`: remove zero-termination, use common approach of returning required size
  - Add `NodeType::type_str_sub()`