### PR TITLE
API cleanup: writers and error_on_excess

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PFX_TARGET: ryml-
   PROJ_PFX_CMAKE: RYML_

--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -11,7 +11,7 @@ defaults:
     - master
   pull_request:
     branches:
-    - '*'
+    - '**'
 env:
   PROJ_PKG_NAME: rapidyaml-
   PROJ_PFX_TARGET: ryml-

--- a/.github/workflows/ys/common.ys
+++ b/.github/workflows/ys/common.ys
@@ -18,7 +18,7 @@ defn workflow-setup(name=nil overrides={})::
       push:
         branches: [master]
       pull_request:
-        branches: ['*']
+        branches: ['**']
   env:
     PROJ_PKG_NAME: rapidyaml-
     PROJ_PFX_TARGET: ryml-

--- a/bm/bm_common.hpp
+++ b/bm/bm_common.hpp
@@ -10,8 +10,6 @@
 #include <vector>
 #include <iostream>
 
-#include <benchmark/benchmark.h>
-
 // warning suppressions for thirdparty code
 #if defined(_MSC_VER)
 #   pragma warning(push)
@@ -38,6 +36,12 @@
 #   endif
 #elif defined(__GNUC__)
 #   pragma GCC diagnostic push
+#   if __GNUC__ >= 7
+#   pragma GCC diagnostic ignored "-Wduplicated-branches"
+#   endif
+#   if __GNUC__ >= 6
+#   pragma GCC diagnostic ignored "-Wunused-const-variable"
+#   endif
 #   pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #   pragma GCC diagnostic ignored "-Wshadow"
 #   pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -52,6 +56,7 @@
 #       pragma GCC diagnostic ignored "-Wclass-memaccess" // rapidjson/document.h:1952:24
 #   endif
 #endif
+#include <benchmark/benchmark.h>
 #include "./libyaml.hpp"
 #include <rapidjson/document.h>
 #include <rapidjson/writer.h>

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,0 +1,3 @@
+- [PR#616](https://github.com/biojppm/rapidyaml/pull/616): Clean emit API **[BREAKING]**
+  - `WriterFile` and `WriterOStream` no longer track the number of emitted bytes.
+  - `error_on_excess` is now used in the emit-to-buffer overloads, and no longer in the main `Emitter::emit_as()` driver function.

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -4285,10 +4285,7 @@ void sample_emit_to_file()
     const ryml::Tree tree = ryml::parse_in_arena(yml);
     // this is emitting to stdout, but of course you can pass in any
     // FILE* obtained from fopen()
-    size_t len = ryml::emit_yaml(tree, tree.root_id(), stdout);
-    // the return value is the number of characters that were written
-    // to the file
-    CHECK(len == yml.len);
+    ryml::emit_yaml(tree, tree.root_id(), stdout);
 }
 
 

--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -104,6 +104,50 @@ static_assert(RYML_LOGBUF_SIZE < RYML_ERRMSG_SIZE, "invalid size");
  * @see sample::sample_emit_style
  */
 
+/** @defgroup doc_emit_to_buffer Emit to a memory buffer
+ * @ingroup doc_emit
+ */
+/** @defgroup doc_emit_to_buffer_from_root Emit full tree
+ * @ingroup doc_emit_to_buffer
+ */
+/** @defgroup doc_emit_to_buffer_from_node_id Emit from nested node id
+ * @ingroup doc_emit_to_buffer
+ */
+/** @defgroup doc_emit_to_buffer_from_noderef Emit from ConstNodeRef
+ * @ingroup doc_emit_to_buffer
+ */
+
+/** @defgroup doc_emit_to_container Emit to a contiguous memory container like std::string or std::vector<char>
+ * @ingroup doc_emit
+ */
+/** @defgroup doc_emit_to_container_from_root Emit full tree
+ * @ingroup doc_emit_to_container
+ */
+/** @defgroup doc_emit_to_container_from_node_id Emit from nested node id
+ * @ingroup doc_emit_to_container
+ */
+/** @defgroup doc_emit_to_container_from_noderef Emit from ConstNodeRef
+ * @ingroup doc_emit_to_container
+ */
+
+/** @defgroup doc_emit_to_file Emit to file
+ * @ingroup doc_emit
+ */
+/** @defgroup doc_emit_to_file_from_root Emit full tree
+ * @ingroup doc_emit_to_file
+ */
+/** @defgroup doc_emit_to_file_from_node_id Emit from nested node id
+ * @ingroup doc_emit_to_file
+ */
+/** @defgroup doc_emit_to_file_from_noderef Emit from ConstNodeRef
+ * @ingroup doc_emit_to_file
+ */
+
+/** @defgroup doc_emit_to_ostream Emit to an STL-like ostream
+ * @ingroup doc_emit
+ */
+
+
 /** @defgroup doc_node_type Node types
  */
 

--- a/src/c4/yml/emit.def.hpp
+++ b/src/c4/yml/emit.def.hpp
@@ -17,12 +17,12 @@ namespace c4 {
 namespace yml {
 
 template<class Writer>
-substr Emitter<Writer>::emit_as(EmitType_e type, Tree const& tree, id_type id, bool error_on_excess)
+void Emitter<Writer>::emit_as(EmitType_e type, Tree const& tree, id_type id)
 {
     if(tree.empty())
     {
         _RYML_ASSERT_BASIC_(tree.callbacks(), id == NONE);
-        return {};
+        return;
     }
     if(id == NONE)
         id = tree.root_id();
@@ -40,7 +40,6 @@ substr Emitter<Writer>::emit_as(EmitType_e type, Tree const& tree, id_type id, b
     else
         _RYML_ERR_BASIC_(m_tree->callbacks(), "unknown emit type"); // LCOV_EXCL_LINE
     m_tree = nullptr;
-    return this->Writer::_get(error_on_excess);
 }
 
 /** @cond dev */

--- a/src/c4/yml/emit.hpp
+++ b/src/c4/yml/emit.hpp
@@ -19,43 +19,31 @@
 C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wold-style-cast")
 // NOLINTBEGIN(modernize-avoid-c-style-cast)
 
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-
 namespace c4 {
 namespace yml {
 
-/** @addtogroup doc_emit
- *
- * @{
- */
-
+/** @cond dev */
 // fwd declarations
 template<class Writer> class Emitter;
 template<class OStream>
 using EmitterOStream = Emitter<WriterOStream<OStream>>;
 using EmitterFile = Emitter<WriterFile>;
 using EmitterBuf  = Emitter<WriterBuf>;
-
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-
 /** Specifies the type of content to emit */
 typedef enum { // NOLINT
     EMIT_YAML = 0, ///< emit YAML
     EMIT_JSON = 1, ///< emit JSON
 } EmitType_e;
+/** @endcond */
 
 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** A lightweight object containing options to be used when emitting. */
+/** A lightweight object containing options to be used when emitting.
+ * @ingroup doc_emit
+ * */
 struct EmitOptions
 {
 public:
@@ -198,7 +186,9 @@ private:
 //-----------------------------------------------------------------------------
 
 /** A stateful emitter, for use with a writer such as @ref WriterBuf,
- * @ref WriterFile, or @ref WriterOStream */
+ * @ref WriterFile, or @ref WriterOStream
+ * @ingroup doc_emit
+ */
 template<class Writer>
 class Emitter : public Writer
 {
@@ -210,7 +200,7 @@ public:
      * @param args arguments to be forwarded to the constructor of the writer.
      */
     template<class ...WriterArgs>
-    Emitter(EmitOptions const& opts, WriterArgs &&...args)
+    Emitter(EmitOptions const& opts, WriterArgs &&...args) noexcept
         : Writer(std::forward<WriterArgs>(args)...)
         , m_tree()
         , m_opts(opts)
@@ -225,7 +215,7 @@ public:
      * @param args arguments to be forwarded to the constructor of the writer.
      */
     template<class ...WriterArgs>
-    Emitter(WriterArgs &&...args)
+    Emitter(WriterArgs &&...args) noexcept
         : Writer(std::forward<WriterArgs>(args)...)
         , m_tree()
         , m_opts()
@@ -252,23 +242,19 @@ public:
      * @param type specify what to emit (YAML or JSON)
      * @param t the tree to emit
      * @param id the id of the node to emit
-     * @param error_on_excess when true, an error is raised when the
-     *        output buffer is too small for the emitted YAML/JSON
-     * */
-    substr emit_as(EmitType_e type, Tree const& t, id_type id, bool error_on_excess);
+     */
+    void emit_as(EmitType_e type, Tree const& t, id_type id);
     /** emit starting at the root node */
-    substr emit_as(EmitType_e type, Tree const& t, bool error_on_excess=true)
+    void emit_as(EmitType_e type, Tree const& t)
     {
-        if(t.empty())
-            return {};
-        return this->emit_as(type, t, t.root_id(), error_on_excess);
+        return this->emit_as(type, t, t.root_id());
     }
     /** emit starting at the given node */
-    substr emit_as(EmitType_e type, ConstNodeRef const& n, bool error_on_excess=true)
+    void emit_as(EmitType_e type, ConstNodeRef const& n)
     {
         if(!n.readable())
-            return {};
-        return this->emit_as(type, *n.tree(), n.id(), error_on_excess);
+            return;
+        return this->emit_as(type, *n.tree(), n.id());
     }
 
 public:
@@ -515,107 +501,121 @@ private:
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** @defgroup doc_emit_to_file Emit to file
+// emit from tree and node id -----------------------
+
+/** @addtogroup doc_emit_to_file_from_node_id
  *
  * @{
  */
 
-
-// emit from tree and node id -----------------------
-
 /** (1) emit YAML to the given file, starting at the given node. A null
- * file defaults to stdout. Return the number of bytes written. */
-inline size_t emit_yaml(Tree const& t, id_type id, EmitOptions const& opts, FILE *f)
+ * file defaults to stdout. */
+inline void emit_yaml(Tree const& t, id_type id, EmitOptions const& opts, FILE *f)
 {
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, t, id);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_yaml(Tree const& t, id_type id, FILE *f)
+inline void emit_yaml(Tree const& t, id_type id, FILE *f)
 {
     EmitterFile em(f);
-    return em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, t, id);
 }
+
 /** (1) emit JSON to the given file, starting at the given node. A null
- * file defaults to stdout.  Return the number of bytes written. */
-inline size_t emit_json(Tree const& t, id_type id, EmitOptions const& opts, FILE *f)
+ * file defaults to stdout. */
+inline void emit_json(Tree const& t, id_type id, EmitOptions const& opts, FILE *f)
 {
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, t, id);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_json(Tree const& t, id_type id, FILE *f)
+inline void emit_json(Tree const& t, id_type id, FILE *f)
 {
     EmitterFile em(f);
-    return em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, t, id);
 }
+
+/** @} */
 
 
 // emit from root -------------------------
 
-/** (1) emit YAML to the given file, starting at the root node. A null file defaults to stdout.
- * Return the number of bytes written. */
-inline size_t emit_yaml(Tree const& t, EmitOptions const& opts, FILE *f=nullptr)
+/** @addtogroup doc_emit_to_file_from_root
+ *
+ * @{
+ */
+
+/** (1) emit YAML to the given file, starting at the root node. A null file defaults to stdout. */
+inline void emit_yaml(Tree const& t, EmitOptions const& opts, FILE *f=nullptr)
 {
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, t);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_yaml(Tree const& t, FILE *f=nullptr)
+inline void emit_yaml(Tree const& t, FILE *f=nullptr)
 {
     EmitterFile em(f);
-    return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, t);
 }
-/** (1) emit JSON to the given file. A null file defaults to stdout.
- * Return the number of bytes written. */
-inline size_t emit_json(Tree const& t, EmitOptions const& opts, FILE *f=nullptr)
+
+/** (1) emit JSON to the given file. A null file defaults to stdout. */
+inline void emit_json(Tree const& t, EmitOptions const& opts, FILE *f=nullptr)
 {
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, t);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_json(Tree const& t, FILE *f=nullptr)
+inline void emit_json(Tree const& t, FILE *f=nullptr)
 {
     EmitterFile em(f);
-    return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, t);
 }
+
+/** @} */
 
 
 // emit from ConstNodeRef ------------------------
 
+/** @addtogroup doc_emit_to_file_from_noderef
+ *
+ * @{
+ */
+
 /** (1) emit YAML to the given file. A null file defaults to stdout.
  * Return the number of bytes written. */
-inline size_t emit_yaml(ConstNodeRef const& r, EmitOptions const& opts, FILE *f=nullptr)
+inline void emit_yaml(ConstNodeRef const& r, EmitOptions const& opts, FILE *f=nullptr)
 {
     if(!r.readable())
-        return {};
+        return;
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_YAML, r, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, r);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_yaml(ConstNodeRef const& r, FILE *f=nullptr)
+inline void emit_yaml(ConstNodeRef const& r, FILE *f=nullptr)
 {
     if(!r.readable())
-        return {};
+        return;
     EmitterFile em(f);
-    return em.emit_as(EMIT_YAML, r, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_YAML, r);
 }
+
 /** (1) emit JSON to the given file. A null file defaults to stdout.
  * Return the number of bytes written. */
-inline size_t emit_json(ConstNodeRef const& r, EmitOptions const& opts, FILE *f=nullptr)
+inline void emit_json(ConstNodeRef const& r, EmitOptions const& opts, FILE *f=nullptr)
 {
     if(!r.readable())
-        return {};
+        return;
     EmitterFile em(opts, f);
-    return em.emit_as(EMIT_JSON, r, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, r);
 }
 /** (2) like (1), but use default emit options */
-inline size_t emit_json(ConstNodeRef const& r, FILE *f=nullptr)
+inline void emit_json(ConstNodeRef const& r, FILE *f=nullptr)
 {
     if(!r.readable())
-        return {};
+        return;
     EmitterFile em(f);
-    return em.emit_as(EMIT_JSON, r, /*error_on_excess*/true).len;
+    em.emit_as(EMIT_JSON, r);
 }
 
 /** @} */
@@ -623,10 +623,11 @@ inline size_t emit_json(ConstNodeRef const& r, FILE *f=nullptr)
 
 //-----------------------------------------------------------------------------
 
-/** @defgroup doc_emit_to_ostream Emit to an STL-like ostream
+/** @addtogroup doc_emit_to_ostream
  *
  * @{
  */
+
 
 /** emit YAML to an STL-like ostream */
 template<class OStream>
@@ -649,14 +650,14 @@ inline OStream& operator<< (OStream& s, ConstNodeRef const& n)
     return s;
 }
 
-/** mark a tree or node to be emitted as yaml when using @ref
- * operator<<, with options. For example:
+/** tag type to mark a tree or node to be emitted as yaml when using
+ * @ref operator<<, with options. For example:
  *
  * ```cpp
  * Tree t = parse_in_arena("{foo: bar}");
  * std::cout << t; // emits YAML
  * std::cout << as_yaml(t); // emits YAML, same as above
- * std::cout << as_yaml(t, EmitOptions().max_depth(10)); // emits JSON with a max tree depth
+ * std::cout << as_yaml(t, EmitOptions{}.flow_spc(true)); // emits YAML forcing spaces after flow commas
  * ```
  *
  * @see @ref operator<< */
@@ -670,14 +671,14 @@ struct as_json
     as_json(ConstNodeRef const& n, EmitOptions const& opts={}) : tree(n.tree()), node(n.id()), options(opts) {}
 };
 
-/** mark a tree or node to be emitted as yaml when using @ref
- * operator<< . For example:
+/** tag type to mark a tree or node to be emitted as yaml when using
+ * @ref operator<< . For example:
  *
  * ```cpp
  * Tree t = parse_in_arena("{foo: bar}");
  * std::cout << t; // emits YAML
  * std::cout << as_json(t); // emits JSON
- * std::cout << as_json(t, EmitOptions().max_depth(10)); // emits JSON with a max tree depth
+ * std::cout << as_json(t, EmitOptions{}.flow_spc(true)); // emits JSON forcing spaces after flow commas
  * ```
  *
  * @see @ref operator<< */
@@ -698,7 +699,7 @@ inline OStream& operator<< (OStream& s, as_json const& j)
     if(!j.tree || j.tree->empty())
         return s;
     EmitterOStream<OStream> em(j.options, s);
-    em.emit_as(EMIT_JSON, *j.tree, j.node != NONE ? j.node : j.tree->root_id(), true);
+    em.emit_as(EMIT_JSON, *j.tree, j.node != NONE ? j.node : j.tree->root_id());
     return s;
 }
 
@@ -709,7 +710,7 @@ inline OStream& operator<< (OStream& s, as_yaml const& y)
     if(!y.tree || y.tree->empty())
         return s;
     EmitterOStream<OStream> em(y.options, s);
-    em.emit_as(EMIT_YAML, *y.tree, y.node != NONE ? y.node : y.tree->root_id(), true);
+    em.emit_as(EMIT_YAML, *y.tree, y.node != NONE ? y.node : y.tree->root_id());
     return s;
 }
 
@@ -718,7 +719,7 @@ inline OStream& operator<< (OStream& s, as_yaml const& y)
 
 //-----------------------------------------------------------------------------
 
-/** @defgroup doc_emit_to_buffer Emit to memory buffer
+/** @addtogroup doc_emit_to_buffer_from_node_id
  *
  * @{
  */
@@ -737,14 +738,17 @@ inline OStream& operator<< (OStream& s, as_yaml const& y)
 inline substr emit_yaml(Tree const& t, id_type id, EmitOptions const& opts, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_YAML, t, id, error_on_excess);
+    em.emit_as(EMIT_YAML, t, id);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_yaml(Tree const& t, id_type id, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_YAML, t, id, error_on_excess);
+    em.emit_as(EMIT_YAML, t, id);
+    return em._get(error_on_excess);
 }
+
 /** (1) emit JSON to the given buffer. Return a substr trimmed to the emitted JSON.
  * @param t the tree to emit.
  * @param id the node where to start emitting.
@@ -757,17 +761,26 @@ inline substr emit_yaml(Tree const& t, id_type id, substr buf, bool error_on_exc
 inline substr emit_json(Tree const& t, id_type id, EmitOptions const& opts, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_JSON, t, id, error_on_excess);
+    em.emit_as(EMIT_JSON, t, id);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_json(Tree const& t, id_type id, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_JSON, t, id, error_on_excess);
+    em.emit_as(EMIT_JSON, t, id);
+    return em._get(error_on_excess);
 }
+
+/** @} */
 
 
 // emit from root -------------------------
+
+/** @addtogroup doc_emit_to_buffer_from_root
+ *
+ * @{
+ */
 
 /** (1) emit YAML to the given buffer. Return a substr trimmed to the emitted YAML.
  * @param t the tree; will be emitted from the root node.
@@ -780,14 +793,17 @@ inline substr emit_json(Tree const& t, id_type id, substr buf, bool error_on_exc
 inline substr emit_yaml(Tree const& t, EmitOptions const& opts, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_YAML, t, error_on_excess);
+    em.emit_as(EMIT_YAML, t);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_yaml(Tree const& t, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_YAML, t, error_on_excess);
+    em.emit_as(EMIT_YAML, t);
+    return em._get(error_on_excess);
 }
+
 /** (1) emit JSON to the given buffer. Return a substr trimmed to the emitted JSON.
  * @param t the tree; will be emitted from the root node.
  * @param opts emit options.
@@ -799,17 +815,26 @@ inline substr emit_yaml(Tree const& t, substr buf, bool error_on_excess=true)
 inline substr emit_json(Tree const& t, EmitOptions const& opts, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_JSON, t, error_on_excess);
+    em.emit_as(EMIT_JSON, t);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_json(Tree const& t, substr buf, bool error_on_excess=true)
 {
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_JSON, t, error_on_excess);
+    em.emit_as(EMIT_JSON, t);
+    return em._get(error_on_excess);
 }
+
+/** @} */
 
 
 // emit from ConstNodeRef ------------------------
+
+/** @addtogroup doc_emit_to_buffer_from_noderef
+ *
+ * @{
+ */
 
 /** (1) emit YAML to the given buffer. Return a substr trimmed to the emitted YAML.
  * @param r the starting node.
@@ -824,7 +849,8 @@ inline substr emit_yaml(ConstNodeRef const& r, EmitOptions const& opts, substr b
     if(!r.readable())
         return {};
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_YAML, r, error_on_excess);
+    em.emit_as(EMIT_YAML, r);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_yaml(ConstNodeRef const& r, substr buf, bool error_on_excess=true)
@@ -832,8 +858,10 @@ inline substr emit_yaml(ConstNodeRef const& r, substr buf, bool error_on_excess=
     if(!r.readable())
         return {};
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_YAML, r, error_on_excess);
+    em.emit_as(EMIT_YAML, r);
+    return em._get(error_on_excess);
 }
+
 /** (1) emit JSON to the given buffer. Return a substr trimmed to the emitted JSON.
  * @param r the starting node.
  * @param buf the output buffer.
@@ -847,7 +875,8 @@ inline substr emit_json(ConstNodeRef const& r, EmitOptions const& opts, substr b
     if(!r.readable())
         return {};
     EmitterBuf em(opts, buf);
-    return em.emit_as(EMIT_JSON, r, error_on_excess);
+    em.emit_as(EMIT_JSON, r);
+    return em._get(error_on_excess);
 }
 /** (2) like (1), but use default emit options */
 inline substr emit_json(ConstNodeRef const& r, substr buf, bool error_on_excess=true)
@@ -855,18 +884,21 @@ inline substr emit_json(ConstNodeRef const& r, substr buf, bool error_on_excess=
     if(!r.readable())
         return {};
     EmitterBuf em(buf);
-    return em.emit_as(EMIT_JSON, r, error_on_excess);
+    em.emit_as(EMIT_JSON, r);
+    return em._get(error_on_excess);
 }
+
+/** @} */
 
 
 //-----------------------------------------------------------------------------
 
-/** @defgroup doc_emit_to_container Emit to resizeable container
+// emit from tree and node id ---------------------------
+
+/** @addtogroup doc_emit_to_container_from_node_id
  *
  * @{
  */
-
-// emit from tree and node id ---------------------------
 
 /** (1) emit+resize: emit YAML to the given `std::string`/`std::vector`-like
  * container, resizing it as needed to fit the emitted YAML. If @p append is
@@ -898,6 +930,7 @@ substr emitrs_yaml(Tree const& t, id_type id, CharOwningContainer * cont, bool a
 {
     return emitrs_yaml(t, id, EmitOptions{}, cont, append);
 }
+
 /** (1) emit+resize: emit JSON to the given `std::string`/`std::vector`-like
  * container, resizing it as needed to fit the emitted JSON. If @p append is
  * set to true, the emitted YAML is appended at the end of the container.
@@ -948,8 +981,15 @@ CharOwningContainer emitrs_json(Tree const& t, id_type id, EmitOptions const& op
     return c;
 }
 
+/** @} */
+
 
 // emit from root -------------------------
+
+/** @addtogroup doc_emit_to_container_from_root
+ *
+ * @{
+ */
 
 /** (1) emit+resize: YAML to the given `std::string`/`std::vector`-like
  * container, resizing it as needed to fit the emitted YAML.
@@ -967,8 +1007,10 @@ substr emitrs_yaml(Tree const& t, CharOwningContainer * cont, bool append=false)
 {
     if(t.empty())
         return {};
-    return emitrs_yaml(t, t.root_id(), EmitOptions{}, cont, append);
+    return emitrs_yaml
+        (t, t.root_id(), EmitOptions{}, cont, append);
 }
+
 /** (1) emit+resize: JSON to the given `std::string`/`std::vector`-like
  * container, resizing it as needed to fit the emitted JSON.
  * @return a substr trimmed to the new emitted contents. */
@@ -1010,9 +1052,15 @@ CharOwningContainer emitrs_json(Tree const& t, EmitOptions const& opts={})
     return c;
 }
 
+/** @} */
+
 
 // emit from ConstNodeRef ------------------------
 
+/** @addtogroup doc_emit_to_container_from_noderef
+ *
+ * @{
+ */
 
 /** (1) emit+resize: YAML to the given `std::string`/`std::vector`-like container,
  * resizing it as needed to fit the emitted YAML.
@@ -1032,6 +1080,7 @@ substr emitrs_yaml(ConstNodeRef const& n, CharOwningContainer * cont, bool appen
         return {};
     return emitrs_yaml(*n.tree(), n.id(), EmitOptions{}, cont, append);
 }
+
 /** (1) emit+resize: JSON to the given `std::string`/`std::vector`-like container,
  * resizing it as needed to fit the emitted JSON.
  * @return a substr trimmed to the new emitted contents */
@@ -1073,7 +1122,6 @@ CharOwningContainer emitrs_json(ConstNodeRef const& n, EmitOptions const& opts={
     return c;
 }
 
-
 /** @} */
 
 
@@ -1096,17 +1144,17 @@ CharOwningContainer emitrs_json(ConstNodeRef const& n, EmitOptions const& opts={
 #undef emit
 #endif
 
-RYML_DEPRECATE_EMIT inline size_t emit(Tree const& t, id_type id, FILE *f)
+RYML_DEPRECATE_EMIT inline void emit(Tree const& t, id_type id, FILE *f)
 {
-    return emit_yaml(t, id, f);
+    emit_yaml(t, id, f);
 }
-RYML_DEPRECATE_EMIT inline size_t emit(Tree const& t, FILE *f=nullptr)
+RYML_DEPRECATE_EMIT inline void emit(Tree const& t, FILE *f=nullptr)
 {
-    return emit_yaml(t, f);
+    emit_yaml(t, f);
 }
-RYML_DEPRECATE_EMIT inline size_t emit(ConstNodeRef const& r, FILE *f=nullptr)
+RYML_DEPRECATE_EMIT inline void emit(ConstNodeRef const& r, FILE *f=nullptr)
 {
-    return emit_yaml(r, f);
+    emit_yaml(r, f);
 }
 
 RYML_DEPRECATE_EMIT inline substr emit(Tree const& t, id_type id, substr buf, bool error_on_excess=true)

--- a/src/c4/yml/writer.hpp
+++ b/src/c4/yml/writer.hpp
@@ -32,48 +32,35 @@ namespace yml {
 struct WriterFile
 {
     FILE * m_file;
-    size_t m_pos;
 
-    WriterFile(FILE *f = nullptr) : m_file(f ? f : stdout), m_pos(0) {}
-
-    substr _get(bool /*error_on_excess*/) const
-    {
-        substr sp;
-        sp.str = nullptr;
-        sp.len = m_pos;
-        return sp;
-    }
+    WriterFile(FILE *f = nullptr) noexcept : m_file(f ? f : stdout) {}
 
     template<size_t N>
-    void _do_write(const char (&a)[N]) noexcept
+    void _do_write(const char (&a)[N]) noexcept // NOLINT
     {
         static_assert(N > 1, "empty string");
         (void)fwrite(a, sizeof(char), N - 1, m_file);
-        m_pos += N - 1;
     }
 
-    void _do_write(csubstr s) noexcept
+    void _do_write(csubstr s) noexcept // NOLINT
     {
         if(s.len)
         {
             C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wsign-conversion")
             (void)fwrite(s.str, sizeof(csubstr::char_type), s.len, m_file);
-            m_pos += s.len;
             C4_SUPPRESS_WARNING_GCC_CLANG_POP
         }
     }
 
-    void _do_write(const char c) noexcept
+    void _do_write(const char c) noexcept // NOLINT
     {
         (void)fputc(c, m_file);
-        ++m_pos;
     }
 
-    void _do_write(const char c, size_t num_times) noexcept
+    void _do_write(const char c, size_t num_times) noexcept // NOLINT
     {
         for(size_t i = 0; i < num_times; ++i)
             (void)fputc(c, m_file);
-        m_pos += num_times;
     }
 };
 
@@ -92,24 +79,14 @@ template<class OStream>
 struct WriterOStream
 {
     OStream* m_stream;
-    size_t   m_pos;
 
-    WriterOStream(OStream &s) : m_stream(&s), m_pos(0) {}
-
-    substr _get(bool /*error_on_excess*/) const noexcept
-    {
-        substr sp;
-        sp.str = nullptr;
-        sp.len = m_pos;
-        return sp;
-    }
+    WriterOStream(OStream &s) noexcept : m_stream(&s) {}
 
     template<size_t N>
     void _do_write(const char (&a)[N]) noexcept
     {
         static_assert(N > 1, "empty string");
         m_stream->write(a, N - 1);
-        m_pos += N - 1;
     }
 
     void _do_write(csubstr s) noexcept
@@ -118,7 +95,6 @@ struct WriterOStream
         {
             C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wsign-conversion")
             m_stream->write(s.str, s.len);
-            m_pos += s.len;
             C4_SUPPRESS_WARNING_GCC_CLANG_POP
         }
     }
@@ -126,14 +102,12 @@ struct WriterOStream
     void _do_write(const char c) noexcept
     {
         m_stream->put(c);
-        ++m_pos;
     }
 
     void _do_write(const char c, size_t num_times) noexcept
     {
         for(size_t i = 0; i < num_times; ++i)
             m_stream->put(c);
-        m_pos += num_times;
     }
 };
 

--- a/test/test_emit.cpp
+++ b/test/test_emit.cpp
@@ -317,40 +317,40 @@ struct TmpContainerStyle
     }
 };
 
-void test_emits(Tree const& t, id_type id, std::string const& expected, std::string const& expected_json, EmitOptions const& opts={})
+void test_emits(Tree const& t, id_type id, std::string const& expected_yaml, std::string const& expected_json, EmitOptions const& opts={})
 {
     RYML_TRACE_FMT("id={}", id);
     std::string append_prefix = "#before\n";
     if(opts == EmitOptions{})
     {
-        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, id, buf); }), expected);
+        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, id, buf); }), expected_yaml);
         EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(t, id, buf); }), expected_json);
-        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, id, f); }), expected);
+        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, id, f); }), expected_yaml);
         EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(t, id, f); }), expected_json);
-        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, id); }), expected);
+        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, id); }), expected_yaml);
         EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(t, id); }), expected_json);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true); }), expected);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true); }), expected_json);
-        EXPECT_EQ(emitrs_yaml<std::string>(t, id), expected);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_YAML, t, id); return em._get(/*error_on_excess*/true); }), expected_yaml);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_JSON, t, id); return em._get(/*error_on_excess*/true); }), expected_json);
+        EXPECT_EQ(emitrs_yaml<std::string>(t, id), expected_yaml);
         EXPECT_EQ(emitrs_json<std::string>(t, id), expected_json);
-        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, id, s, /*append*/true); } ), append_prefix + expected);
+        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, id, s, /*append*/true); } ), append_prefix + expected_yaml);
         EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(t, id, s, /*append*/true); } ), append_prefix + expected_json);
     }
-    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, id, opts, buf); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, id, opts, buf); }), expected_yaml);
     EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(t, id, opts, buf); }), expected_json);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, id, opts, f); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_YAML, t, id); return em._get(/*error_on_excess*/true); }), expected_yaml);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_JSON, t, id); return em._get(/*error_on_excess*/true); }), expected_json);
+    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, id, opts, f); }), expected_yaml);
     EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(t, id, opts, f); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true).len; }), expected);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true).len; }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, id, opts); }), expected);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(t, id, opts); }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, t, id, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, t, id, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emitrs_yaml<std::string>(t, id, opts), expected);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); em.emit_as(EMIT_YAML, t, id); }), expected_yaml);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); em.emit_as(EMIT_JSON, t, id); }), expected_json);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, id, opts); }), expected_yaml);;
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(t, id, opts); }), expected_json);;
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, t, id); }), expected_yaml);;
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, t, id); }), expected_json);;
+    EXPECT_EQ(emitrs_yaml<std::string>(t, id, opts), expected_yaml);
     EXPECT_EQ(emitrs_json<std::string>(t, id, opts), expected_json);
-    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, id, opts, s, /*append*/true); } ), append_prefix + expected);
+    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, id, opts, s, /*append*/true); } ), append_prefix + expected_yaml);
     EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(t, id, opts, s, /*append*/true); } ), append_prefix + expected_json);
     // error on max depth
     if(id == NONE)
@@ -362,8 +362,8 @@ void test_emits(Tree const& t, id_type id, std::string const& expected, std::str
         optsd = optsd.max_depth(0);
         ExpectError::check_error_visit(&t, [&]{ return emit2buf([&](substr buf){ return emit_yaml(t, id, optsd, buf); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2buf([&](substr buf){ return emit_json(t, id, optsd, buf); }); });
-        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ return emit_yaml(t, id, optsd, f); }); });
-        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ return emit_json(t, id, optsd, f); }); });
+        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ emit_yaml(t, id, optsd, f); }); });
+        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ emit_json(t, id, optsd, f); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, id, optsd); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_json(t, id, optsd); }); });
         ExpectError::check_error_visit(&t, [&]{ return emitrs_yaml<std::string>(t, id, optsd); });
@@ -371,46 +371,46 @@ void test_emits(Tree const& t, id_type id, std::string const& expected, std::str
     }
 }
 
-void test_emits(Tree const& t, std::string const& expected, std::string const& expected_json, EmitOptions const& opts={})
+void test_emits(Tree const& t, std::string const& expected_yaml, std::string const& expected_json, EmitOptions const& opts={})
 {
     std::string append_prefix = "#before\n";
     if(opts == EmitOptions{})
     {
-        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, buf); }), expected);
+        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, buf); }), expected_yaml);
         EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(t, buf); }), expected_json);
-        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, f); }), expected);
+        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, f); }), expected_yaml);
         EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(t, f); }), expected_json);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true); }), expected);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true); }), expected_json);
-        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true).len; }), expected);
-        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true).len; }), expected_json);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_YAML, t); return em._get(/*error_on_excess*/true); }), expected_yaml);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_JSON, t); return em._get(/*error_on_excess*/true); }), expected_json);
+        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); em.emit_as(EMIT_YAML, t); }), expected_yaml);
+        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); em.emit_as(EMIT_JSON, t); }), expected_json);
         if(!t.empty())
         {
-            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t); }), expected);
+            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t); }), expected_yaml);
             EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(t); }), expected_json);
-            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(oss); em.emit_as(EMIT_YAML, t, /*error_on_excess*/true); }), expected);
-            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(oss); em.emit_as(EMIT_JSON, t, /*error_on_excess*/true); }), expected_json);
+            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(oss); em.emit_as(EMIT_YAML, t); }), expected_yaml);
+            EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(oss); em.emit_as(EMIT_JSON, t); }), expected_json);
         }
-        EXPECT_EQ(emitrs_yaml<std::string>(t), expected);
+        EXPECT_EQ(emitrs_yaml<std::string>(t), expected_yaml);
         EXPECT_EQ(emitrs_json<std::string>(t), expected_json);
-        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, s, /*append*/true); } ), append_prefix + expected);
+        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, s, /*append*/true); } ), append_prefix + expected_yaml);
         EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(t, s, /*append*/true); } ), append_prefix + expected_json);
     }
-    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, opts, buf); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(t, opts, buf); }), expected_yaml);
     EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(t, opts, buf); }), expected_json);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, opts, f); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_YAML, t); return em._get(/*error_on_excess*/true); }), expected_yaml);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_JSON, t); return em._get(/*error_on_excess*/true); }), expected_json);
+    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(t, opts, f); }), expected_yaml);
     EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(t, opts, f); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_YAML, t, /*error_on_excess*/true).len; }), expected);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_JSON, t, /*error_on_excess*/true).len; }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, opts); }), expected);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_YAML, t); }), expected_yaml);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_JSON, t); }), expected_json);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(t, opts); }), expected_yaml);
     EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(t, opts); }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, t, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, t, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emitrs_yaml<std::string>(t, opts), expected);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, t); }), expected_yaml);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, t); }), expected_json);
+    EXPECT_EQ(emitrs_yaml<std::string>(t, opts), expected_yaml);
     EXPECT_EQ(emitrs_json<std::string>(t, opts), expected_json);
-    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, opts, s, /*append*/true); } ), append_prefix + expected);
+    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(t, opts, s, /*append*/true); } ), append_prefix + expected_yaml);
     EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(t, opts, s, /*append*/true); } ), append_prefix + expected_json);
     // error on max depth
     id_type max_depth = t.empty() ? 0 : t.depth_desc(t.root_id());
@@ -420,8 +420,8 @@ void test_emits(Tree const& t, std::string const& expected, std::string const& e
         optsd = optsd.max_depth(0);
         ExpectError::check_error_visit(&t, [&]{ return emit2buf([&](substr buf){ return emit_yaml(t, optsd, buf); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2buf([&](substr buf){ return emit_json(t, optsd, buf); }); });
-        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ return emit_yaml(t, optsd, f); }); });
-        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ return emit_json(t, optsd, f); }); });
+        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ emit_yaml(t, optsd, f); }); });
+        ExpectError::check_error_visit(&t, [&]{ return emit2file([&](FILE *f){ emit_json(t, optsd, f); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_yaml(ConstNodeRef(&t), optsd); }); });
         ExpectError::check_error_visit(&t, [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_json(ConstNodeRef(&t), optsd); }); });
         ExpectError::check_error_visit(&t, [&]{ return emitrs_yaml<std::string>(t, optsd); });
@@ -430,42 +430,42 @@ void test_emits(Tree const& t, std::string const& expected, std::string const& e
 }
 
 
-void test_emits(ConstNodeRef n, std::string const& expected, std::string const& expected_json, EmitOptions const& opts={})
+void test_emits(ConstNodeRef n, std::string const& expected_yaml, std::string const& expected_json, EmitOptions const& opts={})
 {
     std::string append_prefix = "#before\n";
     if(opts == EmitOptions{})
     {
-        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(n, buf); }), expected);
+        EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(n, buf); }), expected_yaml);
         EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(n, buf); }), expected_json);
-        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(n, f); }), expected);
+        EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(n, f); }), expected_yaml);
         EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(n, f); }), expected_json);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_YAML, n, /*error_on_excess*/true); }), expected);
-        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); return em.emit_as(EMIT_JSON, n, /*error_on_excess*/true); }), expected_json);
-        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); return em.emit_as(EMIT_YAML, n, /*error_on_excess*/true).len; }), expected);
-        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); return em.emit_as(EMIT_JSON, n, /*error_on_excess*/true).len; }), expected_json);
-        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss <<         n; }), expected);
-        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(n); }), expected);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_YAML, n); return em._get(/*error_on_excess*/true); }), expected_yaml);
+        EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(buf); em.emit_as(EMIT_JSON, n); return em._get(/*error_on_excess*/true); }), expected_json);
+        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); em.emit_as(EMIT_YAML, n); }), expected_yaml);
+        EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(f); em.emit_as(EMIT_JSON, n); }), expected_json);
+        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss <<         n; }), expected_yaml);
+        EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(n); }), expected_yaml);
         EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(n); }), expected_json);
-        EXPECT_EQ(emitrs_yaml<std::string>(n), expected);
+        EXPECT_EQ(emitrs_yaml<std::string>(n), expected_yaml);
         EXPECT_EQ(emitrs_json<std::string>(n), expected_json);
-        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(n, s, /*append*/true); } ), append_prefix + expected);
+        EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(n, s, /*append*/true); } ), append_prefix + expected_yaml);
         EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(n, s, /*append*/true); } ), append_prefix + expected_json);
     }
-    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(n, opts, buf); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ return emit_yaml(n, opts, buf); }), expected_yaml);
     EXPECT_EQ(emit2buf([&](substr buf){ return emit_json(n, opts, buf); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(n, opts, f); }), expected);
+    EXPECT_EQ(emit2file([&](FILE *f){ return emit_yaml(n, opts, f); }), expected_yaml);
     EXPECT_EQ(emit2file([&](FILE *f){ return emit_json(n, opts, f); }), expected_json);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_YAML, n, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); return em.emit_as(EMIT_JSON, n, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_YAML, n, /*error_on_excess*/true).len; }), expected);
-    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); return em.emit_as(EMIT_JSON, n, /*error_on_excess*/true).len; }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(n, opts); }), expected);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_YAML, n); return em._get(/*error_on_excess*/true); }), expected_yaml);
+    EXPECT_EQ(emit2buf([&](substr buf){ EmitterBuf em(opts, buf); em.emit_as(EMIT_JSON, n); return em._get(/*error_on_excess*/true); }), expected_json);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); em.emit_as(EMIT_YAML, n); }), expected_yaml);
+    EXPECT_EQ(emit2file([&](FILE *f){ EmitterFile em(opts, f); em.emit_as(EMIT_JSON, n); }), expected_json);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_yaml(n, opts); }), expected_yaml);
     EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ oss << as_json(n, opts); }), expected_json);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, n, /*error_on_excess*/true); }), expected);
-    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, n, /*error_on_excess*/true); }), expected_json);
-    EXPECT_EQ(emitrs_yaml<std::string>(n, opts), expected);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_YAML, n); }), expected_yaml);
+    EXPECT_EQ(emit2stream([&](std::ostringstream &oss){ EmitterOStream<std::ostringstream> em(opts, oss); em.emit_as(EMIT_JSON, n); }), expected_json);
+    EXPECT_EQ(emitrs_yaml<std::string>(n, opts), expected_yaml);
     EXPECT_EQ(emitrs_json<std::string>(n, opts), expected_json);
-    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(n, opts, s, /*append*/true); } ), append_prefix + expected);
+    EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_yaml(n, opts, s, /*append*/true); } ), append_prefix + expected_yaml);
     EXPECT_EQ(emitrs_append(to_csubstr(append_prefix), [&](std::string *s) { emitrs_json(n, opts, s, /*append*/true); } ), append_prefix + expected_json);
     // error on max depth
     if(n.tree() && n.id() != NONE)
@@ -477,8 +477,8 @@ void test_emits(ConstNodeRef n, std::string const& expected, std::string const& 
             optsd = optsd.max_depth(0);
             ExpectError::check_error_visit(n.tree(), [&]{ return emit2buf([&](substr buf){ return emit_yaml(n, optsd, buf); }); });
             ExpectError::check_error_visit(n.tree(), [&]{ return emit2buf([&](substr buf){ return emit_json(n, optsd, buf); }); });
-            ExpectError::check_error_visit(n.tree(), [&]{ return emit2file([&](FILE *f){ return emit_yaml(n, optsd, f); }); });
-            ExpectError::check_error_visit(n.tree(), [&]{ return emit2file([&](FILE *f){ return emit_json(n, optsd, f); }); });
+            ExpectError::check_error_visit(n.tree(), [&]{ return emit2file([&](FILE *f){ emit_yaml(n, optsd, f); }); });
+            ExpectError::check_error_visit(n.tree(), [&]{ return emit2file([&](FILE *f){ emit_json(n, optsd, f); }); });
             ExpectError::check_error_visit(n.tree(), [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_yaml(n, optsd); }); });
             ExpectError::check_error_visit(n.tree(), [&]{ return emit2stream([&](std::ostringstream &oss){ oss << as_json(n, optsd); }); });
             ExpectError::check_error_visit(n.tree(), [&]{ return emitrs_yaml<std::string>(n, optsd); });

--- a/test/test_lib/test_case.cpp
+++ b/test/test_lib/test_case.cpp
@@ -495,7 +495,7 @@ void ExpectError::check_error_parse(Tree *tree, fntestref fn, Location const& ex
     }
     C4_IF_EXCEPTIONS_(catch(std::exception const& exc)
     {
-        FAIL() << "got an unexpected exception:" << exc.what() << "\n";
+        FAIL() << "got an unexpected exception: " << exc.what() << "\n";
     }, )
     C4_IF_EXCEPTIONS_(catch(...)
     {

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -350,9 +350,6 @@ struct CaseDataLineEndings
 
     Tree parsed_tree{0};
 
-    size_t numbytes_stdout;
-    size_t numbytes_stdout_json;
-
     std::string emit_buf;
     csubstr emitted_yml;
 

--- a/test/test_lib/test_group.cpp
+++ b/test/test_lib/test_group.cpp
@@ -172,8 +172,7 @@ void YmlTestCase::_test_emit_yml_stdout(CaseDataLineEndings *cd)
         return;
     _ensure_parse(cd);
     _ensure_emit(cd);
-    cd->numbytes_stdout = emit_yaml(cd->parsed_tree);
-    EXPECT_EQ(cd->numbytes_stdout, cd->emitted_yml.size());
+    emit_yaml(cd->parsed_tree);
 }
 
 //-----------------------------------------------------------------------------
@@ -185,8 +184,7 @@ void YmlTestCase::_test_emit_json_stdout(CaseDataLineEndings *cd)
         return;
     _ensure_parse(cd);
     _ensure_emit_json(cd);
-    cd->numbytes_stdout_json = emit_json(cd->parsed_tree);
-    EXPECT_EQ(cd->numbytes_stdout_json, cd->emitted_json.size());
+    emit_json(cd->parsed_tree);
 }
 
 //-----------------------------------------------------------------------------
@@ -327,7 +325,6 @@ void YmlTestCase::_test_emit_yml_string(CaseDataLineEndings *cd)
     _ensure_emit(cd);
     csubstr emitted = emitrs_yaml(cd->parsed_tree, &cd->emit_buf);
     EXPECT_EQ(emitted.len, cd->emit_buf.size());
-    EXPECT_EQ(emitted.len, cd->numbytes_stdout);
     #ifdef RYML_DBG
     printf("%.*s", (int)emitted.len, emitted.str);
     #endif
@@ -344,7 +341,6 @@ void YmlTestCase::_test_emit_json_string(CaseDataLineEndings *cd)
     _ensure_emit_json(cd);
     auto emitted = emitrs_json(cd->parsed_tree, &cd->emit_buf);
     EXPECT_EQ(emitted.len, cd->emitjson_buf.size());
-    EXPECT_EQ(emitted.len, cd->numbytes_stdout_json);
     #ifdef RYML_DBG
     printf("%.*s", (int)emitted.len, emitted.str);
     #endif

--- a/test/test_lib/test_save.cpp
+++ b/test/test_lib/test_save.cpp
@@ -1,6 +1,7 @@
 #ifdef RYML_SAVE_TEST_YAML
 
 #include <c4/yml/common.hpp>
+#include <c4/yml/file.hpp>
 #include <c4/yml/error.hpp>
 #include <c4/error.hpp>
 #include <c4/format.hpp>
@@ -17,7 +18,7 @@ C4_SUPPRESS_WARNING_GCC_CLANG("-Wold-style-cast")
 namespace c4 {
 namespace yml {
 
-static char savedir[] = "./yamldump\0";
+static char savedir[] = "./yamldump";
 
 struct savehelper
 {
@@ -25,7 +26,7 @@ struct savehelper
     std::vector<char> basename;
     std::vector<char> fullname;
     size_t indexpos;
-    void reset_from_notest(csubstr filename)
+    void reset_from_no_test(csubstr filename)
     {
         char buf[1024];
         ssize_t ret = readlink("/proc/self/exe", buf, sizeof(buf)-1);
@@ -73,7 +74,7 @@ struct savehelper
     }
     void prepare_fullname()
     {
-        printf("new test! %.*s\n", (int)basename.size(), &basename.front());
+        printf("new test! %.*s[%zu]\n", (int)basename.size(), basename.data(), basename.size());
         c4::formatrs(&fullname, "{}/{}--", savedir, basename);
         indexpos = fullname.size();
         fullname.resize(fullname.size() + 32);
@@ -94,7 +95,7 @@ static void save_impl(csubstr filename, csubstr extension, csubstr src)
         if(curr)
             h.reset_from_gtest(curr);
         else
-            h.reset_from_notest(filename);
+            h.reset_from_no_test(filename);
     }
     if(to_csubstr(h.basename).find("FilterTest_filter") != npos)
         return; // this case is not interesting, and very noisy
@@ -113,7 +114,7 @@ static void save_impl(csubstr filename, csubstr extension, csubstr src)
     csubstr savename = to_substr(h.fullname).first(h.indexpos + len);
     // done! dump the file
     printf("saving %.*s\n", (int)savename.len, savename.str);
-    ryml::file_put_contents(src, savename.str);
+    file_put_contents(src, savename.str);
 }
 
 void ryml_save_test_yaml(csubstr filename, csubstr src)


### PR DESCRIPTION
  - `WriterFile` and `WriterOStream` no longer track the number of emitted bytes.
  - `error_on_excess` is now used in the emit-to-buffer overloads, and no longer in the main `Emitter::emit_as()` driver function.
