### PR TITLE
JSON: follow flow style customization, handle streams as seqs

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,0 +1,4 @@
+- [PR#618](https://github.com/biojppm/rapidyaml/pull/618):
+  - JSON now adheres to flow style customization from [PR#615](https://github.com/biojppm/rapidyaml/pull/615)
+  - JSON now emits YAML streams as a top-level seq. The old behavior of throwing an error on streams can be obtained by using the new `EmitOptions::json_err_on_stream()`.
+  - Fix error in `EmitOptions` where `EmitOptions::emit_nonroot_dash()` had the same effect as `EmitOptions::json_err_on_tag()`.

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -106,6 +106,7 @@ void ensure_callbacks();
     #include <c4/yml/error.def.hpp>
 #endif
 
+
 // these are needed for the examples below
 #include <iostream>
 #include <sstream>
@@ -4201,7 +4202,7 @@ void sample_emit_to_stream()
         std::stringstream ss;
         ss << ryml::as_json(tree); // works with any stream having .operator<<() and .write()
         s = ss.str();
-        CHECK(ryml::to_csubstr(s) ==
+        CHECK(s ==
               "["                                        "\n"
               "  \"a\","                                 "\n"
               "  \"b\","                                 "\n"
@@ -4235,7 +4236,7 @@ void sample_emit_to_stream()
         std::stringstream ss;
         ss << tree[3][2]; // works with any stream having .operator<<() and .write()
         s = ss.str();
-        CHECK(ryml::to_csubstr(s) == ""
+        CHECK(s == ""
               "more:"                             "\n"
               "  vinho verde: Soalheiro"          "\n"
               "  vinho tinto: Redoma 2017"        "\n"
@@ -4706,6 +4707,9 @@ void sample_style_flow_formatting()
     auto tostr = [](ryml::ConstNodeRef n, ryml::EmitOptions opts) {
         return ryml::emitrs_yaml<std::string>(n, opts);
     };
+    auto tostr_json = [](ryml::ConstNodeRef n, ryml::EmitOptions opts) {
+        return ryml::emitrs_json<std::string>(n, opts);
+    };
     const ryml::EmitOptions emit_defaults = ryml::EmitOptions{};
     // let's parse this, which is in FLOW_ML1 (flow multiline, 1 value per line):
     ryml::csubstr yaml = ""
@@ -4730,6 +4734,20 @@ void sample_style_flow_formatting()
         CHECK(tree["map"]["seq"][4].is_flow_sl()); // etc
         // emitted yaml is exactly equal to parsed yaml:
         CHECK(tostr(tree, emit_defaults) == yaml);
+        // json looks like similar:
+        CHECK(tostr_json(tree, emit_defaults) ==
+              "{\n"
+              "  \"map\": {\n"
+              "    \"seq\": [\n"
+              "      0,\n"
+              "      1,\n"
+              "      2,\n"
+              "      3,\n"
+              "      [40,41]\n"
+              "    ]\n"
+              "  }\n"
+              "}\n"
+              "");
     }
     // if you prefer to shorten the emitted yaml, you can set the
     // parser to disable flow multiline detection. It will then pick
@@ -4742,12 +4760,18 @@ void sample_style_flow_formatting()
         // notice how this is smaller now:
         CHECK(tostr(tree, emit_defaults) ==
               "{map: {seq: [0,1,2,3,[40,41]]}}");
+        // and json as well
+        CHECK(tostr_json(tree, emit_defaults) ==
+              "{\"map\": {\"seq\": [0,1,2,3,[40,41]]}}");
         // you can also force spaces everywhere without adding
         // FLOW_SPC in individual containers:
         const ryml::EmitOptions with_spaces = ryml::EmitOptions{}
             .force_flow_spc(true);
         CHECK(tostr(tree, with_spaces) ==
               "{map: {seq: [0, 1, 2, 3, [40, 41]]}}");
+        // and json as well
+        CHECK(tostr_json(tree, with_spaces) ==
+              "{\"map\": {\"seq\": [0, 1, 2, 3, [40, 41]]}}");
     }
     // or you can still have the default detection of flow_ml, but set
     // it to pick FLOW_MLN (multiline, n values per line), instead of
@@ -4766,6 +4790,14 @@ void sample_style_flow_formatting()
               "    ]"                       "\n"
               "  }"                         "\n"
               "}"                           "\n");
+        CHECK(tostr_json(tree, emit_defaults) ==
+              "{"                           "\n"
+              "  \"map\": {"                "\n"
+              "    \"seq\": ["              "\n"
+              "      0,1,2,3,[40,41]"       "\n"
+              "    ]"                       "\n"
+              "  }"                         "\n"
+              "}"                           "\n");
         // now with spaces:
         const ryml::EmitOptions with_spaces = ryml::EmitOptions{}
             .force_flow_spc(true);
@@ -4773,6 +4805,14 @@ void sample_style_flow_formatting()
               "{"                           "\n"
               "  map: {"                    "\n"
               "    seq: ["                  "\n"
+              "      0, 1, 2, 3, [40, 41]"  "\n"
+              "    ]"                       "\n"
+              "  }"                         "\n"
+              "}"                           "\n");
+        CHECK(tostr_json(tree, with_spaces) ==
+              "{"                           "\n"
+              "  \"map\": {"                "\n"
+              "    \"seq\": ["              "\n"
               "      0, 1, 2, 3, [40, 41]"  "\n"
               "    ]"                       "\n"
               "  }"                         "\n"
@@ -4790,6 +4830,19 @@ void sample_style_flow_formatting()
               "{"              "\n"
               "map: {"         "\n"
               "seq: ["         "\n"
+              "0,"             "\n"
+              "1,"             "\n"
+              "2,"             "\n"
+              "3,"             "\n"
+              "[40,41]"        "\n"
+              "]"              "\n"
+              "}"              "\n"
+              "}"              "\n"
+              "");
+        CHECK(tostr_json(tree, noindent) == ""
+              "{"              "\n"
+              "\"map\": {"     "\n"
+              "\"seq\": ["     "\n"
               "0,"             "\n"
               "1,"             "\n"
               "2,"             "\n"
@@ -4830,10 +4883,27 @@ void sample_style_flow_formatting()
               "  56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79\n"
               "]\n"
               "");
+        CHECK(tostr_json(tree, emit_defaults) == ""
+              "[\n"
+              "  0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,\n"
+              "  29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,\n"
+              "  55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79\n"
+              "]\n"
+              "");
         // let's try setting max columns to 40:
         const ryml::EmitOptions maxcols40 = ryml::EmitOptions{}
             .max_cols(40);
         CHECK(tostr(tree, maxcols40) == ""
+              "[\n"
+              "  0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,\n"
+              "  16,17,18,19,20,21,22,23,24,25,26,27,28,\n"
+              "  29,30,31,32,33,34,35,36,37,38,39,40,41,\n"
+              "  42,43,44,45,46,47,48,49,50,51,52,53,54,\n"
+              "  55,56,57,58,59,60,61,62,63,64,65,66,67,\n"
+              "  68,69,70,71,72,73,74,75,76,77,78,79\n"
+              "]\n"
+              "");
+        CHECK(tostr_json(tree, maxcols40) == ""
               "[\n"
               "  0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,\n"
               "  16,17,18,19,20,21,22,23,24,25,26,27,28,\n"
@@ -4848,6 +4918,14 @@ void sample_style_flow_formatting()
         const ryml::EmitOptions with_spaces = ryml::EmitOptions{}
             .force_flow_spc(true);
         CHECK(tostr(tree, with_spaces) == ""
+              "[\n"
+              "  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,\n"
+              "  22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,\n"
+              "  42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,\n"
+              "  62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79\n"
+              "]\n"
+              "");
+        CHECK(tostr_json(tree, with_spaces) == ""
               "[\n"
               "  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,\n"
               "  22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41,\n"
@@ -4871,12 +4949,36 @@ void sample_style_flow_formatting()
               "  72, 73, 74, 75, 76, 77, 78, 79\n"
               "]\n"
               "");
+        CHECK(tostr_json(tree, maxcols40_spc) == ""
+              "[\n"
+              "  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,\n"
+              "  12, 13, 14, 15, 16, 17, 18, 19, 20, 21,\n"
+              "  22, 23, 24, 25, 26, 27, 28, 29, 30, 31,\n"
+              "  32, 33, 34, 35, 36, 37, 38, 39, 40, 41,\n"
+              "  42, 43, 44, 45, 46, 47, 48, 49, 50, 51,\n"
+              "  52, 53, 54, 55, 56, 57, 58, 59, 60, 61,\n"
+              "  62, 63, 64, 65, 66, 67, 68, 69, 70, 71,\n"
+              "  72, 73, 74, 75, 76, 77, 78, 79\n"
+              "]\n"
+              "");
         // and you can combine spaces with max columns with no indentation:
         const ryml::EmitOptions maxcols40_spc_noindent = ryml::EmitOptions{}
             .max_cols(40)
             .force_flow_spc(true)
             .indent_flow_ml(false);
         CHECK(tostr(tree, maxcols40_spc_noindent) == ""
+              "[\n"
+              "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,\n"
+              "13, 14, 15, 16, 17, 18, 19, 20, 21, 22,\n"
+              "23, 24, 25, 26, 27, 28, 29, 30, 31, 32,\n"
+              "33, 34, 35, 36, 37, 38, 39, 40, 41, 42,\n"
+              "43, 44, 45, 46, 47, 48, 49, 50, 51, 52,\n"
+              "53, 54, 55, 56, 57, 58, 59, 60, 61, 62,\n"
+              "63, 64, 65, 66, 67, 68, 69, 70, 71, 72,\n"
+              "73, 74, 75, 76, 77, 78, 79\n"
+              "]\n"
+              "");
+        CHECK(tostr_json(tree, maxcols40_spc_noindent) == ""
               "[\n"
               "0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,\n"
               "13, 14, 15, 16, 17, 18, 19, 20, 21, 22,\n"
@@ -5453,7 +5555,7 @@ void sample_tag_directives()
 
 void sample_docs()
 {
-    std::string yml = ""
+    ryml::csubstr yml = ""
         "---"        "\n"
         "a: 0"       "\n"
         "b: 1"       "\n"
@@ -5466,7 +5568,7 @@ void sample_docs()
         "- 6"        "\n"
         "- 7"        "\n"
         "";
-    ryml::Tree tree = ryml::parse_in_place(ryml::to_substr(yml));
+    ryml::Tree tree = ryml::parse_in_arena(yml);
     CHECK(ryml::emitrs_yaml<std::string>(tree) == yml);
 
     // iteration through docs
@@ -5537,55 +5639,60 @@ void sample_docs()
         CHECK(tree.val(tree.child(doc2_id, 3)) == "7");
     }
 
-    // Note: since json does not have streams, you cannot emit the above
-    // tree as json when you start from the root:
-    //CHECK(ryml::emitrs_json<std::string>(tree) == yml); // RUNTIME ERROR!
-
-    // but, althouth emitting streams as json is not possible,
-    // you can iterate through individual documents and emit
-    // them separately:
+    // Note: ryml emits streams as a JSON seq by default:
+    CHECK(ryml::emitrs_json<std::string>(tree) ==
+          "["              "\n"
+          "  {"            "\n"
+          "    \"a\": 0,"  "\n"
+          "    \"b\": 1"   "\n"
+          "  },"           "\n"
+          "  {"            "\n"
+          "    \"c\": 2,"  "\n"
+          "    \"d\": 3"   "\n"
+          "  },"           "\n"
+          "  ["            "\n"
+          "    4,"         "\n"
+          "    5,"         "\n"
+          "    6,"         "\n"
+          "    7"          "\n"
+          "  ]"            "\n"
+          "]\n"
+          "");
+    // ... but you can use EmitOptions{} to set the emitter to fail if
+    // it finds a stream:
     {
+        ScopedErrorHandlerExample errh; // calls ryml::set_callbacks()
+        ryml::Tree err_tree = ryml::parse_in_arena(yml);
+        CHECK(err_tree.callbacks() == errh.callbacks());
+        auto err_opts = ryml::EmitOptions{}.json_err_on_stream(true);
+        CHECK(errh.check_error_occurs([&]{
+            return ryml::emitrs_json<std::string>(err_tree, err_opts);
+        }));
+        // in which case, you can avoid the error by emitting the
+        // documents one-by-one:
         const std::string expected_json[] = {
             "{"            "\n"
             "  \"a\": 0,"  "\n"
             "  \"b\": 1"   "\n"
             "}"            "\n"
-            "",
+            ,
             "{"            "\n"
             "  \"c\": 2,"  "\n"
             "  \"d\": 3"   "\n"
             "}"            "\n"
-            "",
+            ,
             "["            "\n"
             "  4,"         "\n"
             "  5,"         "\n"
             "  6,"         "\n"
             "  7"          "\n"
             "]"            "\n"
-            "",
         };
-        // using the node API
-        {
-            ryml::id_type count = 0;
-            const ryml::ConstNodeRef stream = tree.rootref();
-            CHECK(stream.num_children() == (ryml::id_type)C4_COUNTOF(expected_json));
-            for(ryml::ConstNodeRef doc : stream.children())
-            {
-                CHECK(ryml::emitrs_json<std::string>(doc) == expected_json[count++]);
-            }
-        }
-        // equivalent: using the index API
-        {
-            ryml::id_type count = 0;
-            const ryml::id_type stream_id = tree.root_id();
-            CHECK(tree.num_children(stream_id) == (ryml::id_type)C4_COUNTOF(expected_json));
-            for(ryml::id_type doc_id = tree.first_child(stream_id);
-                doc_id != ryml::NONE;
-                doc_id = tree.next_sibling(doc_id))
-            {
-                CHECK(ryml::emitrs_json<std::string>(tree, doc_id) == expected_json[count++]);
-            }
-        }
+        ryml::id_type count = 0;
+        const ryml::ConstNodeRef stream = err_tree;
+        CHECK(stream.num_children() == (ryml::id_type)C4_COUNTOF(expected_json));
+        for(ryml::ConstNodeRef doc : stream.children())
+            CHECK(ryml::emitrs_json<std::string>(doc, err_opts) == expected_json[count++]);
     }
 }
 

--- a/src/c4/yml/emit.def.hpp
+++ b/src/c4/yml/emit.def.hpp
@@ -1277,40 +1277,65 @@ void Emitter<Writer>::_write_scalar_plain(csubstr s, id_type ilevel)
 
 //-----------------------------------------------------------------------------
 
+namespace detail {
+inline type_bits json_type_(type_bits ty)
+{
+    enum : type_bits { // NOLINT
+        ml_bits = (BLOCK|(STREAM & ~SEQ)), // remove SEQ from STREAM to test
+        sl_bits = (CONTAINER_STYLE & ~FLOW_SPC),
+    };
+    if(ty & ml_bits)
+    {
+        ty &= ~BLOCK;
+        ty |= FLOW_ML1;
+    }
+    else if((ty & (SEQ|MAP)) && !(ty & sl_bits))
+    {
+        ty |= FLOW_SL;
+    }
+    return ty;
+}
+} // namespace detail
+
+
 template<class Writer>
 void Emitter<Writer>::_json_emit(id_type id)
 {
     NodeType ty = m_tree->type(id);
-    if(ty.is_flow_sl() || !(ty & CONTAINER_STYLE))
+    // JSON does not have streams
+    if(C4_UNLIKELY(ty.is_stream() && m_opts.json_err_on_stream()))
+        _RYML_ERR_VISIT_(m_tree->callbacks(), m_tree, id, "found stream node");
+    static_assert(STREAM & SEQ, "STREAM must be a SEQ");
+    ty = detail::json_type_(ty);
+    if(ty.is_flow_mlx())
     {
-        _json_visit_sl(id, 0);
+        _json_visit_ml(id, ty, 0);
+        _newl();
     }
     else
     {
-        _json_visit_ml(id, 0);
-        _newl();
+        _json_visit_sl(id, ty, 0);
     }
 }
 
 template<class Writer>
-void Emitter<Writer>::_json_visit_sl(id_type id, id_type depth)
+void Emitter<Writer>::_json_visit_sl(id_type id, NodeType ty, id_type depth)
 {
-    _RYML_CHECK_VISIT_(m_tree->callbacks(), !m_tree->is_stream(id), m_tree, id); // JSON does not have streams
     if(C4_UNLIKELY(depth > m_opts.max_depth()))
         _RYML_ERR_VISIT_(m_tree->callbacks(), m_tree, id, "max depth exceeded");
-    NodeType ty = m_tree->type(id);
-    if(ty.is_keyval())
+    if(ty.is_val())
+    {
+        _json_writev(id, ty);
+    }
+    else if(ty.is_keyval())
     {
         _json_writek(id, ty);
         _write(": ");
         _json_writev(id, ty);
     }
-    else if(ty.is_val())
-    {
-        _json_writev(id, ty);
-    }
     else if(ty.is_container())
     {
+        ty = detail::json_type_(ty);
         if(ty.has_key())
         {
             _json_writek(id, ty);
@@ -1320,40 +1345,44 @@ void Emitter<Writer>::_json_visit_sl(id_type id, id_type depth)
             _write('[');
         else if(ty.is_map())
             _write('{');
+
+        for(id_type child = m_tree->first_child(id); child != NONE; child = m_tree->next_sibling(child))
+        {
+            if(child != m_tree->first_child(id))
+            {
+                if((ty & FLOW_SPC) || m_opts.force_flow_spc())
+                    _write(", ");
+                else
+                    _write(',');
+            }
+            _json_visit_sl(child, m_tree->type(child), depth+1);
+        }
+
+        if(ty.is_seq())
+            _write(']');
+        else if(ty.is_map())
+            _write('}');
     }  // container
-
-    for(id_type child = m_tree->first_child(id); child != NONE; child = m_tree->next_sibling(child))
-    {
-        if(child != m_tree->first_child(id))
-            _write(',');
-        _json_visit_sl(child, depth+1);
-    }
-
-    if(ty.is_seq())
-        _write(']');
-    else if(ty.is_map())
-        _write('}');
 }
 
 template<class Writer>
-void Emitter<Writer>::_json_visit_ml(id_type id, id_type depth)
+void Emitter<Writer>::_json_visit_ml(id_type id, NodeType ty, id_type depth)
 {
-    _RYML_CHECK_VISIT_(m_tree->callbacks(), !m_tree->is_stream(id), m_tree, id); // JSON does not have streams
     if(C4_UNLIKELY(depth > m_opts.max_depth()))
         _RYML_ERR_VISIT_(m_tree->callbacks(), m_tree, id, "max depth exceeded");
-    NodeType ty = m_tree->type(id);
-    if(ty.is_keyval())
+    if(ty.is_val())
+    {
+        _json_writev(id, ty);
+    }
+    else if(ty.is_keyval())
     {
         _json_writek(id, ty);
         _write(": ");
         _json_writev(id, ty);
     }
-    else if(ty.is_val())
-    {
-        _json_writev(id, ty);
-    }
     else if(ty.is_container())
     {
+        ty = detail::json_type_(ty);
         if(ty.has_key())
         {
             _json_writek(id, ty);
@@ -1363,36 +1392,49 @@ void Emitter<Writer>::_json_visit_ml(id_type id, id_type depth)
             _write('[');
         else if(ty.is_map())
             _write('{');
-    }  // container
 
-    if(m_tree->has_children(id))
-    {
-        ++depth;
-        if(m_opts.indent_flow_ml()) ++m_ilevel;
-        const id_type first = m_tree->first_child(id);
-        const id_type last = m_tree->last_child(id);
-        for(id_type child = first; child != NONE; child = m_tree->next_sibling(child))
+        if(m_tree->has_children(id))
         {
+            ++depth;
+            if(m_opts.indent_flow_ml()) ++m_ilevel;
             _newl();
             _indent(m_ilevel);
-            NodeType chty = m_tree->type(child);
-            if(chty.is_flow_sl() || !(chty & CONTAINER_STYLE))
-                _json_visit_sl(child, depth);
-            else
-                _json_visit_ml(child, depth);
-            if(child != last)
-                _write(',');
+            for(id_type first = m_tree->first_child(id), child = first;
+                child != NONE;
+                child = m_tree->next_sibling(child))
+            {
+                if(child != first)
+                {
+                    _write(',');
+                    const size_t maxcols = m_opts.max_cols();
+                    if((ty & FLOW_MLN) && (m_col+1 < maxcols))
+                    {
+                        if((ty & FLOW_SPC) || m_opts.force_flow_spc())
+                            _write(' ');
+                    }
+                    else if((ty & FLOW_ML1) || (m_col+1 >= maxcols))
+                    {
+                        _newl();
+                        _indent(m_ilevel);
+                    }
+                }
+                NodeType chty = m_tree->type(child);
+                if(chty.is_flow_sl())
+                    _json_visit_sl(child, chty, depth);
+                else
+                    _json_visit_ml(child, chty, depth);
+            }
+            if(m_opts.indent_flow_ml()) --m_ilevel;
+            --depth;
+            _newl();
+            _indent(m_ilevel);
         }
-        if(m_opts.indent_flow_ml()) --m_ilevel;
-        --depth;
-        _newl();
-        _indent(m_ilevel);
-    }
 
-    if(ty.is_seq())
-        _write(']');
-    else if(ty.is_map())
-        _write('}');
+        if(ty.is_seq())
+            _write(']');
+        else if(ty.is_map())
+            _write('}');
+    }
 }
 
 template<class Writer>

--- a/src/c4/yml/emit.hpp
+++ b/src/c4/yml/emit.hpp
@@ -67,9 +67,10 @@ public:
         EMIT_NONROOT_KEY = 1u << 2u,
         EMIT_NONROOT_DASH = 1u << 3u,
         EMIT_NONROOT_MARKUP = EMIT_NONROOT_KEY|EMIT_NONROOT_DASH,
-        JSON_ERR_ON_TAG = 1u << 3u,
-        JSON_ERR_ON_ANCHOR = 1u << 4u,
-        _JSON_ERR_MASK = JSON_ERR_ON_TAG|JSON_ERR_ON_ANCHOR,
+        JSON_ERR_ON_STREAM = 1u << 4u,
+        JSON_ERR_ON_TAG = 1u << 5u,
+        JSON_ERR_ON_ANCHOR = 1u << 6u,
+        _JSON_ERR_MASK = JSON_ERR_ON_STREAM|JSON_ERR_ON_TAG|JSON_ERR_ON_ANCHOR,
         DEFAULT_FLAGS = EMIT_NONROOT_KEY|INDENT_FLOW_ML,
     } Flags_e;
     /** @endcond */
@@ -138,6 +139,11 @@ public:
     /** @name option flags - json behavior
      *
      * @{ */
+
+    /** Whether to trigger an error when findind a stream
+     * in json mode. Disabled by default. */
+    EmitOptions& json_err_on_stream(bool enabled) noexcept { return set_flags_(enabled, JSON_ERR_ON_STREAM); }
+    C4_ALWAYS_INLINE bool json_err_on_stream() const noexcept { return (m_flags & JSON_ERR_ON_STREAM) != 0; }
 
     /** Whether to trigger an error (or ignore the tag) when finding a tag
      * in json mode. Disabled by default. */
@@ -405,8 +411,8 @@ private:
 
 private:
 
-    void _json_visit_ml(id_type id, id_type depth);
-    void _json_visit_sl(id_type id, id_type depth);
+    void _json_visit_ml(id_type id, NodeType ty, id_type depth);
+    void _json_visit_sl(id_type id, NodeType ty, id_type depth);
     bool _json_maybe_write_naninf(csubstr s);
     void _json_writek(id_type id, NodeType ty);
     void _json_writev(id_type id, NodeType ty);


### PR DESCRIPTION
- JSON now adheres to flow style customization from #615
- JSON now emits YAML streams as a top-level seq. The old behavior of throwing an error on streams can be obtained by using the new `EmitOptions::json_err_on_stream()`.
- Fix error in `EmitOptions` where `EmitOptions::emit_nonroot_dash()` had the same effect as `EmitOptions::json_err_on_tag()`.