### PR TITLE
API cleanup: emit, part 3

### DIFF
--- a/bm/bm_emit.cpp
+++ b/bm/bm_emit.cpp
@@ -1,5 +1,6 @@
 #include "./bm_common.hpp"
 
+#include <fstream>
 
 /** this is used by the benchmarks.
  *
@@ -23,6 +24,23 @@ int main(int argc, char** argv)
 
 #define ONLY_FOR_JSON \
     if(!s_bm_case->is_json) { st.SkipWithError("not a json file"); return; }
+
+namespace {
+
+void reset(std::ostringstream &s)
+{
+    s.str("");
+    s.clear();
+}
+void reset(std::ofstream &s)
+{
+    s.clear();
+    s.seekp(0, std::ios::beg); // back to the start!
+}
+void reset(FILE *f)
+{
+    (void)fseek(f, 0, SEEK_SET);
+}
 
 
 void bm_rapidjson(bm::State& st)
@@ -55,6 +73,7 @@ void bm_jsoncpp(bm::State& st)
         ONLY_FOR_JSON;
         os << root;
         str = os.str();
+        reset(os);
     }
     s_bm_case->report(st);
 }
@@ -72,6 +91,7 @@ void bm_nlohmann(bm::State& st)
         ONLY_FOR_JSON;
         os << root;
         str = os.str();
+        reset(os);
     }
     s_bm_case->report(st);
 }
@@ -113,6 +133,7 @@ void bm_fyaml_ostream(bm::State& st)
     {
         fy_emit_document(emitter, doc);
         str = os.str();
+        reset(os);
     }
     s_bm_case->report(st);
     fy_document_destroy(doc);
@@ -173,6 +194,7 @@ void bm_yamlcpp(bm::State& st)
     {
         os << node;
         str = os.str();
+        reset(os);
     }
     s_bm_case->report(st);
 }
@@ -187,11 +209,59 @@ void bm_ryml_yaml_ostream(bm::State& st)
     {
         os << tree;
         str = os.str();
+        reset(os);
     }
     s_bm_case->report(st);
 }
 
-void bm_ryml_yaml_json_ostream(bm::State& st)
+void bm_ryml_yaml_ofstream(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::ofstream os(c4::fs::tmpnam<std::string>());
+    for(auto _ : st)
+    {
+        os << tree;
+        reset(os);
+    }
+    s_bm_case->report(st);
+}
+
+void bm_ryml_yaml_file(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::string name = c4::fs::tmpnam<std::string>();
+    FILE *f = fopen(name.c_str(), "wb");
+    C4_CHECK(f);
+    for(auto _ : st)
+    {
+        emit_yaml(tree, f);
+        reset(f);
+    }
+    (void)fclose(f);
+    s_bm_case->report(st);
+}
+
+void bm_ryml_yaml_str_file(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::string name = c4::fs::tmpnam<std::string>();
+    FILE *f = fopen(name.c_str(), "wb");
+    C4_CHECK(f);
+    std::string str;
+    for(auto _ : st)
+    {
+        emitrs_yaml(tree, &str);
+        ryml::file_put_contents(str, f, name.c_str());
+        reset(f);
+    }
+    (void)fclose(f);
+    s_bm_case->report(st);
+}
+
+void bm_ryml_json_ostream(bm::State& st)
 {
     c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
     ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
@@ -201,7 +271,55 @@ void bm_ryml_yaml_json_ostream(bm::State& st)
     {
         os << ryml::as_json(tree);
         str = os.str();
+        reset(os);
     }
+    s_bm_case->report(st);
+}
+
+void bm_ryml_json_ofstream(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::ofstream os(c4::fs::tmpnam<std::string>());
+    for(auto _ : st)
+    {
+        os << ryml::as_json(tree);
+        reset(os);
+    }
+    s_bm_case->report(st);
+}
+
+void bm_ryml_json_file(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::string name = c4::fs::tmpnam<std::string>();
+    FILE *f = fopen(name.c_str(), "wb");
+    C4_CHECK(f);
+    for(auto _ : st)
+    {
+        emit_json(tree, f);
+        reset(f);
+    }
+    (void)fclose(f);
+    s_bm_case->report(st);
+}
+
+void bm_ryml_json_str_file(bm::State& st)
+{
+    c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
+    ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
+    std::string name = c4::fs::tmpnam<std::string>();
+    FILE *f = fopen(name.c_str(), "wb");
+    C4_CHECK(f);
+    std::string str;
+    for(auto _ : st)
+    {
+        emitrs_json(tree, &str);
+        ryml::file_put_contents(str, f, name.c_str());
+        reset(f);
+    }
+    (void)fclose(f);
     s_bm_case->report(st);
 }
 
@@ -217,7 +335,7 @@ void bm_ryml_yaml_str(bm::State& st)
     s_bm_case->report(st);
 }
 
-void bm_ryml_yaml_json_str(bm::State& st)
+void bm_ryml_json_str(bm::State& st)
 {
     c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
     ryml::Tree tree = ryml::parse_in_arena(s_bm_case->filename, src);
@@ -242,7 +360,7 @@ void bm_ryml_yaml_str_reserve(bm::State& st)
     s_bm_case->report(st);
 }
 
-void bm_ryml_yaml_json_str_reserve(bm::State& st)
+void bm_ryml_json_str_reserve(bm::State& st)
 {
     c4::csubstr src = c4::to_csubstr(s_bm_case->src).trimr('\0');
     std::string str;
@@ -256,11 +374,17 @@ void bm_ryml_yaml_json_str_reserve(bm::State& st)
 }
 
 BENCHMARK(bm_ryml_yaml_str_reserve);
-BENCHMARK(bm_ryml_yaml_json_str_reserve);
+BENCHMARK(bm_ryml_json_str_reserve);
 BENCHMARK(bm_ryml_yaml_str);
-BENCHMARK(bm_ryml_yaml_json_str);
+BENCHMARK(bm_ryml_json_str);
 BENCHMARK(bm_ryml_yaml_ostream);
-BENCHMARK(bm_ryml_yaml_json_ostream);
+BENCHMARK(bm_ryml_json_ostream);
+BENCHMARK(bm_ryml_yaml_ofstream);
+BENCHMARK(bm_ryml_json_ofstream);
+BENCHMARK(bm_ryml_yaml_file);
+BENCHMARK(bm_ryml_json_file);
+BENCHMARK(bm_ryml_yaml_str_file);
+BENCHMARK(bm_ryml_json_str_file);
 #ifdef RYML_HAVE_LIBFYAML
 BENCHMARK(bm_fyaml_str_reserve);
 BENCHMARK(bm_fyaml_str);
@@ -270,3 +394,5 @@ BENCHMARK(bm_yamlcpp);
 BENCHMARK(bm_rapidjson);
 BENCHMARK(bm_jsoncpp);
 BENCHMARK(bm_nlohmann);
+
+} // namespace anon

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -41,4 +41,5 @@
      */
     bool scalar_is_inf_or_nan3(csubstr s);
     ```
+  - Writers: add `C4_ALWAYS_INLINE`. Results in ~10-20% emit improvements.
   - `file_put_contents()`: add `FILE*` overloads

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -41,3 +41,4 @@
      */
     bool scalar_is_inf_or_nan3(csubstr s);
     ```
+  - `file_put_contents()`: add `FILE*` overloads

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -18,3 +18,26 @@
     - There are no external logic changes: all the `emit_*()` functions remain the same.
     - Other changes in this PR:
       - Added `Tree::root_id_maybe()` which is safe to call on an empty tree.
+      - Deprecate `Emitter::max_depth()`
+      - Deprecate `Emitter::options()` setter
+- [PR#618](https://github.com/biojppm/rapidyaml/pull/618): Clean emit API pt3:
+  - Improve handling of NaN and Inf in json emitting.
+  - Expose scalar style helpers for json emitting:
+    ```c++
+    /** JSON-sense query of plain number */
+    bool scalar_is_plain_number_json(csubstr s);
+    /** JSON-sense query of plain number */
+    bool scalar_is_special_json(csubstr s);
+    /** Query if a scalar is nan (nan, NaN, NAN)
+     * @warning length must be 3 (asserted)
+     */
+    bool scalar_is_inf3(csubstr s);
+    /** Query if a scalar is inf (inf, Inf, INF)
+     * @warning length must be 3 (asserted)
+     */
+    bool scalar_is_nan3(csubstr s);
+    /** Same as scalar_is_inf3() || scalar_is_nan3()
+     * @warning length must be 3 (asserted)
+     */
+    bool scalar_is_inf_or_nan3(csubstr s);
+    ```

--- a/src/c4/yml/emitter.def.hpp
+++ b/src/c4/yml/emitter.def.hpp
@@ -1500,22 +1500,59 @@ void Emitter<Writer>::json_visit_ml_(id_type id, NodeType ty, id_type depth)
 template<class Writer>
 bool Emitter<Writer>::json_maybe_write_naninf_(csubstr s)
 {
-    if(s == "nan" || s == ".nan" || s == ".NaN" || s == ".NAN")
+    switch(s.len)
     {
-        write_("\".nan\"");
-        return true;
+    case 3: case 4: case 5: // inf, nan, .nan, -.inf
+    case 8: case 9: // infinity, -infinity
+        break;
+    default:
+        return false;
     }
-    else if(s == "inf" || s == ".inf" || s == ".Inf" || s == ".INF" || s == "infinity")
+    const char first = s.str[0];
+    csubstr rest = s.sub(1);
+    if(s.len == 4 && first == '.')
     {
-        write_("\".inf\"");
-        return true;
+        if(scalar_is_inf3(rest))
+            goto write_inf_positive; // NOLINT
+        else if(scalar_is_nan3(rest))
+            goto write_nan; // NOLINT
     }
-    else if(s == "-inf" || s == "-.inf" || s == "-.Inf" || s == "-.INF" || s == "-infinity")
+    else if(first == '-' || first == '+') // begins with sign: must be inf
     {
-        write_("\"-.inf\"");
-        return true;
+        // match [-+].inf
+        if((rest.len == 4 && rest.str[0] == '.' && scalar_is_inf3(rest.sub(1)))
+           // match [-+]inf
+           || (rest.len == 3 && scalar_is_inf3(rest))
+           // match [-+]infinity
+           || (rest.len == 8 && (0 == memcmp(rest.str, "infinity", 8))))
+        {
+            if(first == '-')
+                goto write_inf_negative; // NOLINT
+            else
+                goto write_inf_positive; // NOLINT
+        }
+    }
+    else if(s.len == 8 && (0 == memcmp(s.str, "infinity", 8)))
+    {
+        goto write_inf_positive; // NOLINT
+    }
+    else if(s.len == 3)
+    {
+        if(scalar_is_inf3(s))
+            goto write_inf_positive; // NOLINT
+        else if(scalar_is_nan3(s))
+            goto write_nan; // NOLINT
     }
     return false;
+write_inf_positive:
+    write_("\".inf\"");
+    return true;
+write_inf_negative:
+    write_("\"-.inf\"");
+    return true;
+write_nan:
+    write_("\".nan\"");
+    return true;
 }
 
 template<class Writer>

--- a/src/c4/yml/file.hpp
+++ b/src/c4/yml/file.hpp
@@ -54,12 +54,27 @@ struct ScopedFILE
  */
 
 /** save a contiguous buffer into a file */
+inline void file_put_contents(void const* buf, size_t sz, FILE *file, const char* filename=nullptr)
+{
+    size_t written = std::fwrite(buf, 1, sz, file); // NOLINT
+    if(C4_UNLIKELY(written != sz))
+        _RYML_ERR_BASIC("{}: failed file write: expected={}B actual={}B", filename ? filename : "file", sz, written); // LCOV_EXCL_LINE
+}
+
+/** save a contiguous buffer into a file */
+template<class ContiguousContainer>
+void file_put_contents(ContiguousContainer const& v, FILE *file, const char *filename=nullptr)
+{
+    size_t vsz = static_cast<size_t>(v.size()) * sizeof(typename ContiguousContainer::value_type);
+    void const* vbuf = v.empty() ? nullptr : &v[0];
+    file_put_contents(vbuf, vsz, file, filename);
+}
+
+/** save a contiguous buffer into a file */
 inline void file_put_contents(void const* buf, size_t sz, const char *filename, const char* access="wb")
 {
     detail::ScopedFILE f(filename, access);
-    size_t written = std::fwrite(buf, 1, sz, f.file); // NOLINT
-    if(C4_UNLIKELY(written != sz))
-        _RYML_ERR_BASIC("{}: failed file write: expected={}B actual={}B", filename, sz, written); // LCOV_EXCL_LINE
+    file_put_contents(buf, sz, f.file, filename);
 }
 
 /** save a contiguous buffer into a file */

--- a/src/c4/yml/node_type.cpp
+++ b/src/c4/yml/node_type.cpp
@@ -300,40 +300,42 @@ bool scalar_is_null(csubstr s) noexcept
 
 //-----------------------------------------------------------------------------
 
-namespace {
-
-#define rest_is(c1, c2) ((s.str[1] == (c1)) && (s.str[2] == (c2)))
-bool is_inf_or_nan(csubstr s) noexcept
+#define ryml_rest_is_(c1, c2) ((s.str[1] == (c1)) && (s.str[2] == (c2)))
+bool scalar_is_inf3(csubstr s) noexcept
 {
-    _RYML_ASSERT_BASIC(!s.begins_with("-."));
-    _RYML_ASSERT_BASIC(!s.begins_with("+."));
-    _RYML_ASSERT_BASIC(!s.begins_with("."));
     _RYML_ASSERT_BASIC(s.len == 3);
     switch(s.str[0])
     {
-    case 'i': return rest_is('n', 'f');
-    case 'I': return rest_is('n', 'f') || rest_is('N', 'F');
-    case 'n': return rest_is('a', 'n');
-    case 'N': return rest_is('a', 'n') || rest_is('A', 'N') || rest_is('a', 'N');
+    case 'i': return ryml_rest_is_('n', 'f');
+    case 'I': return ryml_rest_is_('n', 'f') || ryml_rest_is_('N', 'F');
     }
     return false;
 }
-bool is_inf(csubstr s) noexcept
+bool scalar_is_nan3(csubstr s) noexcept
 {
-    _RYML_ASSERT_BASIC(!s.begins_with("-."));
-    _RYML_ASSERT_BASIC(!s.begins_with("+."));
-    _RYML_ASSERT_BASIC(!s.begins_with("."));
     _RYML_ASSERT_BASIC(s.len == 3);
     switch(s.str[0])
     {
-    case 'i': return rest_is('n', 'f');
-    case 'I': return rest_is('n', 'f') || rest_is('N', 'F');
+    case 'n': return ryml_rest_is_('a', 'n');
+    case 'N': return ryml_rest_is_('a', 'N') || ryml_rest_is_('a', 'n') || ryml_rest_is_('A', 'N');
     }
     return false;
 }
-#undef rest_is
+bool scalar_is_inf_or_nan3(csubstr s) noexcept
+{
+    _RYML_ASSERT_BASIC(s.len == 3);
+    switch(s.str[0])
+    {
+    case 'i': return ryml_rest_is_('n', 'f');
+    case 'I': return ryml_rest_is_('n', 'f') || ryml_rest_is_('N', 'F');
+    case 'n': return ryml_rest_is_('a', 'n');
+    case 'N': return ryml_rest_is_('a', 'N') || ryml_rest_is_('a', 'n') || ryml_rest_is_('A', 'N');
+    }
+    return false;
+}
+#undef ryml_rest_is_
 
-bool json_is_plain_number(csubstr s) noexcept
+bool scalar_is_plain_number_json(csubstr s) noexcept
 {
     return s.is_number()
         &&
@@ -346,22 +348,26 @@ bool json_is_plain_number(csubstr s) noexcept
             || (s.find('.') != csubstr::npos)
         );
 }
-bool json_is_special_scalar(csubstr s)  noexcept
+
+bool scalar_is_special_json(csubstr s) noexcept
 {
     if(s.len == 4)
         return 0 == memcmp("true", s.str, 4)
             || 0 == memcmp("null", s.str, 4)
-            || (s[0] == '.' && is_inf_or_nan(s.sub(1)));
+            || ((s[0] == '.') && scalar_is_inf_or_nan3(s.sub(1)))
+            || ((s[0] == '-' || s[0] == '+') && scalar_is_inf3(s.sub(1)));
     else if(s.len == 5)
         return 0 == memcmp("false", s.str, 5)
-            || ((s[0] == '-' || s[0] == '+') && s[1] == '.' && is_inf(s.sub(2)));
+            || ((s[0] == '-' || s[0] == '+') && s[1] == '.' && scalar_is_inf3(s.sub(2)));
+    else if(s.len == 3)
+        return scalar_is_inf_or_nan3(s);
     return false;
 }
-} // namespace
+
 NodeType_e scalar_style_choose_json(csubstr s) noexcept
 {
     // do not quote numbers or special scalars
-    return json_is_plain_number(s) || json_is_special_scalar(s) ? SCALAR_PLAIN : SCALAR_DQUO;
+    return scalar_is_plain_number_json(s) || scalar_is_special_json(s) ? SCALAR_PLAIN : SCALAR_DQUO;
 }
 
 } // namespace yml

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -434,6 +434,25 @@ inline bool scalar_style_query_plain(csubstr s, bool flow=true) noexcept
  * `"~"`,`"null"`,`"Null"`,`"NULL"` */
 RYML_EXPORT bool scalar_is_null(csubstr s) noexcept;
 
+
+/** JSON-sense query of plain number */
+RYML_EXPORT bool scalar_is_plain_number_json(csubstr s) noexcept;
+/** JSON-sense query of plain number */
+RYML_EXPORT bool scalar_is_special_json(csubstr s)  noexcept;
+
+/** Query if a scalar is nan (nan, NaN, NAN)
+ * @warning length must be 3 (asserted)
+ */
+RYML_EXPORT bool scalar_is_inf3(csubstr s) noexcept;
+/** Query if a scalar is inf (inf, Inf, INF)
+ * @warning length must be 3 (asserted)
+ */
+RYML_EXPORT bool scalar_is_nan3(csubstr s) noexcept;
+/** Same as scalar_is_inf3() || scalar_is_nan3()
+ * @warning length must be 3 (asserted)
+ */
+RYML_EXPORT bool scalar_is_inf_or_nan3(csubstr s) noexcept;
+
 /** @} */
 
 /** @} */

--- a/src/c4/yml/writer_buf.hpp
+++ b/src/c4/yml/writer_buf.hpp
@@ -50,7 +50,7 @@ public:
 public:
 
     template<size_t N>
-    void append(const char (&a)[N]) noexcept
+    C4_ALWAYS_INLINE void append(const char (&a)[N]) noexcept
     {
         static_assert(N > 1, "empty string");
         _RYML_ASSERT_BASIC( ! m_buf.overlaps(a));
@@ -59,7 +59,7 @@ public:
         m_pos += N-1;
     }
 
-    void append(csubstr s) noexcept
+    C4_ALWAYS_INLINE void append(csubstr s) noexcept
     {
         _RYML_ASSERT_BASIC( ! s.overlaps(m_buf));
         if(s.len && m_pos + s.len <= m_buf.len)
@@ -67,14 +67,14 @@ public:
         m_pos += s.len;
     }
 
-    void append(const char c) noexcept
+    C4_ALWAYS_INLINE void append(const char c) noexcept
     {
         if(m_pos + 1 <= m_buf.len)
             m_buf.str[m_pos] = c;
         ++m_pos;
     }
 
-    void append(const char c, size_t num_times) noexcept
+    C4_ALWAYS_INLINE void append(const char c, size_t num_times) noexcept
     {
         if(m_pos + num_times <= m_buf.len)
             memset(m_buf.str + m_pos, c, num_times);

--- a/src/c4/yml/writer_file.hpp
+++ b/src/c4/yml/writer_file.hpp
@@ -25,13 +25,13 @@ struct RYML_EXPORT WriterFile
     WriterFile(FILE *f = nullptr) noexcept : m_file(f ? f : stdout) {}
 
     template<size_t N>
-    void append(const char (&a)[N]) noexcept // NOLINT(*-make-member-function-const)
+    C4_ALWAYS_INLINE void append(const char (&a)[N]) noexcept // NOLINT(*-make-member-function-const)
     {
         static_assert(N > 1, "empty string");
         (void)fwrite(a, sizeof(char), N - 1, m_file);
     }
 
-    void append(csubstr s) noexcept // NOLINT(*-make-member-function-const)
+    C4_ALWAYS_INLINE void append(csubstr s) noexcept // NOLINT(*-make-member-function-const)
     {
         if(s.len)
         {
@@ -41,12 +41,12 @@ struct RYML_EXPORT WriterFile
         }
     }
 
-    void append(const char c) noexcept // NOLINT(*-make-member-function-const)
+    C4_ALWAYS_INLINE void append(const char c) noexcept // NOLINT(*-make-member-function-const)
     {
         (void)fputc(c, m_file);
     }
 
-    void append(const char c, size_t num_times) noexcept // NOLINT(*-make-member-function-const)
+    C4_ALWAYS_INLINE void append(const char c, size_t num_times) noexcept // NOLINT(*-make-member-function-const)
     {
         for(size_t i = 0; i < num_times; ++i)
             (void)fputc(c, m_file);

--- a/src/c4/yml/writer_ostream.hpp
+++ b/src/c4/yml/writer_ostream.hpp
@@ -12,11 +12,6 @@ namespace yml {
 
 /** A writer that outputs to an STL-like ostream.
  *
- * @warning This writer is *much* slower than @ref WriterFile, and
- * @ref WriterFile should be preferred to this. The slowness is due to
- * how std::ostream works, and not because of anything in the code of
- * this class.
- *
  * @ingroup doc_writers
  * @ingroup doc_emit_to_ostream
  */
@@ -28,13 +23,13 @@ struct WriterOStream
     WriterOStream(OStream *s) noexcept : m_stream(s) {}
 
     template<size_t N>
-    void append(const char (&a)[N]) noexcept
+    C4_ALWAYS_INLINE void append(const char (&a)[N]) noexcept
     {
         static_assert(N > 1, "empty string");
         m_stream->write(a, N - 1);
     }
 
-    void append(csubstr s) noexcept
+    C4_ALWAYS_INLINE void append(csubstr s) noexcept
     {
         if(s.len)
         {
@@ -44,12 +39,12 @@ struct WriterOStream
         }
     }
 
-    void append(const char c) noexcept
+    C4_ALWAYS_INLINE void append(const char c) noexcept
     {
         m_stream->put(c);
     }
 
-    void append(const char c, size_t num_times) noexcept
+    C4_ALWAYS_INLINE void append(const char c, size_t num_times) noexcept
     {
         for(size_t i = 0; i < num_times; ++i)
             m_stream->put(c);

--- a/test/test_file.cpp
+++ b/test/test_file.cpp
@@ -17,11 +17,18 @@ std::string mkfile(Container const& expected)
     file_put_contents(expected, name.c_str());
     return name;
 }
+template<class Container>
+std::string mkfile2(Container const& expected)
+{
+    std::string name = c4::fs::tmpnam<std::string>();
+    detail::ScopedFILE sf(name.c_str(), "wb");
+    file_put_contents(expected, sf.file, name.c_str());
+    return name;
+}
 
 template<class Container>
-void test_roundtrip(Container const& expected)
+void test_roundtrip_reads(Container const& expected, std::string const& name)
 {
-    std::string name = mkfile(expected);
     const char *filename = name.c_str();
     Container actual = file_get_contents<Container>(filename);
     EXPECT_EQ(actual.size(), expected.size());
@@ -43,7 +50,22 @@ void test_roundtrip(Container const& expected)
         EXPECT_EQ(other.size(), expected.size());
         EXPECT_EQ(other, expected);
     }
-    c4::fs::rmfile(filename);
+}
+template<class Container>
+void test_roundtrip(Container const& expected)
+{
+    {
+        SCOPED_TRACE("mk1");
+        std::string name = mkfile(expected);
+        test_roundtrip_reads<Container>(expected, name);
+        c4::fs::rmfile(name.c_str());
+    }
+    {
+        SCOPED_TRACE("mk2");
+        std::string name = mkfile2(expected);
+        test_roundtrip_reads<Container>(expected, name);
+        c4::fs::rmfile(name.c_str());
+    }
 }
 template<class T>
 void testvec()

--- a/test/test_number.cpp
+++ b/test/test_number.cpp
@@ -263,6 +263,9 @@ TEST(number, inf_0)
 - -.inf
 - -.inf
 )");
+    EXPECT_TRUE(scalar_is_special_json(".inf"));
+    EXPECT_TRUE(scalar_is_special_json("-.inf"));
+    EXPECT_TRUE(scalar_is_special_json("+.inf"));
     EXPECT_EQ(emitrs_json<std::string>(t),
               R"([".inf",".inf","-.inf","-.inf"])");
 }
@@ -457,6 +460,105 @@ set:
     "-.inf": "-.inf",
     "-.inf": "-.inf",
     "-.inf": "-.inf"
+  },
+  "set": {
+    "nothing0": "nothing",
+    "nothing1": "nothing"
+  }
+}
+)");
+    });
+}
+
+TEST(number, inf_3)
+{
+    csubstr yaml = R"(
+good:
+  +.inf: +.inf
+  +.inf:   +.inf
+  +.Inf: +.Inf
+  +.INF: +.INF
+  +inf: +inf
+  +infinity: +infinity
+  infinity: infinity
+  +.inf:
+    +.inf
+set:
+  nothing0: nothing
+  nothing1: nothing
+)";
+    test_check_emit_check(yaml, [](Tree const& t){
+        float finf = std::numeric_limits<float>::infinity();
+        double dinf = std::numeric_limits<double>::infinity();
+        EXPECT_EQ(t["good"][0].val(), "+.inf");
+        EXPECT_EQ(t["good"][1].val(), "+.inf");
+        EXPECT_EQ(t["good"][2].val(), "+.Inf");
+        EXPECT_EQ(t["good"][3].val(), "+.INF");
+        EXPECT_EQ(t["good"][4].val(), "+inf");
+        EXPECT_EQ(t["good"][5].val(), "+infinity");
+        EXPECT_EQ(t["good"][6].val(), "infinity");
+        EXPECT_EQ(t["good"][7].val(), "+.inf");
+        EXPECT_EQ(t["good"][0].key(), "+.inf");
+        EXPECT_EQ(t["good"][1].key(), "+.inf");
+        EXPECT_EQ(t["good"][2].key(), "+.Inf");
+        EXPECT_EQ(t["good"][3].key(), "+.INF");
+        EXPECT_EQ(t["good"][4].key(), "+inf");
+        EXPECT_EQ(t["good"][5].key(), "+infinity");
+        EXPECT_EQ(t["good"][6].key(), "infinity");
+        EXPECT_EQ(t["good"][7].key(), "+.inf");
+        for(ConstNodeRef ch : t["good"]){
+            SCOPED_TRACE(ch.key());
+            {
+                float f = 0.f;
+                double d = 0.;
+                ch >> f;
+                ch >> d;
+                EXPECT_TRUE(fleq(f, finf));
+                EXPECT_TRUE(fleq(d, dinf));
+            }
+            {
+                float f = 0.f;
+                double d = 0.;
+                ch >> key(f);
+                ch >> key(d);
+                EXPECT_TRUE(fleq(f, finf));
+                EXPECT_TRUE(fleq(d, dinf));
+            }
+        }
+        for(ConstNodeRef ch : t["set"]){
+            SCOPED_TRACE(ch.key());
+            float f = 0.f;
+            double d = 0.;
+            ExpectError::check_error_visit(&t, [&]{ ch >> f; });
+            ExpectError::check_error_visit(&t, [&]{ ch >> d; });
+            ExpectError::check_error_visit(&t, [&]{ ch >> key(f); });
+            ExpectError::check_error_visit(&t, [&]{ ch >> key(d); });
+        }
+        EXPECT_EQ(emitrs_yaml<std::string>(t),
+                  R"(good:
+  +.inf: +.inf
+  +.inf: +.inf
+  +.Inf: +.Inf
+  +.INF: +.INF
+  +inf: +inf
+  +infinity: +infinity
+  infinity: infinity
+  +.inf: +.inf
+set:
+  nothing0: nothing
+  nothing1: nothing
+)");
+        EXPECT_EQ(emitrs_json<std::string>(t),
+                  R"({
+  "good": {
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf",
+    ".inf": ".inf"
   },
   "set": {
     "nothing0": "nothing",


### PR DESCRIPTION
  - Improve handling of NaN and Inf in json emitting.
  - Expose scalar style helpers for json emitting:
    ```c++
    /** JSON-sense query of plain number */
    bool scalar_is_plain_number_json(csubstr s);
    /** JSON-sense query of plain number */
    bool scalar_is_special_json(csubstr s);
    /** Query if a scalar is nan (nan, NaN, NAN)
     * @warning length must be 3 (asserted)
     */
    bool scalar_is_inf3(csubstr s);
    /** Query if a scalar is inf (inf, Inf, INF)
     * @warning length must be 3 (asserted)
     */
    bool scalar_is_nan3(csubstr s);
    /** Same as scalar_is_inf3() || scalar_is_nan3()
     * @warning length must be 3 (asserted)
     */
    bool scalar_is_inf_or_nan3(csubstr s);
    ```
  - Writers: add `C4_ALWAYS_INLINE`. Results in ~10-20% emit improvements.
  - `file_put_contents()`: add `FILE*` overloads