### PR TITLE
API cleanup: Tree and NodeRef

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -47,3 +47,4 @@
 - [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean Tree API:
   - Add `Tree::arena_rem()`
   - Add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256
+  - `Tree`: deprecate to_val() and friends -- add set_val() and friends

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -48,6 +48,7 @@
   - Deprecate `NodeInit`
   - `Tree` and `NodeRef`:
     - deprecate `.to_val()` and friends -- add `.set_val()` and friends.
+    - deprecate `operator=(csubstr)` and friends -- use `.set_val()` instead.
     - deprecate `operator|=(NodeType)` and `operator=(NodeType)` -- use appropriate overload `.set_*(T, NodeType)`. For example:
       ```c++
       // before

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -64,6 +64,7 @@
       ```
     - deprecate `NodeInit` and `NodeScalar` methods (use `.set_*()`)
     - deprecate single-arg `NodeRef::{duplicate,move}(ConstNodeRef)`
+    - deprecate `NodeRef::visit()` and `NodeRef::visit_stacked()`
     - add `Tree::arena_rem()`
     - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with default value of 256
   - `parse_*()`: internal simplification, no semantic changes

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -51,14 +51,19 @@
     - deprecate `operator|=(NodeType)` and `operator=(NodeType)` -- use appropriate overload `.set_*(T, NodeType)`. For example:
       ```c++
       // before
-      node |= MAP;
+      node |= MAP|BLOCK;
       node["key"] = "val";
       node["key"] |= VAL_SQUO;
+      node["seq"] |= SEQ|FLOW;
+      node["seq2"] |= SEQ;
       // now:
-      node.set_map();
+      node.set_map(BLOCK);
       node["key"].set_val("val", VAL_SQUO);
+      node["seq"].set_seq(FLOW);
+      node["seq2"].set_seq();
       ```
     - deprecate `NodeInit` and `NodeScalar` methods (use `.set_*()`)
+    - deprecate single-arg `NodeRef::{duplicate,move}(ConstNodeRef)`
     - add `Tree::arena_rem()`
     - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with default value of 256
   - `parse_*()`: internal simplification, no semantic changes

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -52,4 +52,7 @@
     - add `Tree::arena_rem()`
     - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256
   - `parse_*()`: internal simplification, no semantic changes
+  - `NodeRef`:
+    - deprecate `NodeInit` methods
+    - deprecate `NodeScalar` methods
   

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -46,3 +46,4 @@
 - [PR#622](https://github.com/biojppm/rapidyaml/pull/622): Remove preprocess utilities.
 - [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean Tree API:
   - Add `Tree::arena_rem()`
+  - Add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -44,3 +44,5 @@
   - Writers: add `C4_ALWAYS_INLINE`. Results in ~10-20% emit improvements.
   - `file_put_contents()`: add `FILE*` overloads
 - [PR#622](https://github.com/biojppm/rapidyaml/pull/622): Remove preprocess utilities.
+- [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean Tree API:
+  - Add `Tree::arena_rem()`

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -44,15 +44,22 @@
   - Writers: add `C4_ALWAYS_INLINE`. Results in ~10-20% emit improvements.
   - `file_put_contents()`: add `FILE*` overloads
 - [PR#622](https://github.com/biojppm/rapidyaml/pull/622): Remove preprocess utilities.
-- [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean `Tree` API:
+- [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean `Tree` and `NodeRef`:
   - Deprecate `NodeInit`
-  - `Tree`:
-    - deprecate to_val() and friends -- add set_val() and friends
-    - deprecate `NodeInit` methods
+  - `Tree` and `NodeRef`:
+    - deprecate `.to_val()` and friends -- add `.set_val()` and friends.
+    - deprecate `operator|=(NodeType)` and `operator=(NodeType)` -- use appropriate overload `.set_*(T, NodeType)`. For example:
+      ```c++
+      // before
+      node |= MAP;
+      node["key"] = "val";
+      node["key"] |= VAL_SQUO;
+      // now:
+      node.set_map();
+      node["key"].set_val("val", VAL_SQUO);
+      ```
+    - deprecate `NodeInit` and `NodeScalar` methods (use `.set_*()`)
     - add `Tree::arena_rem()`
-    - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256
+    - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with default value of 256
   - `parse_*()`: internal simplification, no semantic changes
-  - `NodeRef`:
-    - deprecate `NodeInit` methods
-    - deprecate `NodeScalar` methods
   

--- a/changelog/current.md
+++ b/changelog/current.md
@@ -15,12 +15,12 @@
       - `c4/yml/writer_buf.hpp`: policy class to emit to char buffer (`substr`)
       - `c4/yml/writer_file.hpp`: policy class to emit to C `FILE*`
       - `c4/yml/writer_ostream.hpp`: policy class to emit to STL-like ostreams
-    - There are no external logic changes: all the `emit_*()` functions remain the same.
+    - There are no semantic changes: all the `emit_*()` functions remain the same.
     - Other changes in this PR:
       - Added `Tree::root_id_maybe()` which is safe to call on an empty tree.
       - Deprecate `Emitter::max_depth()`
       - Deprecate `Emitter::options()` setter
-- [PR#618](https://github.com/biojppm/rapidyaml/pull/618): Clean emit API pt3:
+- [PR#618](https://github.com/biojppm/rapidyaml/pull/618): Clean emit API, part 3:
   - Improve handling of NaN and Inf in json emitting.
   - Expose scalar style helpers for json emitting:
     ```c++
@@ -44,7 +44,12 @@
   - Writers: add `C4_ALWAYS_INLINE`. Results in ~10-20% emit improvements.
   - `file_put_contents()`: add `FILE*` overloads
 - [PR#622](https://github.com/biojppm/rapidyaml/pull/622): Remove preprocess utilities.
-- [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean Tree API:
-  - Add `Tree::arena_rem()`
-  - Add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256
-  - `Tree`: deprecate to_val() and friends -- add set_val() and friends
+- [PR#619](https://github.com/biojppm/rapidyaml/pull/619): Clean `Tree` API:
+  - Deprecate `NodeInit`
+  - `Tree`:
+    - deprecate to_val() and friends -- add set_val() and friends
+    - deprecate `NodeInit` methods
+    - add `Tree::arena_rem()`
+    - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with value of 256
+  - `parse_*()`: internal simplification, no semantic changes
+  

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -666,14 +666,14 @@ void sample_quick_overview()
     // desired then a NodeRef must be used instead:
     ryml::NodeRef wroot = tree.rootref(); // writeable root
 
-    // operator= assigns an existing string to the receiving node.
+    // .set_val() assigns an existing string to the receiving node.
     // The contents are NOT copied, and the string pointer will be in
     // effect until the tree goes out of scope! So BEWARE to only
     // assign from strings outliving the tree.
-    wroot["foo"] = "says you";
-    wroot["bar"][0] = "-2";
-    wroot["bar"][1] = "-3";
-    wroot["john"] = "ron";
+    wroot["foo"].set_val("says you");
+    wroot["bar"][0].set_val("-2");
+    wroot["bar"][1].set_val("-3");
+    wroot["john"].set_val("ron");
     // Now the tree is _pointing_ at the memory of the strings above.
     // In this case it is OK because those are static strings, located
     // in the executable's static section, and will outlive the tree.
@@ -724,7 +724,7 @@ void sample_quick_overview()
 
     // adding a keyval node to a map:
     CHECK(root.num_children() == 5);
-    wroot["newkeyval"] = "shiny and new"; // using these strings
+    wroot["newkeyval"].set_val("shiny and new"); // using these strings
     wroot.append_child() << ryml::key("newkeyval (serialized)") << "shiny and new (serialized)"; // serializes and assigns the serialization
     CHECK(root.num_children() == 7);
     CHECK(root["newkeyval"].key() == "newkeyval");
@@ -737,7 +737,7 @@ void sample_quick_overview()
     CHECK(   tree.in_arena(root["newkeyval (serialized)"].val())); // it's using a serialization of the string above
     // adding a val node to a seq:
     CHECK(root["bar"].num_children() == 2);
-    wroot["bar"][2] = "oh so nice";
+    wroot["bar"][2].set_val("oh so nice");
     wroot["bar"][3] << "oh so nice (serialized)";
     CHECK(root["bar"].num_children() == 4);
     CHECK(root["bar"][2].val() == "oh so nice");
@@ -807,7 +807,7 @@ void sample_quick_overview()
     CHECK(constsomething.invalid()); // NOTE: because a ConstNodeRef cannot be
                                      // used to mutate a tree, it is only valid()
                                      // if it is pointing at an existing node.
-    something = "indeed";  // this will commit the seed to the tree, mutating at the proper place
+    something.set_val("indeed");  // this will commit the seed to the tree, mutating at the proper place
     CHECK(root.has_child("I am something"));
     CHECK(root["I am something"].val() == "indeed");
     CHECK(!something.invalid()); // it was already valid
@@ -937,7 +937,7 @@ void sample_quick_overview()
     //constnoderef = "21";  // compile error
     //constnoderef << "22"; // compile error
     // ... but a NodeRef can:
-    noderef = "21";         // ok, can assign because it's not const
+    noderef.set_val("21");         // ok, can assign because it's not const
     CHECK(tree["bar"][0].val() == "21");
     noderef << "22";        // ok, can serialize and assign because it's not const
     CHECK(tree["bar"][0].val() == "22");
@@ -2326,7 +2326,7 @@ void sample_create_trees()
 
     // set the value of the node
     const char a_deer[] = "a deer, a female deer";
-    doe = a_deer;
+    doe.set_val(a_deer);
     // now the node really exists in the tree, and this ref is no
     // longer a seed:
     CHECK(!doe.is_seed());
@@ -2351,20 +2351,20 @@ void sample_create_trees()
     root["french-hens"] << 3;
     ryml::NodeRef calling_birds = root["calling-birds"];
     calling_birds.set_seq();
-    calling_birds.append_child() = "huey";
-    calling_birds.append_child() = "dewey";
-    calling_birds.append_child() = "louie";
-    calling_birds.append_child() = "fred";
+    calling_birds.append_child().set_val("huey");
+    calling_birds.append_child().set_val("dewey");
+    calling_birds.append_child().set_val("louie");
+    calling_birds.append_child().set_val("fred");
     ryml::NodeRef xmas5 = root["xmas-fifth-day"];
     xmas5.set_map();
-    xmas5["calling-birds"] = "four";
+    xmas5["calling-birds"].set_val("four");
     xmas5["french-hens"] << 3;
     xmas5["golden-rings"] << 5;
     xmas5["partridges"].set_map();
     xmas5["partridges"]["count"] << 1;
-    xmas5["partridges"]["location"] = "a pear tree";
-    xmas5["turtle-doves"] = "two";
-    root["cars"] = "GTO";
+    xmas5["partridges"]["location"].set_val("a pear tree");
+    xmas5["turtle-doves"].set_val("two");
+    root["cars"].set_val("GTO");
 
     CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
           "doe: a deer, a female deer"       "\n"
@@ -5278,14 +5278,14 @@ void sample_anchors_and_aliases_create()
     {
         ryml::Tree t;
         t.rootref().set_map(ryml::BLOCK);
-        t["kanchor"] = "2";
+        t["kanchor"].set_val("2");
         t["kanchor"].set_key_anchor("kanchor");
-        t["vanchor"] = "3";
+        t["vanchor"].set_val("3");
         t["vanchor"].set_val_anchor("vanchor");
         // to set a reference, need to call .set_val_ref()/.set_key_ref()
         t["kref"].set_val_ref("kanchor");
         t["vref"].set_val_ref("vanchor");
-        t["nref"] = "*vanchor";  // NOTE: this is not set as a reference in the tree!
+        t["nref"].set_val("*vanchor");  // NOTE: this is not set as a reference in the tree!
         CHECK(ryml::emitrs_yaml<std::string>(t) == ""
               "&kanchor kanchor: 2"  "\n"
               "vanchor: &vanchor 3"  "\n"
@@ -5317,7 +5317,7 @@ void sample_anchors_and_aliases_create()
         t["copy"]["<<"].set_val_ref("orig");
         t["notcopy"]["test"].set_val_ref("orig");
         t["notcopy"]["<<"].set_val_ref("orig");
-        t["notref"]["<<"] = "*orig"; // not a reference! .set_val_ref() was not called
+        t["notref"]["<<"].set_val("*orig"); // not a reference! .set_val_ref() was not called
         CHECK(ryml::emitrs_yaml<std::string>(t) == ""
               "orig: &orig {foo: bar,baz: bat}"      "\n"
               "copy: {<<: *orig}"                    "\n"

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -744,8 +744,8 @@ void sample_quick_overview()
     CHECK(root["bar"][3].val() == "oh so nice (serialized)");
     // adding a seq node:
     CHECK(root.num_children() == 7);
-    wroot["newseq"] |= ryml::SEQ;
-    wroot.append_child() << ryml::key("newseq (serialized)") |= ryml::SEQ;
+    wroot["newseq"].set_seq();
+    (wroot.append_child() << ryml::key("newseq (serialized)")).set_seq();
     CHECK(root.num_children() == 9);
     CHECK(root["newseq"].num_children() == 0);
     CHECK(root["newseq"].is_seq());
@@ -753,8 +753,8 @@ void sample_quick_overview()
     CHECK(root["newseq (serialized)"].is_seq());
     // adding a map node:
     CHECK(root.num_children() == 9);
-    wroot["newmap"] |= ryml::MAP;
-    wroot.append_child() << ryml::key("newmap (serialized)") |= ryml::MAP;
+    wroot["newmap"].set_map();
+    (wroot.append_child() << ryml::key("newmap (serialized)")).set_map();
     CHECK(root.num_children() == 11);
     CHECK(root["newmap"].num_children() == 0);
     CHECK(root["newmap"].is_map());
@@ -2062,8 +2062,8 @@ void sample_parse_reuse_tree()
     CHECK(root[3]["champagne"].val() == "Dom Perignon");
     CHECK(root[3]["coffee"].val() == "Arabica");
 
-    mroot[3]["more"] |= ryml::MAP;
-    mroot[3]["beer"] |= ryml::SEQ;
+    mroot[3]["more"].set_map();
+    mroot[3]["beer"].set_seq();
     CHECK(mroot[3]["more"].readable());
     CHECK(mroot[3]["more"].key() == "more");
     CHECK(mroot[3]["more"].is_map());
@@ -2319,7 +2319,7 @@ void sample_create_trees()
 
     ryml::Tree tree;
     ryml::NodeRef root = tree.rootref();
-    root |= ryml::MAP; // mark root as a map
+    root.set_map(); // mark root as a map
     doe = root["doe"];
     CHECK(!doe.invalid()); // it's now pointing at the tree
     CHECK(doe.is_seed()); // but the tree has nothing there, so this is only a seed
@@ -2350,17 +2350,17 @@ void sample_create_trees()
     root["xmas"] << ryml::fmt::boolalpha(true);
     root["french-hens"] << 3;
     ryml::NodeRef calling_birds = root["calling-birds"];
-    calling_birds |= ryml::SEQ;
+    calling_birds.set_seq();
     calling_birds.append_child() = "huey";
     calling_birds.append_child() = "dewey";
     calling_birds.append_child() = "louie";
     calling_birds.append_child() = "fred";
     ryml::NodeRef xmas5 = root["xmas-fifth-day"];
-    xmas5 |= ryml::MAP;
+    xmas5.set_map();
     xmas5["calling-birds"] = "four";
     xmas5["french-hens"] << 3;
     xmas5["golden-rings"] << 5;
-    xmas5["partridges"] |= ryml::MAP;
+    xmas5["partridges"].set_map();
     xmas5["partridges"]["count"] << 1;
     xmas5["partridges"]["location"] = "a pear tree";
     xmas5["turtle-doves"] = "two";
@@ -2744,7 +2744,7 @@ void sample_empty_null_values()
     CHECK(tilde  .len != 0); CHECK(tilde  .str != nullptr); CHECK(tilde   != nullptr);
     tree.clear();
     tree.clear_arena();
-    tree.rootref() |= ryml::MAP;
+    tree.rootref().set_map();
     // serializes as an empty plain scalar:
     tree["empty_null"] << null; CHECK(tree.arena() == "");
     // serializes as an empty quoted scalar:
@@ -3253,7 +3253,7 @@ void sample_base64()
 {
     // let's start by creating a tree with base64 vals and keys
     ryml::Tree tree;
-    tree.rootref() |= ryml::MAP;
+    tree.rootref().set_map();
     struct text_and_base64 { ryml::csubstr text, base64; };
     text_and_base64 cases[] = {
         {{"Hello, World!"}, {"SGVsbG8sIFdvcmxkIQ=="}},
@@ -3585,7 +3585,7 @@ void sample_user_scalar_types()
     ryml::Tree t;
 
     auto r = t.rootref();
-    r |= ryml::MAP;
+    r.set_map();
 
     vec2<int> v2in{10, 11};
     vec2<int> v2out{1, 2};
@@ -3713,20 +3713,20 @@ struct my_type
 template<class T>
 void write(ryml::NodeRef *n, my_seq_type<T> const& seq)
 {
-    *n |= ryml::SEQ;
+    n->set_seq();
     for(auto const& v : seq.seq_member)
         n->append_child() << v;
 }
 template<class K, class V>
 void write(ryml::NodeRef *n, my_map_type<K, V> const& map)
 {
-    *n |= ryml::MAP;
+    n->set_map();
     for(auto const& v : map.map_member)
         n->append_child() << ryml::key(v.first) << v.second;
 }
 void write(ryml::NodeRef *n, my_type const& val)
 {
-    *n |= ryml::MAP;
+    n->set_map();
     // these are leaf nodes:
     n->append_child() << ryml::key("v2") << val.v2;
     n->append_child() << ryml::key("v3") << val.v3;
@@ -4011,7 +4011,7 @@ void sample_float_precision()
     {
         ryml::Tree serialized;
         ryml::NodeRef root = serialized.rootref();
-        root |= ryml::SEQ;
+        root.set_seq();
         for(const double v : reference)
             root.append_child() << ryml::fmt::real(v, num_digits_original, ryml::FTOA_FLOAT);
         check_precision(serialized); // OK - now within bounds!
@@ -4021,7 +4021,7 @@ void sample_float_precision()
     {
         ryml::Tree serialized;
         ryml::NodeRef root = serialized.rootref();
-        root |= ryml::SEQ;
+        root.set_seq();
         char tmp[64];
         for(const double v : reference)
         {
@@ -5277,7 +5277,7 @@ void sample_anchors_and_aliases_create()
     // part 1: anchor/ref
     {
         ryml::Tree t;
-        t.rootref() |= ryml::MAP|ryml::BLOCK;
+        t.rootref().set_map(ryml::BLOCK);
         t["kanchor"] = "2";
         t["kanchor"].set_key_anchor("kanchor");
         t["vanchor"] = "3";
@@ -5342,7 +5342,7 @@ void sample_anchors_and_aliases_create()
             "copy: {}"                       "\n"
             "");
         ryml::NodeRef seq = t["copy"]["<<"];
-        seq |= ryml::SEQ;
+        seq.set_seq();
         seq.append_child().set_val_ref("orig1");
         seq.append_child().set_val_ref("orig2");
         seq.append_child().set_val_ref("orig3");

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -2,6 +2,8 @@
 
 /** @addtogroup doc_quickstart
  *
+ * Best seen online at https://rapidyaml.readthedocs.io/v0.15.2/doxygen/
+ *
  * This file does a quick tour of ryml. It has multiple self-contained
  * and well-commented samples that illustrate how to use ryml, and how
  * it works.
@@ -38,6 +40,7 @@
  *
  * Or very quickly, to build and run this sample on your PC, start by
  * creating this `CMakeLists.txt`:
+ *
  * ```cmake
  * cmake_minimum_required(VERSION 3.13)
  * project(ryml-quickstart LANGUAGES CXX)
@@ -55,7 +58,9 @@
  *     DEPENDS ryml-quickstart
  *     COMMENT "running: $<TARGET_FILE:ryml-quickstart>")
  * ```
+ *
  * Now run the following commands in the same folder:
+ *
  * ```bash
  * # configure the project
  * cmake -S . -B build
@@ -2057,14 +2062,15 @@ void sample_parse_reuse_tree()
     CHECK(root[3]["champagne"].val() == "Dom Perignon");
     CHECK(root[3]["coffee"].val() == "Arabica");
 
-    // watchout: to add to an existing node within a map, the node's
-    // key must be separately set first:
-    ryml::NodeRef more = mroot[3].append_child({ryml::KEYMAP, "more"});
-    ryml::NodeRef beer = mroot[3].append_child({ryml::KEYSEQ, "beer"});
-    ryml::NodeRef always = mroot[3].append_child({ryml::KEY, "always"});
-    ryml::parse_in_arena("{vinho verde: Soalheiro, vinho tinto: Redoma 2017}", more);
-    ryml::parse_in_arena("- Rochefort 10\n- Busch\n- Leffe Rituel", beer);
-    ryml::parse_in_arena("lots\nof\nwater", always);
+    mroot[3]["more"] |= ryml::MAP;
+    mroot[3]["beer"] |= ryml::SEQ;
+    CHECK(mroot[3]["more"].readable());
+    CHECK(mroot[3]["more"].key() == "more");
+    CHECK(mroot[3]["more"].is_map());
+    CHECK(!mroot[3]["more"].is_val());
+    ryml::parse_in_arena("{vinho verde: Soalheiro, vinho tinto: Redoma 2017}", mroot[3]["more"]);
+    ryml::parse_in_arena("- Rochefort 10\n- Busch\n- Leffe Rituel", mroot[3]["beer"]);
+    ryml::parse_in_arena("lots\nof\nwater", mroot[3]["always"]);
     CHECK(ryml::emitrs_yaml<std::string>(tree) == ""
           "- a"                              "\n"
           "- b"                              "\n"
@@ -2106,7 +2112,7 @@ void sample_parse_reuse_tree()
           "");
 
     // or nested:
-    ryml::parse_in_arena("[Kasteel Donker]", beer);
+    ryml::parse_in_arena("[Kasteel Donker]", mroot[3]["beer"]);
     CHECK(ryml::emitrs_yaml<std::string>(tree) ==
           "- a"                              "\n"
           "- b"                              "\n"

--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -28,6 +28,12 @@
 #define RYML_DEFAULT_TREE_ARENA_CAPACITY (0)
 #endif
 
+#ifndef RYML_DEFAULT_TREE_ARENA_CAPACITY_START
+/// default starting capacity for the tree's arena when it is first
+/// allocated. should be larger than @ref RYML_DEFAULT_TREE_ARENA_CAPACITY
+#define RYML_DEFAULT_TREE_ARENA_CAPACITY_START (256)
+#endif
+
 
 #ifndef RYML_LOCATIONS_SMALL_THRESHOLD
 /// threshold at which a location search will revert from linear to

--- a/src/c4/yml/event_handler_tree.hpp
+++ b/src/c4/yml/event_handler_tree.hpp
@@ -69,9 +69,9 @@ public:
     /** @name construction and resetting
      * @{ */
 
-    EventHandlerTree() : EventHandlerStack(), m_tree(), m_curr_doc() {}
-    EventHandlerTree(Callbacks const& cb) : EventHandlerStack(cb), m_tree(), m_curr_doc() {}
-    EventHandlerTree(Tree *tree, id_type id) : EventHandlerStack(tree->callbacks()), m_tree(tree), m_curr_doc()
+    EventHandlerTree() noexcept : EventHandlerStack(), m_tree(), m_curr_doc() {}
+    EventHandlerTree(Callbacks const& cb) noexcept : EventHandlerStack(cb), m_tree(), m_curr_doc() {}
+    EventHandlerTree(Tree *tree, id_type id) /*except!*/ : EventHandlerStack(tree->callbacks()), m_tree(tree), m_curr_doc()
     {
         reset(tree, id);
     }
@@ -81,7 +81,7 @@ public:
         if(C4_UNLIKELY(!tree))
             _RYML_ERR_BASIC_(m_stack.m_callbacks, "null tree");
         if(C4_UNLIKELY(id >= tree->capacity()))
-            _RYML_ERR_BASIC_(tree->callbacks(), "invalid node");
+            _RYML_ERR_VISIT_(tree->callbacks(), tree, id, "invalid node");
         if(C4_UNLIKELY(!tree->is_root(id)))
             if(C4_UNLIKELY(tree->is_map(tree->parent(id))))
                 if(C4_UNLIKELY(!tree->has_key(id)))

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -108,8 +108,9 @@ struct children_view_
     n_iterator end  () const { return e; }
 };
 
+/** @cond dev */ // LCOV_EXCL_START
 template<class NodeRefType, class Visitor>
-bool _visit(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_root=false)
+RYML_DEPRECATED("") bool _visit(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_root=false)
 {
     id_type increment = 0;
     if( ! (node.is_root() && skip_root))
@@ -132,7 +133,7 @@ bool _visit(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_
 }
 
 template<class NodeRefType, class Visitor>
-bool _visit_stacked(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_root=false)
+RYML_DEPRECATED("") bool _visit_stacked(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_root=false)
 {
     id_type increment = 0;
     if( ! (node.is_root() && skip_root))
@@ -158,6 +159,7 @@ bool _visit_stacked(NodeRefType &node, Visitor fn, id_type indentation_level, bo
     }
     return false;
 }
+/** @endcond */ // LCOV_EXCL_STOP
 
 template<class Impl, class ConstImpl>
 struct RoNodeMethods;
@@ -768,39 +770,38 @@ public:
     /** get an iterable view over all siblings (including the calling node) */
     C4_ALWAYS_INLINE const_children_view csiblings() const RYML_NOEXCEPT { return siblings(); }
 
-    /** visit every child node calling fn(node) */
+    /** @} */
+
+public:
+
+    /** @cond dev */ // LCOV_EXCL_START
     template<class Visitor>
-    bool visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
+    RYML_DEPRECATED("") bool visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
     {
         _C4RR();
         return detail::_visit(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }
-    /** visit every child node calling fn(node) */
     template<class Visitor, class U=Impl>
-    auto visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
+    RYML_DEPRECATED("") auto visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
         -> _C4_IF_MUTABLE(bool)
     {
         _C4RR();
         return detail::_visit(*(Impl*)this, fn, indentation_level, skip_root);
     }
-
-    /** visit every child node calling fn(node, level) */
     template<class Visitor>
-    bool visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
+    RYML_DEPRECATED("") bool visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
     {
         _C4RR();
         return detail::_visit_stacked(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }
-    /** visit every child node calling fn(node, level) */
     template<class Visitor, class U=Impl>
-    auto visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
+    RYML_DEPRECATED("") auto visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
         -> _C4_IF_MUTABLE(bool)
     {
         _C4RR();
         return detail::_visit_stacked(*(Impl*)this, fn, indentation_level, skip_root);
     }
-
-    /** @} */
+    /** @endcond */ // LCOV_EXCL_STOP
 
     #if defined(__clang__)
     #   pragma clang diagnostic pop
@@ -891,8 +892,6 @@ public:
      * This method is provided for API equivalence between ConstNodeRef and NodeRef. */
     constexpr static C4_ALWAYS_INLINE bool is_seed() noexcept { return false; }
 
-    RYML_DEPRECATED("use one of readable(), is_seed() or !invalid()") bool valid() const noexcept { return m_tree != nullptr && m_id != NONE; }
-
     /** @} */
 
 public:
@@ -913,15 +912,17 @@ public:
     C4_ALWAYS_INLINE bool operator== (ConstNodeRef const& that) const RYML_NOEXCEPT { return that.m_tree == m_tree && m_id == that.m_id; }
     C4_ALWAYS_INLINE bool operator!= (ConstNodeRef const& that) const RYML_NOEXCEPT { return ! this->operator== (that); }
 
-    /** @cond dev */
+    /** @} */
+
+public:
+
+    /** @cond dev */ // LCOV_EXCL_START
+    RYML_DEPRECATED("use one of readable(), is_seed() or !invalid()") bool valid() const noexcept { return m_tree != nullptr && m_id != NONE; }
     RYML_DEPRECATED("use invalid()")  bool operator== (std::nullptr_t) const noexcept { return m_tree == nullptr || m_id == NONE; }
     RYML_DEPRECATED("use !invalid()") bool operator!= (std::nullptr_t) const noexcept { return !(m_tree == nullptr || m_id == NONE); }
-
     RYML_DEPRECATED("use (this->val() == s)") bool operator== (csubstr s) const RYML_NOEXCEPT { _RYML_ASSERT_BASIC(m_tree); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE, m_tree, NONE); return m_tree->val(m_id) == s; }
     RYML_DEPRECATED("use (this->val() != s)") bool operator!= (csubstr s) const RYML_NOEXCEPT { _RYML_ASSERT_BASIC(m_tree); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE, m_tree, NONE); return m_tree->val(m_id) != s; }
-    /** @endcond */
-
-    /** @} */
+    /** @endcond */ // LCOV_EXCL_STOP
 
 };
 

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -3,27 +3,23 @@
 
 /** @file node.hpp Node classes */
 
-#include <cstddef>
-
+#ifndef _C4_YML_TREE_HPP_
 #include "c4/yml/tree.hpp"
-
-#ifdef __clang__
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wtype-limits"
-#   pragma clang diagnostic ignored "-Wold-style-cast"
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic push
-#   pragma GCC diagnostic ignored "-Wtype-limits"
-#   pragma GCC diagnostic ignored "-Wold-style-cast"
-#   pragma GCC diagnostic ignored "-Wuseless-cast"
-#elif defined(_MSC_VER)
-#   pragma warning(push)
-#   pragma warning(disable: 4251/*needs to have dll-interface to be used by clients of struct*/)
-#   pragma warning(disable: 4296/*expression is always 'boolean_value'*/)
-#   pragma warning(disable: 4996/*deprecated*/)
 #endif
 
+C4_SUPPRESS_WARNING_PUSH
+C4_SUPPRESS_WARNING_GCC_CLANG("-Wtype-limits")
+C4_SUPPRESS_WARNING_GCC_CLANG("-Wold-style-cast")
+C4_SUPPRESS_WARNING_GCC("-Wuseless-cast")
+C4_SUPPRESS_WARNING_CLANG("-Wnull-dereference")
+#if defined(__GNUC__) && __GNUC__ >= 6
+C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
+#endif
+C4_SUPPRESS_WARNING_MSVC(4251/*needs to have dll-interface to be used by clients of struct*/)
+C4_SUPPRESS_WARNING_MSVC(4296/*expression is always 'boolean_value'*/)
+C4_SUPPRESS_WARNING_MSVC(4996/*deprecated*/)
 // NOLINTBEGIN(modernize-avoid-c-style-cast)
+
 
 namespace c4 {
 namespace yml {
@@ -108,7 +104,7 @@ struct children_view_
     n_iterator end  () const { return e; }
 };
 
-/** @cond dev */ // LCOV_EXCL_START
+// LCOV_EXCL_START
 template<class NodeRefType, class Visitor>
 RYML_DEPRECATED("") bool _visit(NodeRefType &node, Visitor fn, id_type indentation_level, bool skip_root=false)
 {
@@ -159,10 +155,8 @@ RYML_DEPRECATED("") bool _visit_stacked(NodeRefType &node, Visitor fn, id_type i
     }
     return false;
 }
-/** @endcond */ // LCOV_EXCL_STOP
+// LCOV_EXCL_STOP
 
-template<class Impl, class ConstImpl>
-struct RoNodeMethods;
 } // detail
 /** @endcond */
 
@@ -711,16 +705,6 @@ public:
 
 public:
 
-    #if defined(__clang__) // NOLINT
-    #   pragma clang diagnostic push
-    #   pragma clang diagnostic ignored "-Wnull-dereference"
-    #elif defined(__GNUC__)
-    #   pragma GCC diagnostic push
-    #   if __GNUC__ >= 6
-    #       pragma GCC diagnostic ignored "-Wnull-dereference"
-    #   endif
-    #endif
-
     /** @name iteration */
     /** @{ */
 
@@ -774,6 +758,10 @@ public:
 
 public:
 
+    C4_SUPPRESS_WARNING_PUSH
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated")
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
+    C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
     /** @cond dev */ // LCOV_EXCL_START
     template<class Visitor>
     RYML_DEPRECATED("") bool visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
@@ -802,12 +790,7 @@ public:
         return detail::_visit_stacked(*(Impl*)this, fn, indentation_level, skip_root);
     }
     /** @endcond */ // LCOV_EXCL_STOP
-
-    #if defined(__clang__)
-    #   pragma clang diagnostic pop
-    #elif defined(__GNUC__)
-    #   pragma GCC diagnostic pop
-    #endif
+    C4_SUPPRESS_WARNING_POP
 
     #undef _C4_IF_MUTABLE
     #undef _C4RR
@@ -1018,9 +1001,11 @@ public:
     NodeRef(Tree *t, id_type id, csubstr  seed_key) noexcept : m_tree(t), m_id(id), m_seed(seed_key) {}
     NodeRef(std::nullptr_t) noexcept : m_tree(nullptr), m_id(NONE), m_seed() {}
 
-    void _clear_seed() noexcept { /*do the following manually or an assert is triggered: */ m_seed.str = nullptr; m_seed.len = npos; }
-
     /** @} */
+
+private:
+
+    void _clear_seed() noexcept { /*do the following manually or an assert is triggered: */ m_seed.str = nullptr; m_seed.len = npos; }
 
 public:
 
@@ -1046,8 +1031,6 @@ public:
     bool is_seed() const noexcept { return (m_tree != nullptr && m_id != NONE) && (m_seed.str != nullptr || m_seed.len != (size_t)NONE); }
     /** true if the object is not invalid and not in seed state. @see the doc for @ref NodeRef */
     bool readable() const noexcept { return (m_tree != nullptr && m_id != NONE) && (m_seed.str == nullptr && m_seed.len == (size_t)NONE); }
-
-    RYML_DEPRECATED("use one of readable(), is_seed() or !invalid()") inline bool valid() const { return m_tree != nullptr && m_id != NONE; }
 
     /** @} */
 
@@ -1079,13 +1062,7 @@ public:
     bool operator== (ConstNodeRef const& that) const { return m_tree == that.m_tree && m_id == that.m_id && !is_seed(); }
     bool operator!= (ConstNodeRef const& that) const { return ! this->operator==(that); }
 
-    /** @cond dev */
-    RYML_DEPRECATED("use !readable()") bool operator== (std::nullptr_t) const { return m_tree == nullptr || m_id == NONE || is_seed(); }
-    RYML_DEPRECATED("use readable()")  bool operator!= (std::nullptr_t) const { return !(m_tree == nullptr || m_id == NONE || is_seed()); }
-
-    RYML_DEPRECATED("use `this->val() == s`") bool operator== (csubstr s) const { _C4RR(); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_val(), m_tree, m_id); return m_tree->val(m_id) == s; }
-    RYML_DEPRECATED("use `this->val() != s`") bool operator!= (csubstr s) const { _C4RR(); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_val(), m_tree, m_id); return m_tree->val(m_id) != s; }
-    /** @endcond */
+    /** @} */
 
 public:
 
@@ -1207,14 +1184,14 @@ public:
     template<class T>
     size_t set_key_serialized(T const& C4_RESTRICT k)
     {
-        _apply_seed();
+        create();
         csubstr s = m_tree->to_arena(k);
         m_tree->set_key(m_id, s);
         return s.len;
     }
     size_t set_key_serialized(std::nullptr_t)
     {
-        _apply_seed();
+        create();
         m_tree->set_key(m_id, csubstr{});
         return 0;
     }
@@ -1222,14 +1199,14 @@ public:
     template<class T>
     size_t set_val_serialized(T const& C4_RESTRICT v)
     {
-        _apply_seed();
+        create();
         csubstr s = m_tree->to_arena(v);
         m_tree->set_val(m_id, s);
         return s.len;
     }
     size_t set_val_serialized(std::nullptr_t)
     {
-        _apply_seed();
+        create();
         m_tree->set_val(m_id, csubstr{});
         return 0;
     }
@@ -1239,7 +1216,7 @@ public:
     {
         // this overload is needed to prevent ambiguity (there's also
         // operator<< for writing a substr to a stream)
-        _apply_seed();
+        create();
         write(this, s);
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, val() == s, m_tree, m_id);
         return *this;
@@ -1248,7 +1225,7 @@ public:
     template<class T>
     NodeRef& operator<< (T const& C4_RESTRICT v)
     {
-        _apply_seed();
+        create();
         write(this, v);
         return *this;
     }
@@ -1257,7 +1234,7 @@ public:
     template<class T>
     NodeRef& operator<< (Key<const T> const& C4_RESTRICT v)
     {
-        _apply_seed();
+        create();
         set_key_serialized(v.k);
         return *this;
     }
@@ -1266,37 +1243,12 @@ public:
     template<class T>
     NodeRef& operator<< (Key<T> const& C4_RESTRICT v)
     {
-        _apply_seed();
+        create();
         set_key_serialized(v.k);
         return *this;
     }
 
     /** @} */
-
-private:
-
-    void _apply_seed()
-    {
-        _C4RID();
-        if(m_seed.str) // we have a seed key: use it to create the new child
-        {
-            m_id = m_tree->append_child(m_id);
-            m_tree->set_key(m_id, m_seed);
-            m_seed.str = nullptr;
-            m_seed.len = (size_t)NONE;
-        }
-        else if(m_seed.len != (size_t)NONE) // we have a seed index: create a child at that position
-        {
-            _RYML_ASSERT_VISIT_(m_tree->m_callbacks, (size_t)m_tree->num_children(m_id) == m_seed.len, m_tree, m_id);
-            m_id = m_tree->append_child(m_id);
-            m_seed.str = nullptr;
-            m_seed.len = (size_t)NONE;
-        }
-        else
-        {
-            _RYML_ASSERT_VISIT_(m_tree->m_callbacks, readable(), m_tree, m_id);
-        }
-    }
 
 public:
 
@@ -1437,6 +1389,12 @@ public: // deprecated functions
     C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
     C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
 
+    RYML_DEPRECATED("use one of readable(), is_seed() or !invalid()") inline bool valid() const { return m_tree != nullptr && m_id != NONE; }
+    RYML_DEPRECATED("use !readable()") bool operator== (std::nullptr_t) const { return m_tree == nullptr || m_id == NONE || is_seed(); }
+    RYML_DEPRECATED("use readable()")  bool operator!= (std::nullptr_t) const { return !(m_tree == nullptr || m_id == NONE || is_seed()); }
+    RYML_DEPRECATED("use `this->val() == s`") bool operator== (csubstr s) const { assert_readable_(); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_val(), m_tree, m_id); return m_tree->val(m_id) == s; }
+    RYML_DEPRECATED("use `this->val() != s`") bool operator!= (csubstr s) const { assert_readable_(); _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_val(), m_tree, m_id); return m_tree->val(m_id) != s; }
+
     RYML_DEPRECATED("") void operator= (NodeType_e t)
     {
         create();
@@ -1495,7 +1453,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") void operator= (NodeScalar const& v)
     {
-        _apply_seed();
+        create();
         _apply(v);
     }
 
@@ -1676,12 +1634,6 @@ C4_ALWAYS_INLINE bool readkey(NodeRef const& C4_RESTRICT n, T const& wrapper)
 
 // NOLINTEND(modernize-avoid-c-style-cast)
 
-#ifdef __clang__
-#   pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic pop
-#elif defined(_MSC_VER)
-#   pragma warning(pop)
-#endif
+C4_SUPPRESS_WARNING_POP
 
 #endif /* _C4_YML_NODE_HPP_ */

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -1032,6 +1032,31 @@ public:
     NodeRef& operator= (NodeRef const&) noexcept = default;
     NodeRef& operator= (NodeRef     &&) noexcept = default;
 
+    /** same as .set_val(v) */
+    NodeRef& operator= (csubstr v)
+    {
+        set_val(v);
+        return *this;
+    }
+
+    /** same as .set_val(csubstr(v)) */
+    template<size_t N>
+    NodeRef& operator= (const char (&v)[N])
+    {
+        csubstr sv;
+        sv.assign<N>(v);
+        set_val(sv);
+        return *this;
+    }
+
+    /** same as .set_key(v.k) */
+    template<class T>
+    NodeRef& operator= (Key<T> const& C4_RESTRICT v)
+    {
+        set_key(v.k);
+        return *this;
+    }
+
     /** @} */
 
 public:
@@ -1103,60 +1128,88 @@ public:
     /** @name node_modifiers */
     /** @{ */
 
-    void create() { _apply_seed(); }
+    /// if this node is in seed state, create the node in the tree
+    void create()
+    {
+        _RYML_ASSERT_BASIC(m_tree != nullptr);
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE && m_id < m_tree->capacity(), m_tree, m_id);
+        if(m_seed.str) // we have a seed key: use it to create the new map child
+        {
+            m_id = m_tree->append_child(m_id);
+            m_tree->set_key(m_id, m_seed);
+            m_seed.str = nullptr;
+            m_seed.len = (size_t)NONE;
+        }
+        else if(m_seed.len != (size_t)NONE) // we have a seed index: create a seq child at that position
+        {
+            _RYML_ASSERT_VISIT_(m_tree->m_callbacks, (size_t)m_tree->num_children(m_id) == m_seed.len, m_tree, m_id);
+            m_id = m_tree->append_child(m_id);
+            m_seed.str = nullptr;
+            m_seed.len = (size_t)NONE;
+        }
+    }
 
-    void change_type(NodeType t) { _C4RR(); m_tree->change_type(m_id, t); }
+    void set_stream() { create(); m_tree->set_stream(m_id); }
+    void set_doc() { create(); m_tree->set_doc(m_id); }
 
-    void set_type(NodeType t) { _apply_seed(); m_tree->_set_flags(m_id, t); }
-    void set_key(csubstr key) { _apply_seed(); m_tree->_set_key(m_id, key); }
-    void set_val(csubstr val) { _apply_seed(); m_tree->_set_val(m_id, val); }
-    void set_key_tag(csubstr key_tag) { _apply_seed(); m_tree->set_key_tag(m_id, key_tag); }
-    void set_val_tag(csubstr val_tag) { _apply_seed(); m_tree->set_val_tag(m_id, val_tag); }
-    void set_key_anchor(csubstr key_anchor) { _apply_seed(); m_tree->set_key_anchor(m_id, key_anchor); }
-    void set_val_anchor(csubstr val_anchor) { _apply_seed(); m_tree->set_val_anchor(m_id, val_anchor); }
-    void set_key_ref(csubstr key_ref) { _apply_seed(); m_tree->set_key_ref(m_id, key_ref); }
-    void set_val_ref(csubstr val_ref) { _apply_seed(); m_tree->set_val_ref(m_id, val_ref); }
+    void set_key(csubstr key) { create(); m_tree->set_key(m_id, key); }
+    void set_key(csubstr key, NodeType more_flags) { create(); m_tree->set_key(m_id, key, more_flags); }
 
-    void set_container_style(NodeType_e style) { _C4RR(); m_tree->set_container_style(m_id, style); }
-    void set_key_style(NodeType_e style) { _C4RR(); m_tree->set_key_style(m_id, style); }
-    void set_val_style(NodeType_e style) { _C4RR(); m_tree->set_val_style(m_id, style); }
-    void clear_style(bool recurse=false) { _C4RR(); m_tree->clear_style(m_id, recurse); }
+    void set_val(csubstr val) { create(); m_tree->set_val(m_id, val); }
+    void set_val(csubstr val, NodeType more_flags) { create(); m_tree->set_val(m_id, val, more_flags); }
+
+    void set_seq() { create(); m_tree->set_seq(m_id); }
+    void set_seq(NodeType more_flags) { create(); m_tree->set_seq(m_id, more_flags); }
+
+    void set_map() { create(); m_tree->set_map(m_id); }
+    void set_map(NodeType more_flags) { create(); m_tree->set_map(m_id, more_flags); }
+
+    void set_key_tag(csubstr key_tag) { create(); m_tree->set_key_tag(m_id, key_tag); }
+    void set_val_tag(csubstr val_tag) { create(); m_tree->set_val_tag(m_id, val_tag); }
+    void set_key_anchor(csubstr key_anchor) { create(); m_tree->set_key_anchor(m_id, key_anchor); }
+    void set_val_anchor(csubstr val_anchor) { create(); m_tree->set_val_anchor(m_id, val_anchor); }
+    void set_key_ref(csubstr key_ref) { create(); m_tree->set_key_ref(m_id, key_ref); }
+    void set_val_ref(csubstr val_ref) { create(); m_tree->set_val_ref(m_id, val_ref); }
+
+    void set_container_style(NodeType_e style) { create(); m_tree->set_container_style(m_id, style); }
+    void set_key_style(NodeType_e style) { create(); m_tree->set_key_style(m_id, style); }
+    void set_val_style(NodeType_e style) { create(); m_tree->set_val_style(m_id, style); }
+    void clear_style(bool recurse=false) { create(); m_tree->clear_style(m_id, recurse); }
     void set_style_conditionally(NodeType type_mask,
                                  NodeType rem_style_flags,
                                  NodeType add_style_flags,
                                  bool recurse=false)
     {
-        _C4RR(); m_tree->set_style_conditionally(m_id, type_mask, rem_style_flags, add_style_flags, recurse);
+        create();
+        m_tree->set_style_conditionally(m_id, type_mask, rem_style_flags, add_style_flags, recurse);
     }
 
 public:
 
+    void change_type(NodeType t) { _C4RR(); m_tree->change_type(m_id, t); }
+
     void clear()
     {
-        if(is_seed())
-            return;
+        _C4RR();
         m_tree->remove_children(m_id);
         m_tree->_clear(m_id);
     }
 
     void clear_key()
     {
-        if(is_seed())
-            return;
+        _C4RR();
         m_tree->_clear_key(m_id);
     }
 
     void clear_val()
     {
-        if(is_seed())
-            return;
+        _C4RR();
         m_tree->_clear_val(m_id);
     }
 
     void clear_children()
     {
-        if(is_seed())
-            return;
+        _apply_seed();
         m_tree->remove_children(m_id);
     }
 
@@ -1172,37 +1225,10 @@ public:
         m_tree->_add_flags(m_id, t);
     }
 
-    void operator= (NodeInit const& v)
-    {
-        _apply_seed();
-        _apply(v);
-    }
-
-    void operator= (NodeScalar const& v)
-    {
-        _apply_seed();
-        _apply(v);
-    }
-
     void operator= (std::nullptr_t)
     {
         _apply_seed();
         _apply(csubstr{});
-    }
-
-    void operator= (csubstr v)
-    {
-        _apply_seed();
-        _apply(v);
-    }
-
-    template<size_t N>
-    void operator= (const char (&v)[N])
-    {
-        _apply_seed();
-        csubstr sv;
-        sv.assign<N>(v);
-        _apply(sv);
     }
 
     /** @} */
@@ -1225,13 +1251,13 @@ public:
     {
         _apply_seed();
         csubstr s = m_tree->to_arena(k);
-        m_tree->_set_key(m_id, s);
+        m_tree->set_key(m_id, s);
         return s.len;
     }
     size_t set_key_serialized(std::nullptr_t)
     {
         _apply_seed();
-        m_tree->_set_key(m_id, csubstr{});
+        m_tree->set_key(m_id, csubstr{});
         return 0;
     }
 
@@ -1240,13 +1266,13 @@ public:
     {
         _apply_seed();
         csubstr s = m_tree->to_arena(v);
-        m_tree->_set_val(m_id, s);
+        m_tree->set_val(m_id, s);
         return s.len;
     }
     size_t set_val_serialized(std::nullptr_t)
     {
         _apply_seed();
-        m_tree->_set_val(m_id, csubstr{});
+        m_tree->set_val(m_id, csubstr{});
         return 0;
     }
 
@@ -1297,7 +1323,7 @@ private:
         if(m_seed.str) // we have a seed key: use it to create the new child
         {
             m_id = m_tree->append_child(m_id);
-            m_tree->_set_key(m_id, m_seed);
+            m_tree->set_key(m_id, m_seed);
             m_seed.str = nullptr;
             m_seed.len = (size_t)NONE;
         }
@@ -1316,17 +1342,7 @@ private:
 
     void _apply(csubstr v)
     {
-        m_tree->_set_val(m_id, v);
-    }
-
-    void _apply(NodeScalar const& v)
-    {
-        m_tree->_set_val(m_id, v);
-    }
-
-    void _apply(NodeInit const& i)
-    {
-        m_tree->_set(m_id, i);
+        m_tree->set_val(m_id, v);
     }
 
 public:
@@ -1342,15 +1358,6 @@ public:
         return r;
     }
 
-    NodeRef insert_child(NodeInit const& i, NodeRef after)
-    {
-        _C4RR();
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
-        NodeRef r(m_tree, m_tree->insert_child(m_id, after.m_id));
-        r._apply(i);
-        return r;
-    }
-
     NodeRef prepend_child()
     {
         _C4RR();
@@ -1358,26 +1365,10 @@ public:
         return r;
     }
 
-    NodeRef prepend_child(NodeInit const& i)
-    {
-        _C4RR();
-        NodeRef r(m_tree, m_tree->insert_child(m_id, NONE));
-        r._apply(i);
-        return r;
-    }
-
     NodeRef append_child()
     {
         _C4RR();
         NodeRef r(m_tree, m_tree->append_child(m_id));
-        return r;
-    }
-
-    NodeRef append_child(NodeInit const& i)
-    {
-        _C4RR();
-        NodeRef r(m_tree, m_tree->append_child(m_id));
-        r._apply(i);
         return r;
     }
 
@@ -1389,15 +1380,6 @@ public:
         return r;
     }
 
-    NodeRef insert_sibling(NodeInit const& i, ConstNodeRef const& after)
-    {
-        _C4RR();
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
-        NodeRef r(m_tree, m_tree->insert_sibling(m_id, after.m_id));
-        r._apply(i);
-        return r;
-    }
-
     NodeRef prepend_sibling()
     {
         _C4RR();
@@ -1405,26 +1387,10 @@ public:
         return r;
     }
 
-    NodeRef prepend_sibling(NodeInit const& i)
-    {
-        _C4RR();
-        NodeRef r(m_tree, m_tree->prepend_sibling(m_id));
-        r._apply(i);
-        return r;
-    }
-
     NodeRef append_sibling()
     {
         _C4RR();
         NodeRef r(m_tree, m_tree->append_sibling(m_id));
-        return r;
-    }
-
-    NodeRef append_sibling(NodeInit const& i)
-    {
-        _C4RR();
-        NodeRef r(m_tree, m_tree->append_sibling(m_id));
-        r._apply(i);
         return r;
     }
 
@@ -1509,36 +1475,112 @@ public:
     NodeRef duplicate(NodeRef const& parent, ConstNodeRef const& after) const
     {
         _C4RR();
+        //parent.assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
-        if(parent.m_tree == m_tree)
-        {
-            id_type dup = m_tree->duplicate(m_id, parent.m_id, after.m_id);
-            NodeRef r(m_tree, dup);
-            return r;
-        }
-        else
-        {
-            id_type dup = parent.m_tree->duplicate(m_tree, m_id, parent.m_id, after.m_id);
-            NodeRef r(parent.m_tree, dup);
-            return r;
-        }
+        id_type dup = parent.m_tree->duplicate(m_tree, m_id, parent.m_id, after.m_id);
+        NodeRef r(parent.m_tree, dup);
+        return r;
     }
 
-    void duplicate_children(NodeRef const& parent, ConstNodeRef const& after) const
+    NodeRef duplicate_children(NodeRef const& parent, ConstNodeRef const& after) const
     {
         _C4RR();
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree, m_tree, m_id);
-        if(parent.m_tree == m_tree)
-        {
-            m_tree->duplicate_children(m_id, parent.m_id, after.m_id);
-        }
-        else
-        {
-            parent.m_tree->duplicate_children(m_tree, m_id, parent.m_id, after.m_id);
-        }
+        //parent.assert_readable_();
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
+        id_type last_dup = parent.m_tree->duplicate_children(m_tree, m_id, parent.m_id, after.m_id);
+        NodeRef r(parent.m_tree, last_dup);
+        return r;
     }
 
     /** @} */
+
+public: // deprecated functions
+
+    // these functions will be removed in future releases. If you
+    // disagree with a particular function being deprecated, let us
+    // know by opening a new issue at
+    // https://github.com/biojppm/rapidyaml/issues
+
+    /** @cond dev */ // LCOV_EXCL_START
+    C4_SUPPRESS_WARNING_PUSH
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated")
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
+    C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
+
+    RYML_DEPRECATED("") void operator= (NodeInit const& v)
+    {
+        create();
+        _apply(v);
+    }
+
+    RYML_DEPRECATED("") void _apply(NodeInit const& i)
+    {
+        m_tree->_set(m_id, i);
+    }
+
+    RYML_DEPRECATED("") NodeRef insert_child(NodeInit const& i, NodeRef after)
+    {
+        _C4RR();
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
+        NodeRef r(m_tree, m_tree->insert_child(m_id, after.m_id));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") NodeRef prepend_child(NodeInit const& i)
+    {
+        _C4RR();
+        NodeRef r(m_tree, m_tree->insert_child(m_id, NONE));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") NodeRef append_child(NodeInit const& i)
+    {
+        _C4RR();
+        NodeRef r(m_tree, m_tree->append_child(m_id));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") NodeRef insert_sibling(NodeInit const& i, ConstNodeRef const& after)
+    {
+        _C4RR();
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
+        NodeRef r(m_tree, m_tree->insert_sibling(m_id, after.m_id));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") NodeRef prepend_sibling(NodeInit const& i)
+    {
+        _C4RR();
+        NodeRef r(m_tree, m_tree->prepend_sibling(m_id));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") NodeRef append_sibling(NodeInit const& i)
+    {
+        _C4RR();
+        NodeRef r(m_tree, m_tree->append_sibling(m_id));
+        r._apply(i);
+        return r;
+    }
+
+    RYML_DEPRECATED("") void _apply(NodeScalar const& v)
+    {
+        m_tree->_set_val(m_id, v);
+    }
+
+    RYML_DEPRECATED("") void operator= (NodeScalar const& v)
+    {
+        _apply_seed();
+        _apply(v);
+    }
+
+    C4_SUPPRESS_WARNING_POP
+    /** @endcond */ // LCOV_EXCL_STOP
 
 #undef _C4RR
 #undef _C4RID

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -1213,18 +1213,6 @@ public:
         m_tree->remove_children(m_id);
     }
 
-    void operator= (NodeType_e t)
-    {
-        _apply_seed();
-        m_tree->_add_flags(m_id, t);
-    }
-
-    void operator|= (NodeType_e t)
-    {
-        _apply_seed();
-        m_tree->_add_flags(m_id, t);
-    }
-
     void operator= (std::nullptr_t)
     {
         _apply_seed();
@@ -1454,19 +1442,6 @@ public:
         }
     }
 
-    /** duplicate the current node somewhere within its parent, and
-     * place it after the node @p after. To place into the first
-     * position of the parent, simply pass an empty or
-     * default-constructed reference like this: `n.move({})`. */
-    NodeRef duplicate(ConstNodeRef const& after) const
-    {
-        _C4RR();
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
-        id_type dup = m_tree->duplicate(m_id, m_tree->parent(m_id), after.m_id);
-        NodeRef r(m_tree, dup);
-        return r;
-    }
-
     /** duplicate the current node somewhere into a different @p parent
      * (possibly from a different tree), and place it after the node
      * @p after. To place into the first position of the parent,
@@ -1506,6 +1481,18 @@ public: // deprecated functions
     C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated")
     C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
     C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
+
+    RYML_DEPRECATED("") void operator= (NodeType_e t)
+    {
+        create();
+        m_tree->_add_flags(m_id, t);
+    }
+
+    RYML_DEPRECATED("") void operator|= (NodeType_e t)
+    {
+        create();
+        m_tree->_add_flags(m_id, t);
+    }
 
     RYML_DEPRECATED("") void operator= (NodeInit const& v)
     {

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -1033,31 +1033,6 @@ public:
     NodeRef& operator= (NodeRef const&) noexcept = default;
     NodeRef& operator= (NodeRef     &&) noexcept = default;
 
-    /** same as .set_val(v) */
-    NodeRef& operator= (csubstr v)
-    {
-        set_val(v);
-        return *this;
-    }
-
-    /** same as .set_val(csubstr(v)) */
-    template<size_t N>
-    NodeRef& operator= (const char (&v)[N])
-    {
-        csubstr sv;
-        sv.assign<N>(v);
-        set_val(sv);
-        return *this;
-    }
-
-    /** same as .set_key(v.k) */
-    template<class T>
-    NodeRef& operator= (Key<T> const& C4_RESTRICT v)
-    {
-        set_key(v.k);
-        return *this;
-    }
-
     /** @} */
 
 public:
@@ -1214,12 +1189,6 @@ public:
         m_tree->remove_children(m_id);
     }
 
-    void operator= (std::nullptr_t)
-    {
-        _apply_seed();
-        _apply(csubstr{});
-    }
-
     /** @} */
 
 public:
@@ -1327,11 +1296,6 @@ private:
         {
             _RYML_ASSERT_VISIT_(m_tree->m_callbacks, readable(), m_tree, m_id);
         }
-    }
-
-    void _apply(csubstr v)
-    {
-        m_tree->set_val(m_id, v);
     }
 
 public:
@@ -1485,10 +1449,43 @@ public: // deprecated functions
         m_tree->_add_flags(m_id, t);
     }
 
+    RYML_DEPRECATED("use .set_val()") NodeRef& operator= (csubstr v)
+    {
+        set_val(v);
+        return *this;
+    }
+
+    template<size_t N>
+    RYML_DEPRECATED("use .set_val()") NodeRef& operator= (const char (&v)[N])
+    {
+        csubstr sv;
+        sv.assign<N>(v);
+        set_val(sv);
+        return *this;
+    }
+
+    RYML_DEPRECATED("use .set_val()") void operator= (std::nullptr_t)
+    {
+        set_val(csubstr{});
+    }
+
+    /** same as .set_key(v.k) */
+    template<class T>
+    RYML_DEPRECATED("use .set_key()") NodeRef& operator= (Key<T> const& C4_RESTRICT v)
+    {
+        set_key(v.k);
+        return *this;
+    }
+
     RYML_DEPRECATED("") void operator= (NodeInit const& v)
     {
         create();
         _apply(v);
+    }
+
+    RYML_DEPRECATED("") void _apply(csubstr v)
+    {
+        m_tree->set_val(m_id, v);
     }
 
     RYML_DEPRECATED("") void _apply(NodeScalar const& v)

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -1340,7 +1340,7 @@ public:
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_child(child), m_tree, m_id);
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, child.parent().id() == id(), m_tree, m_id);
         m_tree->remove(child.id());
-        child.clear();
+        child = NodeRef{};
     }
 
     //! remove the nth child of this node
@@ -1371,6 +1371,8 @@ public:
     void move(NodeRef const& parent, ConstNodeRef const& after)
     {
         assert_readable_();
+        parent.assert_readable_();
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
         if(parent.m_tree == m_tree)
         {
             m_tree->move(m_id, parent.m_id, after.m_id);

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -1414,16 +1414,6 @@ public:
 
 public:
 
-    /** change the node's position within its parent, placing it after
-     * @p after. To move to the first position in the parent, simply
-     * pass an empty or default-constructed reference like this:
-     * `n.move({})`. */
-    void move(ConstNodeRef const& after)
-    {
-        _C4RR();
-        m_tree->move(m_id, after.m_id);
-    }
-
     /** move the node to a different @p parent (which may belong to a
      * different tree), placing it after @p after. When the
      * destination parent is in a new tree, then this node's tree
@@ -1500,6 +1490,17 @@ public: // deprecated functions
         _apply(v);
     }
 
+    RYML_DEPRECATED("") void _apply(NodeScalar const& v)
+    {
+        m_tree->_set_val(m_id, v);
+    }
+
+    RYML_DEPRECATED("") void operator= (NodeScalar const& v)
+    {
+        _apply_seed();
+        _apply(v);
+    }
+
     RYML_DEPRECATED("") void _apply(NodeInit const& i)
     {
         m_tree->_set(m_id, i);
@@ -1555,15 +1556,19 @@ public: // deprecated functions
         return r;
     }
 
-    RYML_DEPRECATED("") void _apply(NodeScalar const& v)
+    RYML_DEPRECATED("") void move(ConstNodeRef const& after)
     {
-        m_tree->_set_val(m_id, v);
+        _C4RR();
+        m_tree->move(m_id, after.m_id);
     }
 
-    RYML_DEPRECATED("") void operator= (NodeScalar const& v)
+    RYML_DEPRECATED("") NodeRef duplicate(ConstNodeRef const& after) const
     {
-        _apply_seed();
-        _apply(v);
+        _C4RR();
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
+        id_type dup = m_tree->duplicate(m_id, m_tree->parent(m_id), after.m_id);
+        NodeRef r(m_tree, dup);
+        return r;
     }
 
     C4_SUPPRESS_WARNING_POP

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -170,22 +170,17 @@ namespace detail {
 template<class Impl, class ConstImpl>
 struct RoNodeMethods // NOLINT
 {
-    C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wcast-align")
     /** @cond dev */
-    // helper CRTP macros, undefined at the end
+    // CRTP helper macros, undefined at the end
     #define tree_ ((ConstImpl const* C4_RESTRICT)this)->m_tree
     #define id_ ((ConstImpl const* C4_RESTRICT)this)->m_id
     #define tree__ ((Impl const* C4_RESTRICT)this)->m_tree
     #define id__ ((Impl const* C4_RESTRICT)this)->m_id
-    // require readable: this is a precondition for reading from the
-    // tree using this object.
-    #define _C4RR()                                       \
-        _RYML_ASSERT_BASIC(tree_ != nullptr);              \
-        _RYML_ASSERT_VISIT_(tree_->m_callbacks, id_ != NONE, tree_, id_); \
-        _RYML_ASSERT_VISIT_(tree_->m_callbacks, (((Impl const* C4_RESTRICT)this)->readable()), tree_, id_)
+    #define assert_readable__() ((Impl const* C4_RESTRICT)this)->assert_readable_()
     // a SFINAE beautifier to enable a function only if the
     // implementation is mutable
     #define _C4_IF_MUTABLE(ty) typename std::enable_if<!std::is_same<U, ConstImpl>::value, ty>::type
+    C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wcast-align") // the leading members are aligned
     /** @endcond */
 
 public:
@@ -200,27 +195,27 @@ public:
     template<class U=Impl>
     C4_ALWAYS_INLINE auto get() RYML_NOEXCEPT -> _C4_IF_MUTABLE(NodeData*) { return ((Impl const*)this)->readable() ? tree__->get(id__) : nullptr; }
 
-    C4_ALWAYS_INLINE NodeType    type()     const RYML_NOEXCEPT { _C4RR(); return tree_->type(id_); }     /**< Forward to @ref Tree::type(). Node must be readable. */
-    C4_ALWAYS_INLINE const char* type_str() const RYML_NOEXCEPT { _C4RR(); return tree_->type_str(id_); } /**< Forward to @ref Tree::type_str(). Node must be readable. */
+    C4_ALWAYS_INLINE NodeType    type()     const RYML_NOEXCEPT { assert_readable__(); return tree_->type(id_); }     /**< Forward to @ref Tree::type(). Node must be readable. */
+    C4_ALWAYS_INLINE const char* type_str() const RYML_NOEXCEPT { assert_readable__(); return tree_->type_str(id_); } /**< Forward to @ref Tree::type_str(). Node must be readable. */
 
-    C4_ALWAYS_INLINE csubstr key()        const RYML_NOEXCEPT { _C4RR(); return tree_->key(id_); }        /**< Forward to @ref Tree::key(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr key_tag()    const RYML_NOEXCEPT { _C4RR(); return tree_->key_tag(id_); }    /**< Forward to @ref Tree::key_tag(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr key_ref()    const RYML_NOEXCEPT { _C4RR(); return tree_->key_ref(id_); }    /**< Forward to @ref Tree::key_ref(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr key_anchor() const RYML_NOEXCEPT { _C4RR(); return tree_->key_anchor(id_); } /**< Forward to @ref Tree::key_anchor(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr key()        const RYML_NOEXCEPT { assert_readable__(); return tree_->key(id_); }        /**< Forward to @ref Tree::key(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr key_tag()    const RYML_NOEXCEPT { assert_readable__(); return tree_->key_tag(id_); }    /**< Forward to @ref Tree::key_tag(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr key_ref()    const RYML_NOEXCEPT { assert_readable__(); return tree_->key_ref(id_); }    /**< Forward to @ref Tree::key_ref(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr key_anchor() const RYML_NOEXCEPT { assert_readable__(); return tree_->key_anchor(id_); } /**< Forward to @ref Tree::key_anchor(). Node must be readable. */
 
-    C4_ALWAYS_INLINE csubstr val()        const RYML_NOEXCEPT { _C4RR(); return tree_->val(id_); }        /**< Forward to @ref Tree::val(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr val_tag()    const RYML_NOEXCEPT { _C4RR(); return tree_->val_tag(id_); }    /**< Forward to @ref Tree::val_tag(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr val_ref()    const RYML_NOEXCEPT { _C4RR(); return tree_->val_ref(id_); }    /**< Forward to @ref Tree::val_ref(). Node must be readable. */
-    C4_ALWAYS_INLINE csubstr val_anchor() const RYML_NOEXCEPT { _C4RR(); return tree_->val_anchor(id_); } /**< Forward to @ref Tree::val_anchor(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr val()        const RYML_NOEXCEPT { assert_readable__(); return tree_->val(id_); }        /**< Forward to @ref Tree::val(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr val_tag()    const RYML_NOEXCEPT { assert_readable__(); return tree_->val_tag(id_); }    /**< Forward to @ref Tree::val_tag(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr val_ref()    const RYML_NOEXCEPT { assert_readable__(); return tree_->val_ref(id_); }    /**< Forward to @ref Tree::val_ref(). Node must be readable. */
+    C4_ALWAYS_INLINE csubstr val_anchor() const RYML_NOEXCEPT { assert_readable__(); return tree_->val_anchor(id_); } /**< Forward to @ref Tree::val_anchor(). Node must be readable. */
 
-    C4_ALWAYS_INLINE NodeScalar const& keysc() const RYML_NOEXCEPT { _C4RR(); return tree_->keysc(id_); } /**< Forward to @ref Tree::keysc(). Node must be readable. */
-    C4_ALWAYS_INLINE NodeScalar const& valsc() const RYML_NOEXCEPT { _C4RR(); return tree_->valsc(id_); } /**< Forward to @ref Tree::valsc(). Node must be readable. */
+    C4_ALWAYS_INLINE NodeScalar const& keysc() const RYML_NOEXCEPT { assert_readable__(); return tree_->keysc(id_); } /**< Forward to @ref Tree::keysc(). Node must be readable. */
+    C4_ALWAYS_INLINE NodeScalar const& valsc() const RYML_NOEXCEPT { assert_readable__(); return tree_->valsc(id_); } /**< Forward to @ref Tree::valsc(). Node must be readable. */
 
-    C4_ALWAYS_INLINE bool key_is_null() const RYML_NOEXCEPT { _C4RR(); return tree_->key_is_null(id_); } /**< Forward to @ref Tree::key_is_null(). Node must be readable. */
-    C4_ALWAYS_INLINE bool val_is_null() const RYML_NOEXCEPT { _C4RR(); return tree_->val_is_null(id_); } /**< Forward to @ref Tree::val_is_null(). Node must be readable. */
+    C4_ALWAYS_INLINE bool key_is_null() const RYML_NOEXCEPT { assert_readable__(); return tree_->key_is_null(id_); } /**< Forward to @ref Tree::key_is_null(). Node must be readable. */
+    C4_ALWAYS_INLINE bool val_is_null() const RYML_NOEXCEPT { assert_readable__(); return tree_->val_is_null(id_); } /**< Forward to @ref Tree::val_is_null(). Node must be readable. */
 
-    C4_ALWAYS_INLINE bool is_key_unfiltered() const noexcept { _C4RR(); return tree_->is_key_unfiltered(id_); } /**< Forward to @ref Tree::is_key_unfiltered(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_unfiltered() const noexcept { _C4RR(); return tree_->is_val_unfiltered(id_); } /**< Forward to @ref Tree::is_val_unfiltered(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_unfiltered() const noexcept { assert_readable__(); return tree_->is_key_unfiltered(id_); } /**< Forward to @ref Tree::is_key_unfiltered(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_unfiltered() const noexcept { assert_readable__(); return tree_->is_val_unfiltered(id_); } /**< Forward to @ref Tree::is_val_unfiltered(). Node must be readable. */
 
     /** @} */
 
@@ -229,31 +224,31 @@ public:
     /** @name node type predicates */
     /** @{ */
 
-    C4_ALWAYS_INLINE bool empty()            const RYML_NOEXCEPT { _C4RR(); return tree_->empty(id_); } /**< Forward to @ref Tree::empty(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_stream()        const RYML_NOEXCEPT { _C4RR(); return tree_->is_stream(id_); } /**< Forward to @ref Tree::is_stream(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_doc()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_doc(id_); } /**< Forward to @ref Tree::is_doc(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_container()     const RYML_NOEXCEPT { _C4RR(); return tree_->is_container(id_); } /**< Forward to @ref Tree::is_container(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_map()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_map(id_); } /**< Forward to @ref Tree::is_map(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_seq()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_seq(id_); } /**< Forward to @ref Tree::is_seq(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_val()          const RYML_NOEXCEPT { _C4RR(); return tree_->has_val(id_); } /**< Forward to @ref Tree::has_val(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_key()          const RYML_NOEXCEPT { _C4RR(); return tree_->has_key(id_); } /**< Forward to @ref Tree::has_key(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_val(id_); } /**< Forward to @ref Tree::is_val(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_keyval()        const RYML_NOEXCEPT { _C4RR(); return tree_->is_keyval(id_); } /**< Forward to @ref Tree::is_keyval(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_key_tag()      const RYML_NOEXCEPT { _C4RR(); return tree_->has_key_tag(id_); } /**< Forward to @ref Tree::has_key_tag(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_val_tag()      const RYML_NOEXCEPT { _C4RR(); return tree_->has_val_tag(id_); } /**< Forward to @ref Tree::has_val_tag(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_key_anchor()   const RYML_NOEXCEPT { _C4RR(); return tree_->has_key_anchor(id_); } /**< Forward to @ref Tree::has_key_anchor(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_val_anchor()   const RYML_NOEXCEPT { _C4RR(); return tree_->has_val_anchor(id_); } /**< Forward to @ref Tree::has_val_anchor(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_anchor()       const RYML_NOEXCEPT { _C4RR(); return tree_->has_anchor(id_); } /**< Forward to @ref Tree::has_anchor(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_ref()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_ref(id_); } /**< Forward to @ref Tree::is_key_ref(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_ref()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_ref(id_); } /**< Forward to @ref Tree::is_val_ref(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_ref()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_ref(id_); } /**< Forward to @ref Tree::is_ref(). Node must be readable. */
-    C4_ALWAYS_INLINE bool parent_is_seq()    const RYML_NOEXCEPT { _C4RR(); return tree_->parent_is_seq(id_); } /**< Forward to @ref Tree::parent_is_seq(). Node must be readable. */
-    C4_ALWAYS_INLINE bool parent_is_map()    const RYML_NOEXCEPT { _C4RR(); return tree_->parent_is_map(id_); } /**< Forward to @ref Tree::parent_is_map(). Node must be readable. */
+    C4_ALWAYS_INLINE bool empty()            const RYML_NOEXCEPT { assert_readable__(); return tree_->empty(id_); } /**< Forward to @ref Tree::empty(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_stream()        const RYML_NOEXCEPT { assert_readable__(); return tree_->is_stream(id_); } /**< Forward to @ref Tree::is_stream(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_doc()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_doc(id_); } /**< Forward to @ref Tree::is_doc(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_container()     const RYML_NOEXCEPT { assert_readable__(); return tree_->is_container(id_); } /**< Forward to @ref Tree::is_container(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_map()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_map(id_); } /**< Forward to @ref Tree::is_map(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_seq()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_seq(id_); } /**< Forward to @ref Tree::is_seq(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_val()          const RYML_NOEXCEPT { assert_readable__(); return tree_->has_val(id_); } /**< Forward to @ref Tree::has_val(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_key()          const RYML_NOEXCEPT { assert_readable__(); return tree_->has_key(id_); } /**< Forward to @ref Tree::has_key(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val(id_); } /**< Forward to @ref Tree::is_val(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_keyval()        const RYML_NOEXCEPT { assert_readable__(); return tree_->is_keyval(id_); } /**< Forward to @ref Tree::is_keyval(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_key_tag()      const RYML_NOEXCEPT { assert_readable__(); return tree_->has_key_tag(id_); } /**< Forward to @ref Tree::has_key_tag(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_val_tag()      const RYML_NOEXCEPT { assert_readable__(); return tree_->has_val_tag(id_); } /**< Forward to @ref Tree::has_val_tag(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_key_anchor()   const RYML_NOEXCEPT { assert_readable__(); return tree_->has_key_anchor(id_); } /**< Forward to @ref Tree::has_key_anchor(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_val_anchor()   const RYML_NOEXCEPT { assert_readable__(); return tree_->has_val_anchor(id_); } /**< Forward to @ref Tree::has_val_anchor(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_anchor()       const RYML_NOEXCEPT { assert_readable__(); return tree_->has_anchor(id_); } /**< Forward to @ref Tree::has_anchor(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_ref()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_ref(id_); } /**< Forward to @ref Tree::is_key_ref(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_ref()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_ref(id_); } /**< Forward to @ref Tree::is_val_ref(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_ref()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_ref(id_); } /**< Forward to @ref Tree::is_ref(). Node must be readable. */
+    C4_ALWAYS_INLINE bool parent_is_seq()    const RYML_NOEXCEPT { assert_readable__(); return tree_->parent_is_seq(id_); } /**< Forward to @ref Tree::parent_is_seq(). Node must be readable. */
+    C4_ALWAYS_INLINE bool parent_is_map()    const RYML_NOEXCEPT { assert_readable__(); return tree_->parent_is_map(id_); } /**< Forward to @ref Tree::parent_is_map(). Node must be readable. */
 
-    RYML_DEPRECATED("use has_key_anchor()")  bool is_key_anchor() const noexcept { _C4RR(); return tree_->has_key_anchor(id_); }
-    RYML_DEPRECATED("use has_val_anchor()")  bool is_val_hanchor() const noexcept { _C4RR(); return tree_->has_val_anchor(id_); }
-    RYML_DEPRECATED("use has_anchor()")      bool is_anchor()     const noexcept { _C4RR(); return tree_->has_anchor(id_); }
-    RYML_DEPRECATED("use has_anchor() || is_ref()") bool is_anchor_or_ref() const noexcept { _C4RR(); return tree_->is_anchor_or_ref(id_); }
+    RYML_DEPRECATED("use has_key_anchor()")  bool is_key_anchor() const noexcept { assert_readable__(); return tree_->has_key_anchor(id_); }
+    RYML_DEPRECATED("use has_val_anchor()")  bool is_val_hanchor() const noexcept { assert_readable__(); return tree_->has_val_anchor(id_); }
+    RYML_DEPRECATED("use has_anchor()")      bool is_anchor()     const noexcept { assert_readable__(); return tree_->has_anchor(id_); }
+    RYML_DEPRECATED("use has_anchor() || is_ref()") bool is_anchor_or_ref() const noexcept { assert_readable__(); return tree_->is_anchor_or_ref(id_); }
 
     /** @} */
 
@@ -264,39 +259,39 @@ public:
 
     // documentation to the right -->
 
-    C4_ALWAYS_INLINE bool type_has_any(NodeType_e bits)  const RYML_NOEXCEPT { _C4RR(); return tree_->type_has_any(id_, bits); }  /**< Forward to @ref Tree::type_has_any(). Node must be readable. */
-    C4_ALWAYS_INLINE bool type_has_all(NodeType_e bits)  const RYML_NOEXCEPT { _C4RR(); return tree_->type_has_all(id_, bits); }  /**< Forward to @ref Tree::type_has_all(). Node must be readable. */
-    C4_ALWAYS_INLINE bool type_has_none(NodeType_e bits) const RYML_NOEXCEPT { _C4RR(); return tree_->type_has_none(id_, bits); } /**< Forward to @ref Tree::type_has_none(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_any(NodeType_e bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_any(id_, bits); }  /**< Forward to @ref Tree::type_has_any(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_all(NodeType_e bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_all(id_, bits); }  /**< Forward to @ref Tree::type_has_all(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_none(NodeType_e bits) const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_none(id_, bits); } /**< Forward to @ref Tree::type_has_none(). Node must be readable. */
 
-    C4_ALWAYS_INLINE NodeType key_style()       const RYML_NOEXCEPT { _C4RR(); return tree_->key_style(id_); } /**< Forward to @ref Tree::key_style(). Node must be readable. */
-    C4_ALWAYS_INLINE NodeType val_style()       const RYML_NOEXCEPT { _C4RR(); return tree_->val_style(id_); } /**< Forward to @ref Tree::val_style(). Node must be readable. */
+    C4_ALWAYS_INLINE NodeType key_style()       const RYML_NOEXCEPT { assert_readable__(); return tree_->key_style(id_); } /**< Forward to @ref Tree::key_style(). Node must be readable. */
+    C4_ALWAYS_INLINE NodeType val_style()       const RYML_NOEXCEPT { assert_readable__(); return tree_->val_style(id_); } /**< Forward to @ref Tree::val_style(). Node must be readable. */
 
-    C4_ALWAYS_INLINE bool is_container_styled() const RYML_NOEXCEPT { _C4RR(); return tree_->is_container_styled(id_); } /**< Forward to @ref Tree::is_container_styled(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_block()            const RYML_NOEXCEPT { _C4RR(); return tree_->is_block(id_); }   /**< Forward to @ref Tree::is_block(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_flow()             const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow(id_); }     /**< Forward to @ref Tree::is_flow(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_flow_sl()          const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow_sl(id_); } /**< Forward to @ref Tree::is_flow_sl(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_container_styled() const RYML_NOEXCEPT { assert_readable__(); return tree_->is_container_styled(id_); } /**< Forward to @ref Tree::is_container_styled(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_block()            const RYML_NOEXCEPT { assert_readable__(); return tree_->is_block(id_); }   /**< Forward to @ref Tree::is_block(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow()             const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow(id_); }     /**< Forward to @ref Tree::is_flow(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow_sl()          const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow_sl(id_); } /**< Forward to @ref Tree::is_flow_sl(). Node must be readable. */
     RYML_DEPRECATED("use one of .is_flow_ml{1,x,n}()")
-    C4_ALWAYS_INLINE bool is_flow_ml()          const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow_ml1(id_); } /**< Forward to @ref Tree::is_flow_ml1(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_flow_ml1()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow_ml1(id_); } /**< Forward to @ref Tree::is_flow_ml1(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_flow_mln()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow_mln(id_); } /**< Forward to @ref Tree::is_flow_mln(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_flow_mlx()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_flow_mlx(id_); } /**< Forward to @ref Tree::is_flow_mlx(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_flow_space()      const RYML_NOEXCEPT { _C4RR(); return tree_->has_flow_space(id_); }  /**< Forward to @ref Tree::has_flow_space(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow_ml()          const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow_ml1(id_); } /**< Forward to @ref Tree::is_flow_ml1(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow_ml1()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow_ml1(id_); } /**< Forward to @ref Tree::is_flow_ml1(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow_mln()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow_mln(id_); } /**< Forward to @ref Tree::is_flow_mln(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_flow_mlx()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_flow_mlx(id_); } /**< Forward to @ref Tree::is_flow_mlx(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_flow_space()      const RYML_NOEXCEPT { assert_readable__(); return tree_->has_flow_space(id_); }  /**< Forward to @ref Tree::has_flow_space(). Node must be readable. */
 
-    C4_ALWAYS_INLINE bool is_key_styled()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_styled(id_); }  /**< Forward to @ref Tree::is_key_styled(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_styled()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_styled(id_); }  /**< Forward to @ref Tree::is_val_styled(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_literal()      const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_literal(id_); } /**< Forward to @ref Tree::is_key_literal(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_literal()      const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_literal(id_); } /**< Forward to @ref Tree::is_val_literal(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_folded()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_folded(id_); }  /**< Forward to @ref Tree::is_key_folded(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_folded()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_folded(id_); }  /**< Forward to @ref Tree::is_val_folded(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_squo()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_squo(id_); }    /**< Forward to @ref Tree::is_key_squo(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_squo()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_squo(id_); }    /**< Forward to @ref Tree::is_val_squo(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_dquo()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_dquo(id_); }    /**< Forward to @ref Tree::is_key_dquo(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_dquo()         const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_dquo(id_); }    /**< Forward to @ref Tree::is_val_dquo(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_plain()        const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_plain(id_); }   /**< Forward to @ref Tree::is_key_plain(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_plain()        const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_plain(id_); }   /**< Forward to @ref Tree::is_val_plain(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_key_quoted()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_key_quoted(id_); }  /**< Forward to @ref Tree::is_key_quoted(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_val_quoted()       const RYML_NOEXCEPT { _C4RR(); return tree_->is_val_quoted(id_); }  /**< Forward to @ref Tree::is_val_quoted(). Node must be readable. */
-    C4_ALWAYS_INLINE bool is_quoted()           const RYML_NOEXCEPT { _C4RR(); return tree_->is_quoted(id_); }      /**< Forward to @ref Tree::is_quoted(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_styled()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_styled(id_); }  /**< Forward to @ref Tree::is_key_styled(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_styled()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_styled(id_); }  /**< Forward to @ref Tree::is_val_styled(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_literal()      const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_literal(id_); } /**< Forward to @ref Tree::is_key_literal(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_literal()      const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_literal(id_); } /**< Forward to @ref Tree::is_val_literal(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_folded()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_folded(id_); }  /**< Forward to @ref Tree::is_key_folded(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_folded()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_folded(id_); }  /**< Forward to @ref Tree::is_val_folded(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_squo()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_squo(id_); }    /**< Forward to @ref Tree::is_key_squo(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_squo()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_squo(id_); }    /**< Forward to @ref Tree::is_val_squo(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_dquo()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_dquo(id_); }    /**< Forward to @ref Tree::is_key_dquo(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_dquo()         const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_dquo(id_); }    /**< Forward to @ref Tree::is_val_dquo(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_plain()        const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_plain(id_); }   /**< Forward to @ref Tree::is_key_plain(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_plain()        const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_plain(id_); }   /**< Forward to @ref Tree::is_val_plain(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_key_quoted()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_key_quoted(id_); }  /**< Forward to @ref Tree::is_key_quoted(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_val_quoted()       const RYML_NOEXCEPT { assert_readable__(); return tree_->is_val_quoted(id_); }  /**< Forward to @ref Tree::is_val_quoted(). Node must be readable. */
+    C4_ALWAYS_INLINE bool is_quoted()           const RYML_NOEXCEPT { assert_readable__(); return tree_->is_quoted(id_); }      /**< Forward to @ref Tree::is_quoted(). Node must be readable. */
 
     /** @} */
 
@@ -307,21 +302,21 @@ public:
 
     // documentation to the right -->
 
-    C4_ALWAYS_INLINE bool is_root()    const RYML_NOEXCEPT { _C4RR(); return tree_->is_root(id_); } /**< Forward to @ref Tree::is_root(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_parent() const RYML_NOEXCEPT { _C4RR(); return tree_->has_parent(id_); } /**< Forward to @ref Tree::has_parent()  Node must be readable. */
-    C4_ALWAYS_INLINE bool is_ancestor(ConstImpl const& ancestor) const RYML_NOEXCEPT { _C4RR(); return tree_->is_ancestor(id_, ancestor.m_id); } /**< Forward to @ref Tree::is_ancestor()  Node must be readable. */
+    C4_ALWAYS_INLINE bool is_root()    const RYML_NOEXCEPT { assert_readable__(); return tree_->is_root(id_); } /**< Forward to @ref Tree::is_root(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_parent() const RYML_NOEXCEPT { assert_readable__(); return tree_->has_parent(id_); } /**< Forward to @ref Tree::has_parent()  Node must be readable. */
+    C4_ALWAYS_INLINE bool is_ancestor(ConstImpl const& ancestor) const RYML_NOEXCEPT { assert_readable__(); return tree_->is_ancestor(id_, ancestor.m_id); } /**< Forward to @ref Tree::is_ancestor()  Node must be readable. */
 
-    C4_ALWAYS_INLINE bool has_child(ConstImpl const& n) const RYML_NOEXCEPT { _C4RR(); return n.readable() ? tree_->has_child(id_, n.m_id) : false; } /**< Forward to @ref Tree::has_child(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_child(id_type node) const RYML_NOEXCEPT { _C4RR(); return tree_->has_child(id_, node); } /**< Forward to @ref Tree::has_child(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_child(csubstr name) const RYML_NOEXCEPT { _C4RR(); return tree_->has_child(id_, name); } /**< Forward to @ref Tree::has_child(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_children() const RYML_NOEXCEPT { _C4RR(); return tree_->has_children(id_); } /**< Forward to @ref Tree::has_children(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_child(ConstImpl const& n) const RYML_NOEXCEPT { assert_readable__(); return n.readable() ? tree_->has_child(id_, n.m_id) : false; } /**< Forward to @ref Tree::has_child(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_child(id_type node) const RYML_NOEXCEPT { assert_readable__(); return tree_->has_child(id_, node); } /**< Forward to @ref Tree::has_child(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_child(csubstr name) const RYML_NOEXCEPT { assert_readable__(); return tree_->has_child(id_, name); } /**< Forward to @ref Tree::has_child(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_children() const RYML_NOEXCEPT { assert_readable__(); return tree_->has_children(id_); } /**< Forward to @ref Tree::has_children(). Node must be readable. */
 
-    C4_ALWAYS_INLINE bool has_sibling(ConstImpl const& n) const RYML_NOEXCEPT { _C4RR(); return n.readable() ? tree_->has_sibling(id_, n.m_id) : false; } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_sibling(id_type node) const RYML_NOEXCEPT { _C4RR(); return tree_->has_sibling(id_, node); } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_sibling(csubstr name) const RYML_NOEXCEPT { _C4RR(); return tree_->has_sibling(id_, name); } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE bool has_other_siblings() const RYML_NOEXCEPT { _C4RR(); return tree_->has_other_siblings(id_); }  /**< Forward to @ref Tree::has_other_siblings(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_sibling(ConstImpl const& n) const RYML_NOEXCEPT { assert_readable__(); return n.readable() ? tree_->has_sibling(id_, n.m_id) : false; } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_sibling(id_type node) const RYML_NOEXCEPT { assert_readable__(); return tree_->has_sibling(id_, node); } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_sibling(csubstr name) const RYML_NOEXCEPT { assert_readable__(); return tree_->has_sibling(id_, name); } /**< Forward to @ref Tree::has_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE bool has_other_siblings() const RYML_NOEXCEPT { assert_readable__(); return tree_->has_other_siblings(id_); }  /**< Forward to @ref Tree::has_other_siblings(). Node must be readable. */
 
-    RYML_DEPRECATED("use has_other_siblings()") bool has_siblings() const RYML_NOEXCEPT { _C4RR(); return tree_->has_siblings(id_); }
+    RYML_DEPRECATED("use has_other_siblings()") bool has_siblings() const RYML_NOEXCEPT { assert_readable__(); return tree_->has_siblings(id_); }
 
     /** @} */
 
@@ -337,61 +332,61 @@ public:
     C4_ALWAYS_INLINE ConstImpl doc(id_type i) const RYML_NOEXCEPT { _RYML_ASSERT_BASIC(tree_); return {tree_, tree_->doc(i)}; }                /**< Forward to @ref Tree::doc(). Node must be readable. succeeds even when the node may have invalid or seed id */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto parent() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->parent(id__)}; } /**< Forward to @ref Tree::parent(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl parent() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->parent(id_)}; }                 /**< Forward to @ref Tree::parent(). Node must be readable. */
+    C4_ALWAYS_INLINE auto parent() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->parent(id__)}; } /**< Forward to @ref Tree::parent(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl parent() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->parent(id_)}; }                 /**< Forward to @ref Tree::parent(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto first_child() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->first_child(id__)}; }  /**< Forward to @ref Tree::first_child(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl first_child() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->first_child(id_)}; }                  /**< Forward to @ref Tree::first_child(). Node must be readable. */
+    C4_ALWAYS_INLINE auto first_child() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->first_child(id__)}; }  /**< Forward to @ref Tree::first_child(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl first_child() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->first_child(id_)}; }                  /**< Forward to @ref Tree::first_child(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto last_child() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->last_child(id__)}; }  /**< Forward to @ref Tree::last_child(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl last_child () const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->last_child (id_)}; }                /**< Forward to @ref Tree::last_child(). Node must be readable. */
+    C4_ALWAYS_INLINE auto last_child() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->last_child(id__)}; }  /**< Forward to @ref Tree::last_child(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl last_child () const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->last_child (id_)}; }                /**< Forward to @ref Tree::last_child(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto child(id_type pos) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->child(id__, pos)}; }  /**< Forward to @ref Tree::child(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl child(id_type pos) const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->child(id_, pos)}; }                  /**< Forward to @ref Tree::child(). Node must be readable. */
+    C4_ALWAYS_INLINE auto child(id_type pos) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->child(id__, pos)}; }  /**< Forward to @ref Tree::child(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl child(id_type pos) const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->child(id_, pos)}; }                  /**< Forward to @ref Tree::child(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto find_child(csubstr name)  RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->find_child(id__, name)}; }  /**< Forward to @ref Tree::find_child(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl find_child(csubstr name) const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->find_child(id_, name)}; }                   /**< Forward to @ref Tree::find_child(). Node must be readable. */
+    C4_ALWAYS_INLINE auto find_child(csubstr name)  RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->find_child(id__, name)}; }  /**< Forward to @ref Tree::find_child(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl find_child(csubstr name) const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->find_child(id_, name)}; }                   /**< Forward to @ref Tree::find_child(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto prev_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->prev_sibling(id__)}; }  /**< Forward to @ref Tree::prev_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl prev_sibling() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->prev_sibling(id_)}; }                  /**< Forward to @ref Tree::prev_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto prev_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->prev_sibling(id__)}; }  /**< Forward to @ref Tree::prev_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl prev_sibling() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->prev_sibling(id_)}; }                  /**< Forward to @ref Tree::prev_sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto next_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->next_sibling(id__)}; }  /**< Forward to @ref Tree::next_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl next_sibling() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->next_sibling(id_)}; }                  /**< Forward to @ref Tree::next_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto next_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->next_sibling(id__)}; }  /**< Forward to @ref Tree::next_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl next_sibling() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->next_sibling(id_)}; }                  /**< Forward to @ref Tree::next_sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto first_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->first_sibling(id__)}; }  /**< Forward to @ref Tree::first_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl first_sibling() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->first_sibling(id_)}; }                  /**< Forward to @ref Tree::first_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto first_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->first_sibling(id__)}; }  /**< Forward to @ref Tree::first_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl first_sibling() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->first_sibling(id_)}; }                  /**< Forward to @ref Tree::first_sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto last_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->last_sibling(id__)}; }  /**< Forward to @ref Tree::last_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl last_sibling () const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->last_sibling(id_)}; }                 /**< Forward to @ref Tree::last_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto last_sibling() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->last_sibling(id__)}; }  /**< Forward to @ref Tree::last_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl last_sibling () const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->last_sibling(id_)}; }                 /**< Forward to @ref Tree::last_sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto sibling(id_type pos) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->sibling(id__, pos)}; }  /**< Forward to @ref Tree::sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl sibling(id_type pos) const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->sibling(id_, pos)}; }                  /**< Forward to @ref Tree::sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto sibling(id_type pos) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->sibling(id__, pos)}; }  /**< Forward to @ref Tree::sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl sibling(id_type pos) const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->sibling(id_, pos)}; }                  /**< Forward to @ref Tree::sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto find_sibling(csubstr name) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->find_sibling(id__, name)}; }  /**< Forward to @ref Tree::find_sibling(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl find_sibling(csubstr name) const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->find_sibling(id_, name)}; }                  /**< Forward to @ref Tree::find_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE auto find_sibling(csubstr name) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->find_sibling(id__, name)}; }  /**< Forward to @ref Tree::find_sibling(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl find_sibling(csubstr name) const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->find_sibling(id_, name)}; }                  /**< Forward to @ref Tree::find_sibling(). Node must be readable. */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto ancestor_doc() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { _C4RR(); return {tree__, tree__->ancestor_doc(id__)}; }  /**< Forward to @ref Tree::ancestor_doc(). Node must be readable. */
-    C4_ALWAYS_INLINE ConstImpl ancestor_doc() const RYML_NOEXCEPT { _C4RR(); return {tree_, tree_->ancestor_doc(id_)}; }                  /**< Forward to @ref Tree::ancestor_doc(). Node must be readable. */
+    C4_ALWAYS_INLINE auto ancestor_doc() RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl) { assert_readable__(); return {tree__, tree__->ancestor_doc(id__)}; }  /**< Forward to @ref Tree::ancestor_doc(). Node must be readable. */
+    C4_ALWAYS_INLINE ConstImpl ancestor_doc() const RYML_NOEXCEPT { assert_readable__(); return {tree_, tree_->ancestor_doc(id_)}; }                  /**< Forward to @ref Tree::ancestor_doc(). Node must be readable. */
 
-    C4_ALWAYS_INLINE id_type num_children() const RYML_NOEXCEPT { _C4RR(); return tree_->num_children(id_); } /**< O(num_children). Forward to @ref Tree::num_children(). */
-    C4_ALWAYS_INLINE id_type num_siblings() const RYML_NOEXCEPT { _C4RR(); return tree_->num_siblings(id_); } /**< O(num_children). Forward to @ref Tree::num_siblings(). */
-    C4_ALWAYS_INLINE id_type num_other_siblings() const RYML_NOEXCEPT { _C4RR(); return tree_->num_other_siblings(id_); } /**< O(num_siblings). Forward to @ref Tree::num_other_siblings(). */
-    C4_ALWAYS_INLINE id_type child_pos(ConstImpl const& n) const RYML_NOEXCEPT { _C4RR(); _RYML_ASSERT_VISIT_(tree_->m_callbacks, n.readable(), n.tree(), n.id()); return tree_->child_pos(id_, n.m_id); } /**< O(num_children). Forward to @ref Tree::child_pos(). */
-    C4_ALWAYS_INLINE id_type sibling_pos(ConstImpl const& n) const RYML_NOEXCEPT { _C4RR(); _RYML_ASSERT_VISIT_(tree_->callbacks(), n.readable(), n.tree(), n.id()); return tree_->child_pos(tree_->parent(id_), n.m_id); } /**< O(num_siblings). Forward to @ref Tree::sibling_pos(). */
+    C4_ALWAYS_INLINE id_type num_children() const RYML_NOEXCEPT { assert_readable__(); return tree_->num_children(id_); } /**< O(num_children). Forward to @ref Tree::num_children(). */
+    C4_ALWAYS_INLINE id_type num_siblings() const RYML_NOEXCEPT { assert_readable__(); return tree_->num_siblings(id_); } /**< O(num_children). Forward to @ref Tree::num_siblings(). */
+    C4_ALWAYS_INLINE id_type num_other_siblings() const RYML_NOEXCEPT { assert_readable__(); return tree_->num_other_siblings(id_); } /**< O(num_siblings). Forward to @ref Tree::num_other_siblings(). */
+    C4_ALWAYS_INLINE id_type child_pos(ConstImpl const& n) const RYML_NOEXCEPT { assert_readable__(); _RYML_ASSERT_VISIT_(tree_->m_callbacks, n.readable(), n.tree(), n.id()); return tree_->child_pos(id_, n.m_id); } /**< O(num_children). Forward to @ref Tree::child_pos(). */
+    C4_ALWAYS_INLINE id_type sibling_pos(ConstImpl const& n) const RYML_NOEXCEPT { assert_readable__(); _RYML_ASSERT_VISIT_(tree_->callbacks(), n.readable(), n.tree(), n.id()); return tree_->child_pos(tree_->parent(id_), n.m_id); } /**< O(num_siblings). Forward to @ref Tree::sibling_pos(). */
 
-    C4_ALWAYS_INLINE id_type depth_asc() const RYML_NOEXCEPT { _C4RR(); return tree_->depth_asc(id_); } /** O(log(num_nodes)). Forward to Tree::depth_asc(). Node must be readable. */
-    C4_ALWAYS_INLINE id_type depth_desc() const RYML_NOEXCEPT { _C4RR(); return tree_->depth_desc(id_); } /** O(num_nodes). Forward to Tree::depth_desc(). Node must be readable. */
+    C4_ALWAYS_INLINE id_type depth_asc() const RYML_NOEXCEPT { assert_readable__(); return tree_->depth_asc(id_); } /** O(log(num_nodes)). Forward to Tree::depth_asc(). Node must be readable. */
+    C4_ALWAYS_INLINE id_type depth_desc() const RYML_NOEXCEPT { assert_readable__(); return tree_->depth_desc(id_); } /** O(num_nodes). Forward to Tree::depth_desc(). Node must be readable. */
 
     /** @} */
 
@@ -422,7 +417,7 @@ public:
     template<class U=Impl>
     C4_ALWAYS_INLINE auto operator[] (csubstr key) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl)
     {
-        _C4RR();
+        assert_readable__();
         id_type ch = tree__->find_child(id__, key);
         return ch != NONE ? Impl(tree__, ch) : Impl(tree__, id__, key);
     }
@@ -448,7 +443,7 @@ public:
     template<class U=Impl>
     C4_ALWAYS_INLINE auto operator[] (id_type pos) RYML_NOEXCEPT -> _C4_IF_MUTABLE(Impl)
     {
-        _C4RR();
+        assert_readable__();
         id_type ch = tree__->child(id__, pos);
         return ch != NONE ? Impl(tree__, ch) : Impl(tree__, id__, pos);
     }
@@ -464,7 +459,7 @@ public:
      * @see https://github.com/biojppm/rapidyaml/issues/389  */
     C4_ALWAYS_INLINE ConstImpl operator[] (csubstr key) const RYML_NOEXCEPT
     {
-        _C4RR();
+        assert_readable__();
         id_type ch = tree_->find_child(id_, key);
         _RYML_ASSERT_VISIT_(tree_->m_callbacks, ch != NONE, tree_, id_);
         return {tree_, ch};
@@ -481,7 +476,7 @@ public:
      * @see https://github.com/biojppm/rapidyaml/issues/389  */
     C4_ALWAYS_INLINE ConstImpl operator[] (id_type pos) const RYML_NOEXCEPT
     {
-        _C4RR();
+        assert_readable__();
         id_type ch = tree_->child(id_, pos);
         _RYML_ASSERT_VISIT_(tree_->m_callbacks, ch != NONE, tree_, id_);
         return {tree_, ch};
@@ -626,7 +621,7 @@ public:
 
     Location location(Parser const& parser) const
     {
-        _C4RR();
+        assert_readable__();
         return tree_->location(parser, id_);
     }
 
@@ -642,7 +637,7 @@ public:
     template<class T>
     ConstImpl const& operator>> (T &v) const
     {
-        _C4RR();
+        assert_readable__();
         if( ! read((ConstImpl const&)*this, &v))
             _RYML_ERR_VISIT_(tree_->m_callbacks, tree_, id_, "could not deserialize value");
         return *((ConstImpl const*)this);
@@ -650,7 +645,7 @@ public:
     template<class T>
     ConstImpl const& operator>> (T const& wrapper) const
     {
-        _C4RR();
+        assert_readable__();
         if( ! read((ConstImpl const&)*this, wrapper))
             _RYML_ERR_VISIT_(tree_->m_callbacks, tree_, id_, "could not deserialize value");
         return *((ConstImpl const*)this);
@@ -662,7 +657,7 @@ public:
     template<class T>
     ConstImpl const& operator>> (Key<T> v) const
     {
-        _C4RR();
+        assert_readable__();
         if( ! readkey((ConstImpl const&)*this, &v.k))
             _RYML_ERR_VISIT_(tree_->m_callbacks, tree_, id_, "could not deserialize key");
         return *((ConstImpl const*)this);
@@ -673,7 +668,7 @@ public:
     template<class T>
     bool get_if(csubstr name, T *var) const
     {
-        _C4RR();
+        assert_readable__();
         ConstImpl ch = find_child(name);
         if(!ch.readable())
             return false;
@@ -687,7 +682,7 @@ public:
     template<class T>
     bool get_if(csubstr name, T *var, T const& fallback) const
     {
-        _C4RR();
+        assert_readable__();
         ConstImpl ch = find_child(name);
         if(ch.readable())
         {
@@ -714,27 +709,27 @@ public:
     using const_children_view = detail::children_view_<ConstImpl>;
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto begin() RYML_NOEXCEPT -> _C4_IF_MUTABLE(iterator) { _C4RR(); return iterator(tree__, tree__->first_child(id__)); }  /**< get a mutable iterator to the first child. NOT AVAILABLE for ConstNodeRef. */
-    C4_ALWAYS_INLINE const_iterator begin() const RYML_NOEXCEPT { _C4RR(); return const_iterator(tree_, tree_->first_child(id_)); } /**< get an iterator to the first child */
-    C4_ALWAYS_INLINE const_iterator cbegin() const RYML_NOEXCEPT { _C4RR(); return const_iterator(tree_, tree_->first_child(id_)); } /**< get an iterator to the first child */
+    C4_ALWAYS_INLINE auto begin() RYML_NOEXCEPT -> _C4_IF_MUTABLE(iterator) { assert_readable__(); return iterator(tree__, tree__->first_child(id__)); }  /**< get a mutable iterator to the first child. NOT AVAILABLE for ConstNodeRef. */
+    C4_ALWAYS_INLINE const_iterator begin() const RYML_NOEXCEPT { assert_readable__(); return const_iterator(tree_, tree_->first_child(id_)); } /**< get an iterator to the first child */
+    C4_ALWAYS_INLINE const_iterator cbegin() const RYML_NOEXCEPT { assert_readable__(); return const_iterator(tree_, tree_->first_child(id_)); } /**< get an iterator to the first child */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto end() RYML_NOEXCEPT -> _C4_IF_MUTABLE(iterator) { _C4RR(); return iterator(tree__, NONE); } /**< get an iterator to after the last child. NOT AVAILABLE for ConstNodeRef. */
+    C4_ALWAYS_INLINE auto end() RYML_NOEXCEPT -> _C4_IF_MUTABLE(iterator) { assert_readable__(); return iterator(tree__, NONE); } /**< get an iterator to after the last child. NOT AVAILABLE for ConstNodeRef. */
     /** get an iterator to after the last child */
-    C4_ALWAYS_INLINE const_iterator end() const RYML_NOEXCEPT { _C4RR(); return const_iterator(tree_, NONE); } /**< get an iterator to after the last child */
+    C4_ALWAYS_INLINE const_iterator end() const RYML_NOEXCEPT { assert_readable__(); return const_iterator(tree_, NONE); } /**< get an iterator to after the last child */
     /** get an iterator to after the last child */
-    C4_ALWAYS_INLINE const_iterator cend() const RYML_NOEXCEPT { _C4RR(); return const_iterator(tree_, NONE); } /**< get an iterator to after the last child */
+    C4_ALWAYS_INLINE const_iterator cend() const RYML_NOEXCEPT { assert_readable__(); return const_iterator(tree_, NONE); } /**< get an iterator to after the last child */
 
     template<class U=Impl>
-    C4_ALWAYS_INLINE auto children() RYML_NOEXCEPT -> _C4_IF_MUTABLE(children_view) { _C4RR(); return children_view(begin(), end()); } /**< get an iterable view over children. NOT AVAILABLE for ConstNodeRef. */
-    C4_ALWAYS_INLINE const_children_view children() const RYML_NOEXCEPT { _C4RR(); return const_children_view(begin(), end()); } /**< get an iterable view over children */
-    C4_ALWAYS_INLINE const_children_view cchildren() const RYML_NOEXCEPT { _C4RR(); return const_children_view(begin(), end()); } /**< get an iterable view over children */
+    C4_ALWAYS_INLINE auto children() RYML_NOEXCEPT -> _C4_IF_MUTABLE(children_view) { assert_readable__(); return children_view(begin(), end()); } /**< get an iterable view over children. NOT AVAILABLE for ConstNodeRef. */
+    C4_ALWAYS_INLINE const_children_view children() const RYML_NOEXCEPT { assert_readable__(); return const_children_view(begin(), end()); } /**< get an iterable view over children */
+    C4_ALWAYS_INLINE const_children_view cchildren() const RYML_NOEXCEPT { assert_readable__(); return const_children_view(begin(), end()); } /**< get an iterable view over children */
 
     /** get an iterable view over all siblings (including the calling node) */
     template<class U=Impl>
     C4_ALWAYS_INLINE auto siblings() RYML_NOEXCEPT -> _C4_IF_MUTABLE(children_view)
     {
-        _C4RR();
+        assert_readable__();
         NodeData const *nd = tree__->get(id__);
         return (nd->m_parent != NONE) ? // does it have a parent?
             children_view(iterator(tree__, tree_->get(nd->m_parent)->m_first_child), iterator(tree__, NONE))
@@ -744,7 +739,7 @@ public:
     /** get an iterable view over all siblings (including the calling node) */
     C4_ALWAYS_INLINE const_children_view siblings() const RYML_NOEXCEPT
     {
-        _C4RR();
+        assert_readable__();
         NodeData const *nd = tree_->get(id_);
         return (nd->m_parent != NONE) ? // does it have a parent?
             const_children_view(const_iterator(tree_, tree_->get(nd->m_parent)->m_first_child), const_iterator(tree_, NONE))
@@ -766,34 +761,34 @@ public:
     template<class Visitor>
     RYML_DEPRECATED("") bool visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
     {
-        _C4RR();
+        assert_readable__();
         return detail::_visit(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }
     template<class Visitor, class U=Impl>
     RYML_DEPRECATED("") auto visit(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
         -> _C4_IF_MUTABLE(bool)
     {
-        _C4RR();
+        assert_readable__();
         return detail::_visit(*(Impl*)this, fn, indentation_level, skip_root);
     }
     template<class Visitor>
     RYML_DEPRECATED("") bool visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) const RYML_NOEXCEPT
     {
-        _C4RR();
+        assert_readable__();
         return detail::_visit_stacked(*(ConstImpl const*)this, fn, indentation_level, skip_root);
     }
     template<class Visitor, class U=Impl>
     RYML_DEPRECATED("") auto visit_stacked(Visitor fn, id_type indentation_level=0, bool skip_root=true) RYML_NOEXCEPT
         -> _C4_IF_MUTABLE(bool)
     {
-        _C4RR();
+        assert_readable__();
         return detail::_visit_stacked(*(Impl*)this, fn, indentation_level, skip_root);
     }
     /** @endcond */ // LCOV_EXCL_STOP
     C4_SUPPRESS_WARNING_POP
 
     #undef _C4_IF_MUTABLE
-    #undef _C4RR
+    #undef assert_readable__
     #undef tree_
     #undef tree__
     #undef id_
@@ -876,6 +871,22 @@ public:
     constexpr static C4_ALWAYS_INLINE bool is_seed() noexcept { return false; }
 
     /** @} */
+
+private:
+
+    void assert_readable_() const
+    {
+        _RYML_ASSERT_BASIC(m_tree != nullptr);
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE && (m_id < m_tree->capacity()), m_tree, m_id);
+    }
+
+    void check_readable_() const
+    {
+        if(C4_UNLIKELY(!m_tree))
+            _RYML_ERR_BASIC("invalid node");
+        if(C4_UNLIKELY(!m_tree || m_id == NONE || (m_id > m_tree->capacity())))
+            _RYML_ERR_VISIT_(m_tree->m_callbacks, m_tree, m_id, "invalid node");
+    }
 
 public:
 
@@ -979,15 +990,6 @@ private:
     friend ConstNodeRef;
     friend struct detail::RoNodeMethods<NodeRef, ConstNodeRef>;
 
-    // require valid: a helper macro, undefined at the end
-    #define _C4RR()                                                     \
-        _RYML_ASSERT_BASIC(m_tree != nullptr);                           \
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE && !is_seed(), m_tree, m_id)
-    // require id: a helper macro, undefined at the end
-    #define _C4RID()                                                        \
-        _RYML_ASSERT_BASIC(m_tree != nullptr);                                     \
-        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_id != NONE, m_tree, m_id)
-
 public:
 
     /** @name construction */
@@ -1034,6 +1036,26 @@ public:
 
     /** @} */
 
+private:
+
+    C4_ALWAYS_INLINE bool valid_id_() const noexcept { return m_id != NONE && m_id < m_tree->capacity(); }
+    C4_ALWAYS_INLINE bool has_seed_() const noexcept { return m_seed.str != nullptr || m_seed.len != (size_t)NONE; }
+
+    void assert_readable_() const
+    {
+        _RYML_ASSERT_BASIC(m_tree != nullptr);
+        _RYML_ASSERT_VISIT_(m_tree->m_callbacks, valid_id_() && !has_seed_(), m_tree, m_id);
+    }
+
+    void check_readable_() const
+    {
+        if(C4_UNLIKELY(!m_tree))
+            _RYML_ERR_BASIC("invalid node");
+        if(C4_UNLIKELY((m_id == NONE || (m_id > m_tree->capacity())) ||
+                       (m_seed.str != nullptr || m_seed.len != (size_t)NONE)))
+            _RYML_ERR_VISIT_(m_tree->m_callbacks, m_tree, m_id, "invalid node");
+    }
+
 public:
 
     /** @name comparisons */
@@ -1078,7 +1100,7 @@ public:
 
 public:
 
-    /** @name node_modifiers */
+    /** @name node_setters */
     /** @{ */
 
     /// if this node is in seed state, create the node in the tree
@@ -1127,43 +1149,54 @@ public:
     void set_container_style(NodeType_e style) { create(); m_tree->set_container_style(m_id, style); }
     void set_key_style(NodeType_e style) { create(); m_tree->set_key_style(m_id, style); }
     void set_val_style(NodeType_e style) { create(); m_tree->set_val_style(m_id, style); }
-    void clear_style(bool recurse=false) { create(); m_tree->clear_style(m_id, recurse); }
-    void set_style_conditionally(NodeType type_mask,
-                                 NodeType rem_style_flags,
-                                 NodeType add_style_flags,
-                                 bool recurse=false)
-    {
-        create();
-        m_tree->set_style_conditionally(m_id, type_mask, rem_style_flags, add_style_flags, recurse);
-    }
+
+    /** @} */
 
 public:
 
-    void change_type(NodeType t) { _C4RR(); m_tree->change_type(m_id, t); }
+    /** @name node_modifiers */
+    /** @{ */
+
+    void change_type(NodeType t) { assert_readable_(); m_tree->change_type(m_id, t); }
 
     void clear()
     {
-        _C4RR();
+        assert_readable_();
         m_tree->remove_children(m_id);
         m_tree->_clear(m_id);
     }
 
     void clear_key()
     {
-        _C4RR();
+        assert_readable_();
         m_tree->_clear_key(m_id);
     }
 
     void clear_val()
     {
-        _C4RR();
+        assert_readable_();
         m_tree->_clear_val(m_id);
     }
 
     void clear_children()
     {
-        _apply_seed();
+        assert_readable_();
         m_tree->remove_children(m_id);
+    }
+
+    void clear_style(bool recurse=false)
+    {
+        assert_readable_();
+        m_tree->clear_style(m_id, recurse);
+    }
+
+    void set_style_conditionally(NodeType type_mask,
+                                 NodeType rem_style_flags,
+                                 NodeType add_style_flags,
+                                 bool recurse=false)
+    {
+        assert_readable_();
+        m_tree->set_style_conditionally(m_id, type_mask, rem_style_flags, add_style_flags, recurse);
     }
 
     /** @} */
@@ -1257,7 +1290,7 @@ public:
 
     NodeRef insert_child(NodeRef after)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
         NodeRef r(m_tree, m_tree->insert_child(m_id, after.m_id));
         return r;
@@ -1265,21 +1298,21 @@ public:
 
     NodeRef prepend_child()
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->insert_child(m_id, NONE));
         return r;
     }
 
     NodeRef append_child()
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->append_child(m_id));
         return r;
     }
 
     NodeRef insert_sibling(ConstNodeRef const& after)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
         NodeRef r(m_tree, m_tree->insert_sibling(m_id, after.m_id));
         return r;
@@ -1287,14 +1320,14 @@ public:
 
     NodeRef prepend_sibling()
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->prepend_sibling(m_id));
         return r;
     }
 
     NodeRef append_sibling()
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->append_sibling(m_id));
         return r;
     }
@@ -1303,7 +1336,7 @@ public:
 
     void remove_child(NodeRef & child)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, has_child(child), m_tree, m_id);
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, child.parent().id() == id(), m_tree, m_id);
         m_tree->remove(child.id());
@@ -1313,7 +1346,7 @@ public:
     //! remove the nth child of this node
     void remove_child(id_type pos)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, pos >= 0 && pos < num_children(), m_tree, m_id);
         id_type child = m_tree->child(m_id, pos);
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, child != NONE, m_tree, m_id);
@@ -1323,7 +1356,7 @@ public:
     //! remove a child by name
     void remove_child(csubstr key)
     {
-        _C4RR();
+        assert_readable_();
         id_type child = m_tree->find_child(m_id, key);
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, child != NONE, m_tree, m_id);
         m_tree->remove(child);
@@ -1337,7 +1370,7 @@ public:
      * pointer is reset to the tree of the parent node. */
     void move(NodeRef const& parent, ConstNodeRef const& after)
     {
-        _C4RR();
+        assert_readable_();
         if(parent.m_tree == m_tree)
         {
             m_tree->move(m_id, parent.m_id, after.m_id);
@@ -1356,8 +1389,8 @@ public:
      * this: `n.move({})`. */
     NodeRef duplicate(NodeRef const& parent, ConstNodeRef const& after) const
     {
-        _C4RR();
-        //parent.assert_readable_();
+        assert_readable_();
+        parent.assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
         id_type dup = parent.m_tree->duplicate(m_tree, m_id, parent.m_id, after.m_id);
         NodeRef r(parent.m_tree, dup);
@@ -1366,8 +1399,8 @@ public:
 
     NodeRef duplicate_children(NodeRef const& parent, ConstNodeRef const& after) const
     {
-        _C4RR();
-        //parent.assert_readable_();
+        assert_readable_();
+        parent.assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, parent.m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
         id_type last_dup = parent.m_tree->duplicate_children(m_tree, m_id, parent.m_id, after.m_id);
         NodeRef r(parent.m_tree, last_dup);
@@ -1464,7 +1497,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef insert_child(NodeInit const& i, NodeRef after)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
         NodeRef r(m_tree, m_tree->insert_child(m_id, after.m_id));
         r._apply(i);
@@ -1473,7 +1506,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef prepend_child(NodeInit const& i)
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->insert_child(m_id, NONE));
         r._apply(i);
         return r;
@@ -1481,7 +1514,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef append_child(NodeInit const& i)
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->append_child(m_id));
         r._apply(i);
         return r;
@@ -1489,7 +1522,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef insert_sibling(NodeInit const& i, ConstNodeRef const& after)
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, after.m_tree == m_tree, m_tree, m_id);
         NodeRef r(m_tree, m_tree->insert_sibling(m_id, after.m_id));
         r._apply(i);
@@ -1498,7 +1531,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef prepend_sibling(NodeInit const& i)
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->prepend_sibling(m_id));
         r._apply(i);
         return r;
@@ -1506,7 +1539,7 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") NodeRef append_sibling(NodeInit const& i)
     {
-        _C4RR();
+        assert_readable_();
         NodeRef r(m_tree, m_tree->append_sibling(m_id));
         r._apply(i);
         return r;
@@ -1514,13 +1547,13 @@ public: // deprecated functions
 
     RYML_DEPRECATED("") void move(ConstNodeRef const& after)
     {
-        _C4RR();
+        assert_readable_();
         m_tree->move(m_id, after.m_id);
     }
 
     RYML_DEPRECATED("") NodeRef duplicate(ConstNodeRef const& after) const
     {
-        _C4RR();
+        assert_readable_();
         _RYML_ASSERT_VISIT_(m_tree->m_callbacks, m_tree == after.m_tree || after.m_id == NONE, m_tree, m_id);
         id_type dup = m_tree->duplicate(m_id, m_tree->parent(m_id), after.m_id);
         NodeRef r(m_tree, dup);
@@ -1530,8 +1563,6 @@ public: // deprecated functions
     C4_SUPPRESS_WARNING_POP
     /** @endcond */ // LCOV_EXCL_STOP
 
-#undef _C4RR
-#undef _C4RID
 };
 
 // NOLINTEND(cppcoreguidelines-c-copy-assignment-signature,misc-unconventional-assign-operator)

--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -19,115 +19,234 @@
 namespace c4 {
 namespace yml {
 
+
 // instantiate the parser class
 template class RYML_EXPORT ParseEngine<EventHandlerTree>;
 
 
 namespace {
-void _reset_tree_handler(Parser *parser, Tree *t, id_type node_id)
+// so many things can go wrong...
+void check_(Tree *tree)
 {
-    _RYML_ASSERT_BASIC(parser);
-    _RYML_ASSERT_BASIC(t);
-    if(!parser->m_evt_handler)
-        _RYML_ERR_BASIC_(t->m_callbacks, "event handler is not set");
-    parser->m_evt_handler->reset(t, node_id);
-    _RYML_ASSERT_BASIC(parser->m_evt_handler->m_tree == t);
+    if(C4_UNLIKELY(!tree))
+        _RYML_ERR_BASIC("null tree");
+    if(C4_UNLIKELY(tree->empty()))
+        tree->reserve();
+}
+void check_(NodeRef &node)
+{
+    check_(node.tree());
+    if(C4_UNLIKELY(node.id() == NONE))
+        _RYML_ERR_VISIT_(node.tree()->m_callbacks, node.tree(), node.id(), "invalid node");
+    node.create();
+}
+void check_(Parser *parser)
+{
+    if(C4_UNLIKELY(!parser))
+        _RYML_ERR_BASIC("null parser");
+    if(C4_UNLIKELY(!parser->m_evt_handler))
+        // the parser callbacks are from the handler. do not use parser->callbacks()
+        _RYML_ERR_BASIC("null handler");
+}
+void check_(Parser *parser, Tree *tree)
+{
+    if(C4_UNLIKELY(!parser && !tree))
+    {
+        _RYML_ERR_BASIC("null parser and tree");
+    }
+    else if(C4_UNLIKELY(!parser))
+    {
+        _RYML_ERR_BASIC_(tree->callbacks(), "null parser");
+    }
+    else if(C4_UNLIKELY(!tree))
+    {
+        if(C4_UNLIKELY(!parser->m_evt_handler))
+            _RYML_ERR_BASIC("null tree and handler");
+        else
+            _RYML_ERR_BASIC_(parser->callbacks(), "null tree");
+    }
+    if(C4_UNLIKELY(!parser->m_evt_handler))
+    {
+        _RYML_ERR_BASIC("null handler");
+    }
+    if(C4_UNLIKELY(tree->empty()))
+    {
+        tree->reserve();
+    }
+}
+void check_(Parser *parser, NodeRef &node)
+{
+    check_(parser, node.tree());
+    check_(node);
+}
+void checksrc_(Tree *tree, csubstr src)
+{
+    if(C4_UNLIKELY(src.len && !src.str))
+        _RYML_ERR_BASIC_(tree->callbacks(), "null source buffer");
+}
+substr cpsrc_(Tree *tree, csubstr src)
+{
+    checksrc_(tree, src);
+    return tree->copy_to_arena(src);
+}
+// helpers: check and copy to arena
+substr checkcp_(Tree *tree, csubstr src)
+{
+    check_(tree);
+    return cpsrc_(tree, src);
+}
+substr checkcp_(NodeRef &node, csubstr src)
+{
+    check_(node);
+    return cpsrc_(node.tree(), src);
+}
+substr checkcp_(Parser *parser, Tree *tree, csubstr src)
+{
+    check_(parser, tree);
+    return cpsrc_(tree, src);
+}
+substr checkcp_(Parser *parser, NodeRef &node, csubstr src)
+{
+    check_(parser, node);
+    return cpsrc_(node.tree(), src);
+}
+using Handler = Parser::handler_type;
+struct TmpParser
+{
+    Handler handler;
+    Parser  parser;
+    // assumes checks above were done prior to instantiation
+    TmpParser(ParserOptions const& opts={})
+        : handler(get_callbacks())
+        , parser(&handler, opts)
+    {
+    }
+    TmpParser(Tree* tree, ParserOptions const& opts={})
+        : handler(tree->callbacks())
+        , parser(&handler, opts)
+    {
+    }
+    TmpParser(NodeRef &node, ParserOptions const& opts={})
+        : handler(node.tree()->callbacks())
+        , parser(&handler, opts)
+    {
+    }
+};
+// assumes checks above were done prior to calling
+C4_ALWAYS_INLINE void reset_handler_(Parser *parser, Tree *tree, id_type node_id)
+{
+    _RYML_ASSERT_BASIC(parser); // LCOV_EXCL_LINE lcov weirdly fails here
+    _RYML_ASSERT_BASIC(parser->m_evt_handler);
+    _RYML_ASSERT_BASIC(tree);
+    if(C4_UNLIKELY(node_id == NONE || node_id >= tree->capacity()))
+        _RYML_ERR_VISIT_(tree->m_callbacks, tree, node_id, "invalid node");
+    parser->m_evt_handler->reset(tree, node_id);
+    _RYML_ASSERT_BASIC(parser->m_evt_handler->m_tree == tree);
+}
+// assumes checks above were done prior to calling
+void parse_yaml_(Parser *parser, csubstr filename, substr yaml, Tree *tree, id_type node_id)
+{
+    reset_handler_(parser, tree, node_id);
+    checksrc_(tree, yaml);
+    parser->parse_in_place_ev(filename, yaml);
+}
+// assumes checks above were done prior to calling
+void parse_json_(Parser *parser, csubstr filename, substr json, Tree *tree, id_type node_id)
+{
+    reset_handler_(parser, tree, node_id);
+    checksrc_(tree, json);
+    parser->parse_json_in_place_ev(filename, json);
 }
 } // namespace
 
-void parse_in_place(Parser *parser, csubstr filename, substr yaml, Tree *t, id_type node_id)
-{
-    _reset_tree_handler(parser, t, node_id);
-    parser->parse_in_place_ev(filename, yaml);
-}
-
-void parse_json_in_place(Parser *parser, csubstr filename, substr json, Tree *t, id_type node_id)
-{
-    _reset_tree_handler(parser, t, node_id);
-    parser->parse_json_in_place_ev(filename, json);
-}
 
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_in_place(Parser *parser,                   substr yaml, Tree *t, id_type node_id) { parse_in_place(parser, {}, yaml, t, node_id); }
-void parse_in_place(Parser *parser, csubstr filename, substr yaml, Tree *t                 ) { _RYML_CHECK_BASIC(t); if(t->empty()) { t->reserve(); } parse_in_place(parser, filename, yaml, t, t->root_id()); }
-void parse_in_place(Parser *parser,                   substr yaml, Tree *t                 ) { _RYML_CHECK_BASIC(t); if(t->empty()) { t->reserve(); } parse_in_place(parser, {}      , yaml, t, t->root_id()); }
-void parse_in_place(Parser *parser, csubstr filename, substr yaml, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); parse_in_place(parser, filename, yaml, node.tree(), node.id()); }
-void parse_in_place(Parser *parser,                   substr yaml, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); parse_in_place(parser, {}      , yaml, node.tree(), node.id()); }
-Tree parse_in_place(Parser *parser, csubstr filename, substr yaml                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); parse_in_place(parser, filename, yaml, &tree, tree.root_id()); return tree; }
-Tree parse_in_place(Parser *parser,                   substr yaml                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); parse_in_place(parser, {}      , yaml, &tree, tree.root_id()); return tree; }
+void parse_in_place(Parser *parser, csubstr filename, substr yaml, Tree *tree, id_type node_id) { check_(parser, tree); parse_yaml_(parser, filename, yaml, tree, node_id); }
+void parse_in_place(Parser *parser,                   substr yaml, Tree *tree, id_type node_id) { check_(parser, tree); parse_yaml_(parser, {}      , yaml, tree, node_id); }
+void parse_in_place(Parser *parser, csubstr filename, substr yaml, Tree *tree                 ) { check_(parser, tree); parse_yaml_(parser, filename, yaml, tree, tree->root_id()); }
+void parse_in_place(Parser *parser,                   substr yaml, Tree *tree                 ) { check_(parser, tree); parse_yaml_(parser, {}      , yaml, tree, tree->root_id()); }
+void parse_in_place(Parser *parser, csubstr filename, substr yaml, NodeRef node               ) { check_(parser, node); parse_yaml_(parser, filename, yaml, node.tree(), node.id()); }
+void parse_in_place(Parser *parser,                   substr yaml, NodeRef node               ) { check_(parser, node); parse_yaml_(parser, {}      , yaml, node.tree(), node.id()); }
+Tree parse_in_place(Parser *parser, csubstr filename, substr yaml                             ) { check_(parser); Tree tree(parser->callbacks()); parse_yaml_(parser, filename, yaml, &tree, tree.root_id()); return tree; }
+Tree parse_in_place(Parser *parser,                   substr yaml                             ) { check_(parser); Tree tree(parser->callbacks()); parse_yaml_(parser, {}      , yaml, &tree, tree.root_id()); return tree; }
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_in_place(csubstr filename, substr yaml, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); parse_in_place(&parser, filename, yaml, t, node_id); }
-void parse_in_place(                  substr yaml, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); parse_in_place(&parser, {}      , yaml, t, node_id); }
-void parse_in_place(csubstr filename, substr yaml, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); if(t->empty()) { t->reserve(); } parse_in_place(&parser, filename, yaml, t, t->root_id()); }
-void parse_in_place(                  substr yaml, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); if(t->empty()) { t->reserve(); } parse_in_place(&parser, {}      , yaml, t, t->root_id()); }
-void parse_in_place(csubstr filename, substr yaml, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); parse_in_place(&parser, filename, yaml, node.tree(), node.id()); }
-void parse_in_place(                  substr yaml, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); parse_in_place(&parser, {}      , yaml, node.tree(), node.id()); }
-Tree parse_in_place(csubstr filename, substr yaml                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); parse_in_place(&parser, filename, yaml, &tree, tree.root_id()); return tree; }
-Tree parse_in_place(                  substr yaml                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); parse_in_place(&parser, {}      , yaml, &tree, tree.root_id()); return tree; }
+void parse_in_place(csubstr filename, substr yaml, Tree *tree, id_type node_id, ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, filename, yaml, tree, node_id); }
+void parse_in_place(                  substr yaml, Tree *tree, id_type node_id, ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, {}      , yaml, tree, node_id); }
+void parse_in_place(csubstr filename, substr yaml, Tree *tree                 , ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, filename, yaml, tree, tree->root_id()); }
+void parse_in_place(                  substr yaml, Tree *tree                 , ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, {}      , yaml, tree, tree->root_id()); }
+void parse_in_place(csubstr filename, substr yaml, NodeRef node               , ParserOptions const& opts) { check_(node); TmpParser tmp(node, opts); parse_yaml_(&tmp.parser, filename, yaml, node.tree(), node.id()); }
+void parse_in_place(                  substr yaml, NodeRef node               , ParserOptions const& opts) { check_(node); TmpParser tmp(node, opts); parse_yaml_(&tmp.parser, {}      , yaml, node.tree(), node.id()); }
+Tree parse_in_place(csubstr filename, substr yaml                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree;          parse_yaml_(&tmp.parser, filename, yaml, &tree, tree.root_id()); return tree; }
+Tree parse_in_place(                  substr yaml                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree;          parse_yaml_(&tmp.parser, {}      , yaml, &tree, tree.root_id()); return tree; }
 
-
-// this is vertically aligned to highlight the parameter differences.
-void parse_json_in_place(Parser *parser,                   substr json, Tree *t, id_type node_id) { parse_json_in_place(parser, {}, json, t, node_id); }
-void parse_json_in_place(Parser *parser, csubstr filename, substr json, Tree *t                 ) { _RYML_CHECK_BASIC(t); if(t->empty()) { t->reserve(); } parse_json_in_place(parser, filename, json, t, t->root_id()); }
-void parse_json_in_place(Parser *parser,                   substr json, Tree *t                 ) { _RYML_CHECK_BASIC(t); if(t->empty()) { t->reserve(); } parse_json_in_place(parser, {}      , json, t, t->root_id()); }
-void parse_json_in_place(Parser *parser, csubstr filename, substr json, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); parse_json_in_place(parser, filename, json, node.tree(), node.id()); }
-void parse_json_in_place(Parser *parser,                   substr json, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); parse_json_in_place(parser, {}      , json, node.tree(), node.id()); }
-Tree parse_json_in_place(Parser *parser, csubstr filename, substr json                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); parse_json_in_place(parser, filename, json, &tree, tree.root_id()); return tree; }
-Tree parse_json_in_place(Parser *parser,                   substr json                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); parse_json_in_place(parser, {}      , json, &tree, tree.root_id()); return tree; }
-
-// this is vertically aligned to highlight the parameter differences.
-void parse_json_in_place(csubstr filename, substr json, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); parse_json_in_place(&parser, filename, json, t, node_id); }
-void parse_json_in_place(                  substr json, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); parse_json_in_place(&parser, {}      , json, t, node_id); }
-void parse_json_in_place(csubstr filename, substr json, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); if(t->empty()) { t->reserve(); } parse_json_in_place(&parser, filename, json, t, t->root_id()); }
-void parse_json_in_place(                  substr json, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); if(t->empty()) { t->reserve(); } parse_json_in_place(&parser, {}      , json, t, t->root_id()); }
-void parse_json_in_place(csubstr filename, substr json, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); parse_json_in_place(&parser, filename, json, node.tree(), node.id()); }
-void parse_json_in_place(                  substr json, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); parse_json_in_place(&parser, {}      , json, node.tree(), node.id()); }
-Tree parse_json_in_place(csubstr filename, substr json                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); parse_json_in_place(&parser, filename, json, &tree, tree.root_id()); return tree; }
-Tree parse_json_in_place(                  substr json                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); parse_json_in_place(&parser, {}      , json, &tree, tree.root_id()); return tree; }
 
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, Tree *t, id_type node_id) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(yaml); parse_in_place(parser, filename, src, t, node_id); }
-void parse_in_arena(Parser *parser,                   csubstr yaml, Tree *t, id_type node_id) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(yaml); parse_in_place(parser, {}      , src, t, node_id); }
-void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, Tree *t                 ) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(yaml); if(t->empty()) { t->reserve(); } parse_in_place(parser, filename, src, t, t->root_id()); }
-void parse_in_arena(Parser *parser,                   csubstr yaml, Tree *t                 ) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(yaml); if(t->empty()) { t->reserve(); } parse_in_place(parser, {}      , src, t, t->root_id()); }
-void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); substr src = node.tree()->copy_to_arena(yaml); parse_in_place(parser, filename, src, node.tree(), node.id()); }
-void parse_in_arena(Parser *parser,                   csubstr yaml, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); substr src = node.tree()->copy_to_arena(yaml); parse_in_place(parser, {}      , src, node.tree(), node.id()); }
-Tree parse_in_arena(Parser *parser, csubstr filename, csubstr yaml                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); substr src = tree.copy_to_arena(yaml); parse_in_place(parser, filename, src, &tree, tree.root_id()); return tree; }
-Tree parse_in_arena(Parser *parser,                   csubstr yaml                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); substr src = tree.copy_to_arena(yaml); parse_in_place(parser, {}      , src, &tree, tree.root_id()); return tree; }
+void parse_json_in_place(Parser *parser, csubstr filename, substr json, Tree *tree, id_type node_id) { check_(parser, tree); parse_json_(parser, filename, json, tree, node_id); }
+void parse_json_in_place(Parser *parser,                   substr json, Tree *tree, id_type node_id) { check_(parser, tree); parse_json_(parser, {}      , json, tree, node_id); }
+void parse_json_in_place(Parser *parser, csubstr filename, substr json, Tree *tree                 ) { check_(parser, tree); parse_json_(parser, filename, json, tree, tree->root_id()); }
+void parse_json_in_place(Parser *parser,                   substr json, Tree *tree                 ) { check_(parser, tree); parse_json_(parser, {}      , json, tree, tree->root_id()); }
+void parse_json_in_place(Parser *parser, csubstr filename, substr json, NodeRef node               ) { check_(parser, node); parse_json_(parser, filename, json, node.tree(), node.id()); }
+void parse_json_in_place(Parser *parser,                   substr json, NodeRef node               ) { check_(parser, node); parse_json_(parser, {}      , json, node.tree(), node.id()); }
+Tree parse_json_in_place(Parser *parser, csubstr filename, substr json                             ) { check_(parser); Tree tree(parser->callbacks()); parse_json_(parser, filename, json, &tree, tree.root_id()); return tree; }
+Tree parse_json_in_place(Parser *parser,                   substr json                             ) { check_(parser); Tree tree(parser->callbacks()); parse_json_(parser, {}      , json, &tree, tree.root_id()); return tree; }
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_in_arena(csubstr filename, csubstr yaml, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(yaml); parse_in_place(&parser, filename, src, t, node_id); }
-void parse_in_arena(                  csubstr yaml, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(yaml); parse_in_place(&parser, {}      , src, t, node_id); }
-void parse_in_arena(csubstr filename, csubstr yaml, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(yaml); if(t->empty()) { t->reserve(); } parse_in_place(&parser, filename, src, t, t->root_id()); }
-void parse_in_arena(                  csubstr yaml, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(yaml); if(t->empty()) { t->reserve(); } parse_in_place(&parser, {}      , src, t, t->root_id()); }
-void parse_in_arena(csubstr filename, csubstr yaml, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); substr src = node.tree()->copy_to_arena(yaml); parse_in_place(&parser, filename, src, node.tree(), node.id()); }
-void parse_in_arena(                  csubstr yaml, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); substr src = node.tree()->copy_to_arena(yaml); parse_in_place(&parser, {}      , src, node.tree(), node.id()); }
-Tree parse_in_arena(csubstr filename, csubstr yaml                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); substr src = tree.copy_to_arena(yaml); parse_in_place(&parser, filename, src, &tree, tree.root_id()); return tree; }
-Tree parse_in_arena(                  csubstr yaml                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); substr src = tree.copy_to_arena(yaml); parse_in_place(&parser, {}      , src, &tree, tree.root_id()); return tree; }
+void parse_json_in_place(csubstr filename, substr json, Tree *tree, id_type node_id, ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, filename, json, tree, node_id); }
+void parse_json_in_place(                  substr json, Tree *tree, id_type node_id, ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, {}      , json, tree, node_id); }
+void parse_json_in_place(csubstr filename, substr json, Tree *tree                 , ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, filename, json, tree, tree->root_id()); }
+void parse_json_in_place(                  substr json, Tree *tree                 , ParserOptions const& opts) { check_(tree); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, {}      , json, tree, tree->root_id()); }
+void parse_json_in_place(csubstr filename, substr json, NodeRef node               , ParserOptions const& opts) { check_(node); TmpParser tmp(node, opts); parse_json_(&tmp.parser, filename, json, node.tree(), node.id()); }
+void parse_json_in_place(                  substr json, NodeRef node               , ParserOptions const& opts) { check_(node); TmpParser tmp(node, opts); parse_json_(&tmp.parser, {}      , json, node.tree(), node.id()); }
+Tree parse_json_in_place(csubstr filename, substr json                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree;          parse_json_(&tmp.parser, filename, json, &tree, tree.root_id()); return tree; }
+Tree parse_json_in_place(                  substr json                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree;          parse_json_(&tmp.parser, {}      , json, &tree, tree.root_id()); return tree; }
+
+
+
+// this is vertically aligned to highlight the parameter differences.
+void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, Tree *tree, id_type node_id) { substr src = checkcp_(parser, tree, yaml); parse_yaml_(parser, filename, src, tree, node_id); }
+void parse_in_arena(Parser *parser,                   csubstr yaml, Tree *tree, id_type node_id) { substr src = checkcp_(parser, tree, yaml); parse_yaml_(parser, {}      , src, tree, node_id); }
+void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, Tree *tree                 ) { substr src = checkcp_(parser, tree, yaml); parse_yaml_(parser, filename, src, tree, tree->root_id()); }
+void parse_in_arena(Parser *parser,                   csubstr yaml, Tree *tree                 ) { substr src = checkcp_(parser, tree, yaml); parse_yaml_(parser, {}      , src, tree, tree->root_id()); }
+void parse_in_arena(Parser *parser, csubstr filename, csubstr yaml, NodeRef node               ) { substr src = checkcp_(parser, node, yaml); parse_yaml_(parser, filename, src, node.tree(), node.id()); }
+void parse_in_arena(Parser *parser,                   csubstr yaml, NodeRef node               ) { substr src = checkcp_(parser, node, yaml); parse_yaml_(parser, {}      , src, node.tree(), node.id()); }
+Tree parse_in_arena(Parser *parser, csubstr filename, csubstr yaml                             ) { check_(parser); Tree tree(parser->callbacks()); substr src = cpsrc_(&tree, yaml); parse_yaml_(parser, filename, src, &tree, tree.root_id()); return tree; }
+Tree parse_in_arena(Parser *parser,                   csubstr yaml                             ) { check_(parser); Tree tree(parser->callbacks()); substr src = cpsrc_(&tree, yaml); parse_yaml_(parser, {}      , src, &tree, tree.root_id()); return tree; }
+
+// this is vertically aligned to highlight the parameter differences.
+void parse_in_arena(csubstr filename, csubstr yaml, Tree *tree, id_type node_id, ParserOptions const& opts) { substr src = checkcp_(tree, yaml); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, filename, src, tree, node_id); }
+void parse_in_arena(                  csubstr yaml, Tree *tree, id_type node_id, ParserOptions const& opts) { substr src = checkcp_(tree, yaml); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, {}      , src, tree, node_id); }
+void parse_in_arena(csubstr filename, csubstr yaml, Tree *tree                 , ParserOptions const& opts) { substr src = checkcp_(tree, yaml); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, filename, src, tree, tree->root_id()); }
+void parse_in_arena(                  csubstr yaml, Tree *tree                 , ParserOptions const& opts) { substr src = checkcp_(tree, yaml); TmpParser tmp(tree, opts); parse_yaml_(&tmp.parser, {}      , src, tree, tree->root_id()); }
+void parse_in_arena(csubstr filename, csubstr yaml, NodeRef node               , ParserOptions const& opts) { substr src = checkcp_(node, yaml); TmpParser tmp(node, opts); parse_yaml_(&tmp.parser, filename, src, node.tree(), node.id()); }
+void parse_in_arena(                  csubstr yaml, NodeRef node               , ParserOptions const& opts) { substr src = checkcp_(node, yaml); TmpParser tmp(node, opts); parse_yaml_(&tmp.parser, {}      , src, node.tree(), node.id()); }
+Tree parse_in_arena(csubstr filename, csubstr yaml                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree; substr src = cpsrc_(&tree, yaml); parse_yaml_(&tmp.parser, filename, src, &tree, tree.root_id()); return tree; }
+Tree parse_in_arena(                  csubstr yaml                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree; substr src = cpsrc_(&tree, yaml); parse_yaml_(&tmp.parser, {}      , src, &tree, tree.root_id()); return tree; }
+
 
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, Tree *t, id_type node_id) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(json); parse_json_in_place(parser, filename, src, t, node_id); }
-void parse_json_in_arena(Parser *parser,                   csubstr json, Tree *t, id_type node_id) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(json); parse_json_in_place(parser, {}      , src, t, node_id); }
-void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, Tree *t                 ) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(json); if(t->empty()) { t->reserve(); } parse_json_in_place(parser, filename, src, t, t->root_id()); }
-void parse_json_in_arena(Parser *parser,                   csubstr json, Tree *t                 ) { _RYML_CHECK_BASIC(t); substr src = t->copy_to_arena(json); if(t->empty()) { t->reserve(); } parse_json_in_place(parser, {}      , src, t, t->root_id()); }
-void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); substr src = node.tree()->copy_to_arena(json); parse_json_in_place(parser, filename, src, node.tree(), node.id()); }
-void parse_json_in_arena(Parser *parser,                   csubstr json, NodeRef node            ) { _RYML_CHECK_BASIC(!node.invalid()); substr src = node.tree()->copy_to_arena(json); parse_json_in_place(parser, {}      , src, node.tree(), node.id()); }
-Tree parse_json_in_arena(Parser *parser, csubstr filename, csubstr json                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); substr src = tree.copy_to_arena(json); parse_json_in_place(parser, filename, src, &tree, tree.root_id()); return tree; }
-Tree parse_json_in_arena(Parser *parser,                   csubstr json                          ) { _RYML_CHECK_BASIC(parser); _RYML_CHECK_BASIC(parser->m_evt_handler); Tree tree(parser->callbacks()); substr src = tree.copy_to_arena(json); parse_json_in_place(parser, {}      , src, &tree, tree.root_id()); return tree; }
+void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, Tree *tree, id_type node_id) { substr src = checkcp_(parser, tree, json); parse_json_(parser, filename, src, tree, node_id); }
+void parse_json_in_arena(Parser *parser,                   csubstr json, Tree *tree, id_type node_id) { substr src = checkcp_(parser, tree, json); parse_json_(parser, {}      , src, tree, node_id); }
+void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, Tree *tree                 ) { substr src = checkcp_(parser, tree, json); parse_json_(parser, filename, src, tree, tree->root_id()); }
+void parse_json_in_arena(Parser *parser,                   csubstr json, Tree *tree                 ) { substr src = checkcp_(parser, tree, json); parse_json_(parser, {}      , src, tree, tree->root_id()); }
+void parse_json_in_arena(Parser *parser, csubstr filename, csubstr json, NodeRef node               ) { substr src = checkcp_(parser, node, json); parse_json_(parser, filename, src, node.tree(), node.id()); }
+void parse_json_in_arena(Parser *parser,                   csubstr json, NodeRef node               ) { substr src = checkcp_(parser, node, json); parse_json_(parser, {}      , src, node.tree(), node.id()); }
+Tree parse_json_in_arena(Parser *parser, csubstr filename, csubstr json                             ) { check_(parser); Tree tree(parser->callbacks()); substr src = cpsrc_(&tree, json); parse_json_(parser, filename, src, &tree, tree.root_id()); return tree; }
+Tree parse_json_in_arena(Parser *parser,                   csubstr json                             ) { check_(parser); Tree tree(parser->callbacks()); substr src = cpsrc_(&tree, json); parse_json_(parser, {}      , src, &tree, tree.root_id()); return tree; }
 
 // this is vertically aligned to highlight the parameter differences.
-void parse_json_in_arena(csubstr filename, csubstr json, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(json); parse_json_in_place(&parser, filename, src, t, node_id); }
-void parse_json_in_arena(                  csubstr json, Tree *t, id_type node_id, ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(json); parse_json_in_place(&parser, {}      , src, t, node_id); }
-void parse_json_in_arena(csubstr filename, csubstr json, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(json); if(t->empty()) { t->reserve(); } parse_json_in_place(&parser, filename, src, t, t->root_id()); }
-void parse_json_in_arena(                  csubstr json, Tree *t                 , ParserOptions const& opts) { _RYML_CHECK_BASIC(t); Parser::handler_type event_handler(t->callbacks()); Parser parser(&event_handler, opts); substr src = t->copy_to_arena(json); if(t->empty()) { t->reserve(); } parse_json_in_place(&parser, {}      , src, t, t->root_id()); }
-void parse_json_in_arena(csubstr filename, csubstr json, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); substr src = node.tree()->copy_to_arena(json); parse_json_in_place(&parser, filename, src, node.tree(), node.id()); }
-void parse_json_in_arena(                  csubstr json, NodeRef node            , ParserOptions const& opts) { _RYML_CHECK_BASIC(!node.invalid()); Parser::handler_type event_handler(node.tree()->callbacks()); Parser parser(&event_handler, opts); substr src = node.tree()->copy_to_arena(json); parse_json_in_place(&parser, {}      , src, node.tree(), node.id()); }
-Tree parse_json_in_arena(csubstr filename, csubstr json                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); substr src = tree.copy_to_arena(json); parse_json_in_place(&parser, filename, src, &tree, tree.root_id()); return tree; }
-Tree parse_json_in_arena(                  csubstr json                          , ParserOptions const& opts) { Parser::handler_type event_handler; Parser parser(&event_handler, opts); Tree tree(parser.callbacks()); substr src = tree.copy_to_arena(json); parse_json_in_place(&parser, {}      , src, &tree, tree.root_id()); return tree; }
+void parse_json_in_arena(csubstr filename, csubstr json, Tree *tree, id_type node_id, ParserOptions const& opts) { substr src = checkcp_(tree, json); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, filename, src, tree, node_id); }
+void parse_json_in_arena(                  csubstr json, Tree *tree, id_type node_id, ParserOptions const& opts) { substr src = checkcp_(tree, json); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, {}      , src, tree, node_id); }
+void parse_json_in_arena(csubstr filename, csubstr json, Tree *tree                 , ParserOptions const& opts) { substr src = checkcp_(tree, json); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, filename, src, tree, tree->root_id()); }
+void parse_json_in_arena(                  csubstr json, Tree *tree                 , ParserOptions const& opts) { substr src = checkcp_(tree, json); TmpParser tmp(tree, opts); parse_json_(&tmp.parser, {}      , src, tree, tree->root_id()); }
+void parse_json_in_arena(csubstr filename, csubstr json, NodeRef node               , ParserOptions const& opts) { substr src = checkcp_(node, json); TmpParser tmp(node, opts); parse_json_(&tmp.parser, filename, src, node.tree(), node.id()); }
+void parse_json_in_arena(                  csubstr json, NodeRef node               , ParserOptions const& opts) { substr src = checkcp_(node, json); TmpParser tmp(node, opts); parse_json_(&tmp.parser, {}      , src, node.tree(), node.id()); }
+Tree parse_json_in_arena(csubstr filename, csubstr json                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree; substr src = cpsrc_(&tree, json); parse_json_(&tmp.parser, filename, src, &tree, tree.root_id()); return tree; }
+Tree parse_json_in_arena(                  csubstr json                             , ParserOptions const& opts) { TmpParser tmp(opts); Tree tree; substr src = cpsrc_(&tree, json); parse_json_(&tmp.parser, {}      , src, &tree, tree.root_id()); return tree; }
+
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/yml/parse_engine.def.hpp
+++ b/src/c4/yml/parse_engine.def.hpp
@@ -282,14 +282,14 @@ inline size_t _count_following_newlines(csubstr r, size_t *C4_RESTRICT i, size_t
 //-----------------------------------------------------------------------------
 
 template<class EventHandler>
-ParseEngine<EventHandler>::~ParseEngine()
+ParseEngine<EventHandler>::~ParseEngine() noexcept
 {
     _free();
     _clr();
 }
 
 template<class EventHandler>
-ParseEngine<EventHandler>::ParseEngine(EventHandler *evt_handler, ParserOptions opts)
+ParseEngine<EventHandler>::ParseEngine(EventHandler *evt_handler, ParserOptions const& opts)
     : m_options(opts)
     , m_evt_handler(evt_handler)
     , m_pending_anchors()

--- a/src/c4/yml/parse_engine.hpp
+++ b/src/c4/yml/parse_engine.hpp
@@ -270,8 +270,8 @@ public:
     /** @name construction and assignment */
     /** @{ */
 
-    ParseEngine(EventHandler *evt_handler, ParserOptions opts={});
-    ~ParseEngine();
+    ParseEngine(EventHandler *evt_handler, ParserOptions const& opts={});
+    ~ParseEngine() noexcept;
 
     ParseEngine(ParseEngine &&) noexcept;
     ParseEngine(ParseEngine const&);

--- a/src/c4/yml/std/map.hpp
+++ b/src/c4/yml/std/map.hpp
@@ -16,7 +16,7 @@ namespace yml {
 template<class K, class V, class Less, class Alloc>
 void write(c4::yml::NodeRef *n, std::map<K, V, Less, Alloc> const& m)
 {
-    *n |= c4::yml::MAP;
+    n->set_map();
     for(auto const& C4_RESTRICT p : m)
     {
         auto ch = n->append_child();

--- a/src/c4/yml/std/vector.hpp
+++ b/src/c4/yml/std/vector.hpp
@@ -16,7 +16,7 @@ namespace yml {
 template<class V, class Alloc>
 void write(c4::yml::NodeRef *n, std::vector<V, Alloc> const& vec)
 {
-    *n |= c4::yml::SEQ;
+    n->set_seq();
     for(V const& v : vec)
         n->append_child() << v;
 }

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1330,6 +1330,7 @@ bool Tree::is_ancestor(id_type node, id_type ancestor) const
 
 //-----------------------------------------------------------------------------
 
+/** @cond dev */
 void Tree::to_val(id_type node, csubstr val, type_bits more_flags)
 {
     _RYML_ASSERT_VISIT_(m_callbacks,  ! has_children(node), this, node);
@@ -1399,6 +1400,7 @@ void Tree::to_stream(id_type node, type_bits more_flags)
     _p(node)->m_key.clear();
     _p(node)->m_val.clear();
 }
+/** @endcond */
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1,7 +1,15 @@
+#ifndef _C4_YML_TREE_HPP_
 #include "c4/yml/tree.hpp"
+#endif
+#ifndef _C4_YML_DETAIL_DBGPRINT_HPP_
 #include "c4/yml/detail/dbgprint.hpp"
+#endif
+#ifndef _C4_YML_NODE_HPP_
 #include "c4/yml/node.hpp"
+#endif
+#ifndef _C4_YML_REFERENCE_RESOLVERS_HPP_
 #include "c4/yml/reference_resolver.hpp"
+#endif
 
 
 C4_SUPPRESS_WARNING_MSVC_WITH_PUSH(4296/*expression is always 'boolean_value'*/)
@@ -442,20 +450,18 @@ id_type Tree::_claim()
 
 //-----------------------------------------------------------------------------
 
-C4_SUPPRESS_WARNING_GCC_PUSH
-C4_SUPPRESS_WARNING_CLANG_PUSH
-C4_SUPPRESS_WARNING_CLANG("-Wnull-dereference")
-#if defined(__GNUC__)
-#if (__GNUC__ >= 6)
-C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
-#endif
-#if (__GNUC__ > 9)
-C4_SUPPRESS_WARNING_GCC("-Wanalyzer-fd-leak")
-#endif
-#endif
-
 void Tree::_set_hierarchy(id_type ichild, id_type iparent, id_type iprev_sibling)
 {
+    C4_SUPPRESS_WARNING_PUSH
+    C4_SUPPRESS_WARNING_CLANG("-Wnull-dereference")
+    #if defined(__GNUC__)
+    #if (__GNUC__ >= 6)
+    C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
+    #endif
+    #if (__GNUC__ > 9)
+    C4_SUPPRESS_WARNING_GCC("-Wanalyzer-fd-leak")
+    #endif
+    #endif
     _RYML_ASSERT_VISIT_(m_callbacks, ichild >= 0 && ichild < m_cap, this, ichild);
     _RYML_ASSERT_VISIT_(m_callbacks, iparent == NONE || (iparent >= 0 && iparent < m_cap), this, iparent);
     _RYML_ASSERT_VISIT_(m_callbacks, iprev_sibling == NONE || (iprev_sibling >= 0 && iprev_sibling < m_cap), this, iprev_sibling);
@@ -510,10 +516,9 @@ void Tree::_set_hierarchy(id_type ichild, id_type iparent, id_type iprev_sibling
         if(child->m_prev_sibling == parent->m_last_child)
             parent->m_last_child = id(child);
     }
+    C4_SUPPRESS_WARNING_POP
 }
 
-C4_SUPPRESS_WARNING_GCC_POP
-C4_SUPPRESS_WARNING_CLANG_POP
 
 
 //-----------------------------------------------------------------------------
@@ -814,6 +819,7 @@ void Tree::_swap_props(id_type n_, id_type m_)
     std::swap(n.m_val, m.m_val);
 }
 /** @endcond */
+
 
 //-----------------------------------------------------------------------------
 void Tree::move(id_type node, id_type after)
@@ -1149,13 +1155,8 @@ void Tree::merge_with(Tree const *src, id_type src_node, id_type dst_node)
                 remove_children(dst_node);
             _clear_type(dst_node);
             if(src->has_key(src_node))
-            {
-                set_key(dst_node, src->key(src_node), SEQ);
-            }
-            else
-            {
-                set_seq(dst_node);
-            }
+                set_key(dst_node, src->key(src_node));
+            set_seq(dst_node);
             _p(dst_node)->m_type = src->_p(src_node)->m_type;
         }
         for(id_type sch = src->first_child(src_node); sch != NONE; sch = src->next_sibling(sch))
@@ -1174,9 +1175,8 @@ void Tree::merge_with(Tree const *src, id_type src_node, id_type dst_node)
                 remove_children(dst_node);
             _clear_type(dst_node);
             if(src->has_key(src_node))
-                set_key(dst_node, src->key(src_node), MAP);
-            else
-                set_map(dst_node);
+                set_key(dst_node, src->key(src_node));
+            set_map(dst_node);
             _p(dst_node)->m_type = src->_p(src_node)->m_type;
         }
         for(id_type sch = src->first_child(src_node); sch != NONE; sch = src->next_sibling(sch))
@@ -1246,23 +1246,21 @@ id_type Tree::child_pos(id_type node, id_type ch) const
     return NONE;
 }
 
-#if defined(__clang__)
-#   pragma clang diagnostic push
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic push
-#   if __GNUC__ >= 6
-#       pragma GCC diagnostic ignored "-Wnull-dereference"
-#   endif
-#   if __GNUC__ > 9
-#       pragma GCC diagnostic ignored "-Wanalyzer-null-dereference"
-#   endif
-#endif
-
 id_type Tree::find_child(id_type node, csubstr const& name) const
 {
+    C4_SUPPRESS_WARNING_PUSH
+    #if defined(__clang__)
+    #elif defined(__GNUC__)
+    #   if __GNUC__ >= 6
+            C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
+    #   endif
+    #   if __GNUC__ > 9
+            C4_SUPPRESS_WARNING_GCC("-Wanalyzer-null-dereference")
+    #   endif
+    #endif
     _RYML_ASSERT_VISIT_(m_callbacks, node != NONE, this, node);
     _RYML_ASSERT_VISIT_(m_callbacks, is_map(node), this, node);
-    if(get(node)->m_first_child == NONE)
+    if(_p(node)->m_first_child == NONE)
     {
         _RYML_ASSERT_VISIT_(m_callbacks, _p(node)->m_last_child == NONE, this, node);
         return NONE;
@@ -1279,13 +1277,9 @@ id_type Tree::find_child(id_type node, csubstr const& name) const
         }
     }
     return NONE;
+    C4_SUPPRESS_WARNING_POP
 }
 
-#if defined(__clang__)
-#   pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic pop
-#endif
 
 namespace {
 id_type depth_desc_(Tree const& C4_RESTRICT t, id_type id, id_type currdepth=0, id_type maxdepth=0)
@@ -1334,11 +1328,12 @@ bool Tree::is_ancestor(id_type node, id_type ancestor) const
 
 //-----------------------------------------------------------------------------
 
-/** @cond dev */
+/** @cond dev */ // LCOV_EXCL_START
 void Tree::to_val(id_type node, csubstr val, type_bits more_flags)
 {
     _RYML_ASSERT_VISIT_(m_callbacks,  ! has_children(node), this, node);
     _RYML_ASSERT_VISIT_(m_callbacks, parent(node) == NONE || ! parent_is_map(node), this, node);
+    _RYML_ASSERT_VISIT_(m_callbacks, !is_seq(node) && !is_map(node), this, node);
     _set_flags(node, VAL|more_flags);
     _p(node)->m_key.clear();
     _p(node)->m_val = val;
@@ -1348,6 +1343,7 @@ void Tree::to_keyval(id_type node, csubstr key, csubstr val, type_bits more_flag
 {
     _RYML_ASSERT_VISIT_(m_callbacks,  ! has_children(node), this, node);
     _RYML_ASSERT_VISIT_(m_callbacks, parent(node) == NONE || parent_is_map(node), this, node);
+    _RYML_ASSERT_VISIT_(m_callbacks, !is_seq(node) && !is_map(node), this, node);
     _set_flags(node, KEYVAL|more_flags);
     _p(node)->m_key = key;
     _p(node)->m_val = val;
@@ -1404,7 +1400,7 @@ void Tree::to_stream(id_type node, type_bits more_flags)
     _p(node)->m_key.clear();
     _p(node)->m_val.clear();
 }
-/** @endcond */
+/** @endcond */ // LCOV_EXCL_STOP
 
 
 //-----------------------------------------------------------------------------
@@ -1629,15 +1625,7 @@ Tree::lookup_result Tree::lookup_path(csubstr path, id_type start) const
 id_type Tree::lookup_path_or_modify(csubstr default_value, csubstr path, id_type start)
 {
     id_type target = _lookup_path_or_create(path, start);
-    if(parent_is_map(target))
-    {
-        set_key(target, key(target));
-        set_val(target, default_value);
-    }
-    else
-    {
-        set_val(target, default_value);
-    }
+    set_val(target, default_value);
     return target;
 }
 
@@ -1761,10 +1749,7 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
         //_RYML_ASSERT_VISIT_(m_callbacks, is_container(r->closest) || r->closest == NONE);
         if( ! is_container(r->closest))
         {
-            if(has_key(r->closest))
-                set_key(r->closest, key(r->closest), MAP);
-            else
-                set_map(r->closest);
+            set_map(r->closest);
         }
         else
         {
@@ -1815,20 +1800,12 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
         token.value = token.value.offs(1, 1).trim(' ');
         id_type idx;
         if( ! from_chars(token.value, &idx))
+        {
              return NONE;
+        }
         if( ! is_container(r->closest))
         {
-            if(has_key(r->closest))
-            {
-                csubstr k = key(r->closest);
-                _clear_type(r->closest);
-                set_key(r->closest, k, SEQ);
-            }
-            else
-            {
-                _clear_type(r->closest);
-                set_seq(r->closest);
-            }
+            set_seq(r->closest);
         }
         _RYML_ASSERT_VISIT_(m_callbacks, is_container(r->closest), this, r->closest);
         node = child(r->closest, idx);
@@ -1845,7 +1822,7 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
                         set_key(node, {});
                         set_val(node, {});
                     }
-                    else if(is_seq(r->closest))
+                    else
                     {
                         set_val(node, {});
                     }
@@ -1920,9 +1897,15 @@ Tree::_lookup_path_token Tree::_next_token(lookup_result *r, _lookup_path_token 
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
+#ifndef _C4_YML_EVENT_HANDLER_TREE_HPP_
 #include "c4/yml/event_handler_tree.hpp"
+#endif
+#ifndef _C4_YML_PARSE_ENGINE_DEF_HPP_
 #include "c4/yml/parse_engine.def.hpp"
+#endif
+#ifndef _C4_YML_PARSE_HPP_
 #include "c4/yml/parse.hpp"
+#endif
 
 namespace c4 {
 namespace yml {

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1149,9 +1149,13 @@ void Tree::merge_with(Tree const *src, id_type src_node, id_type dst_node)
                 remove_children(dst_node);
             _clear_type(dst_node);
             if(src->has_key(src_node))
-                to_seq(dst_node, src->key(src_node));
+            {
+                set_key(dst_node, src->key(src_node), SEQ);
+            }
             else
-                to_seq(dst_node);
+            {
+                set_seq(dst_node);
+            }
             _p(dst_node)->m_type = src->_p(src_node)->m_type;
         }
         for(id_type sch = src->first_child(src_node); sch != NONE; sch = src->next_sibling(sch))
@@ -1170,9 +1174,9 @@ void Tree::merge_with(Tree const *src, id_type src_node, id_type dst_node)
                 remove_children(dst_node);
             _clear_type(dst_node);
             if(src->has_key(src_node))
-                to_map(dst_node, src->key(src_node));
+                set_key(dst_node, src->key(src_node), MAP);
             else
-                to_map(dst_node);
+                set_map(dst_node);
             _p(dst_node)->m_type = src->_p(src_node)->m_type;
         }
         for(id_type sch = src->first_child(src_node); sch != NONE; sch = src->next_sibling(sch))
@@ -1626,9 +1630,14 @@ id_type Tree::lookup_path_or_modify(csubstr default_value, csubstr path, id_type
 {
     id_type target = _lookup_path_or_create(path, start);
     if(parent_is_map(target))
-        to_keyval(target, key(target), default_value);
+    {
+        set_key(target, key(target));
+        set_val(target, default_value);
+    }
     else
-        to_val(target, default_value);
+    {
+        set_val(target, default_value);
+    }
     return target;
 }
 
@@ -1753,9 +1762,9 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
         if( ! is_container(r->closest))
         {
             if(has_key(r->closest))
-                to_map(r->closest, key(r->closest));
+                set_key(r->closest, key(r->closest), MAP);
             else
-                to_map(r->closest);
+                set_map(r->closest);
         }
         else
         {
@@ -1813,12 +1822,12 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
             {
                 csubstr k = key(r->closest);
                 _clear_type(r->closest);
-                to_seq(r->closest, k);
+                set_key(r->closest, k, SEQ);
             }
             else
             {
                 _clear_type(r->closest);
-                to_seq(r->closest);
+                set_seq(r->closest);
             }
         }
         _RYML_ASSERT_VISIT_(m_callbacks, is_container(r->closest), this, r->closest);
@@ -1832,9 +1841,14 @@ id_type Tree::_next_node_modify(lookup_result * r, _lookup_path_token *parent)
                 if(i < idx)
                 {
                     if(is_map(r->closest))
-                        to_keyval(node, /*"~"*/{}, /*"~"*/{});
+                    {
+                        set_key(node, {});
+                        set_val(node, {});
+                    }
                     else if(is_seq(r->closest))
-                        to_val(node, /*"~"*/{});
+                    {
+                        set_val(node, {});
+                    }
                 }
             }
         }

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -35,12 +35,17 @@
 C4_SUPPRESS_WARNING_MSVC_PUSH
 C4_SUPPRESS_WARNING_MSVC(4251) // needs to have dll-interface to be used by clients of struct
 C4_SUPPRESS_WARNING_MSVC(4296) // expression is always 'boolean_value'
+C4_SUPPRESS_WARNING_MSVC(4127) // conditional expression is constant
 C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
 C4_SUPPRESS_WARNING_GCC_CLANG("-Wold-style-cast")
 C4_SUPPRESS_WARNING_GCC("-Wuseless-cast")
 C4_SUPPRESS_WARNING_GCC("-Wtype-limits")
-
+C4_SUPPRESS_WARNING_CLANG("-Wnull-dereference")
+#if defined(__GNUC__) && (__GNUC__ >= 6)
+C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
+#endif
 // NOLINTBEGIN(modernize-avoid-c-style-cast)
+
 
 namespace c4 {
 namespace yml {
@@ -101,7 +106,6 @@ C4_ALWAYS_INLINE csubstr serialize_to_arena(Tree * C4_RESTRICT, std::nullptr_t)
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-
 
 /** @addtogroup doc_tree
  *
@@ -298,18 +302,8 @@ public:
     /** @name node getters */
     /** @{ */
 
-    //! get the index of a node belonging to this tree.
-    //! @p n can be nullptr, in which case NONE is returned
-    id_type id(NodeData const* n) const
-    {
-        if( ! n)
-            return NONE;
-        _RYML_ASSERT_VISIT_(m_callbacks, n >= m_buf && n < m_buf + m_cap, this, NONE);
-        return static_cast<id_type>(n - m_buf);
-    }
-
     //! get a pointer to a node's NodeData.
-    //! i can be NONE, in which case a nullptr is returned
+    //! node can be NONE, in which case a nullptr is returned
     NodeData *get(id_type node) // NOLINT(readability-make-member-function-const)
     {
         if(node == NONE)
@@ -318,7 +312,7 @@ public:
         return m_buf + node;
     }
     //! get a pointer to a node's NodeData.
-    //! i can be NONE, in which case a nullptr is returned.
+    //! node can be NONE, in which case a nullptr is returned.
     NodeData const *get(id_type node) const
     {
         if(node == NONE)
@@ -338,6 +332,23 @@ public:
     id_type root_id() const { _RYML_ASSERT_VISIT_(m_callbacks, m_size > 0, this, id_type(0)); return 0; }
     //! Get the id of the root node, or NONE if the tree is empty.
     id_type root_id_maybe() const { return m_size ? 0 : id_type(NONE); }
+    //! get the id of a node belonging to this tree.
+    //! @p n can be nullptr, in which case NONE is returned
+    //! @p n must belong to this tree
+    id_type id(NodeData const* n) const
+    {
+        if( ! n)
+            return NONE;
+        _RYML_ASSERT_VISIT_(m_callbacks, n >= m_buf && n < m_buf + m_cap, this, NONE);
+        return static_cast<id_type>(n - m_buf);
+    }
+
+    /** @} */
+
+public:
+
+    /** @name NodeRef helpers */
+    /** @{ */
 
     //! Get a NodeRef of a node by id
     NodeRef      ref(id_type node);
@@ -346,11 +357,11 @@ public:
     //! Get a NodeRef of a node by id
     ConstNodeRef cref(id_type node) const;
 
-    //! Get the root as a NodeRef
+    //! Get the root as a @ref NodeRef . Note that a non-const Tree implicitly converts to @ref NodeRef.
     NodeRef      rootref();
-    //! Get the root as a ConstNodeRef
+    //! Get the root as a @ref ConstNodeRef . Note that Tree implicitly converts to @ref ConstNodeRef.
     ConstNodeRef rootref() const;
-    //! Get the root as a ConstNodeRef
+    //! Get the root as a @ref ConstNodeRef . Note that Tree implicitly converts to @ref ConstNodeRef.
     ConstNodeRef crootref() const;
 
     //! get the i-th document of the stream
@@ -371,10 +382,10 @@ public:
     ConstNodeRef operator[] (csubstr key) const;
 
     //! find a root child (ie child of root) by index: return the root node's @p i-th child as a NodeRef
-    //! @note @p i is NOT the node id, but the child's position
+    //! @note @p i is NOT the node id, but the child's position within the parent
     NodeRef      operator[] (id_type i);
     //! find a root child (ie child of root) by index: return the root node's @p i-th child as a NodeRef
-    //! @note @p i is NOT the node id, but the child's position
+    //! @note @p i is NOT the node id, but the child's position within the parent
     ConstNodeRef operator[] (id_type i) const;
 
     /** @} */
@@ -476,7 +487,7 @@ public:
     bool has_child(id_type node, id_type ch) const { return _p(ch)->m_parent == node; }
     /** true if @p node has a child with key @p key */
     bool has_child(id_type node, csubstr key) const { return find_child(node, key) != NONE; }
-    /** true if @p node has any children key */
+    /** true if @p node has any children */
     bool has_children(id_type node) const { return _p(node)->m_first_child != NONE; }
 
     /** true if @p node has a sibling with id @p sib */
@@ -666,11 +677,10 @@ public:
     /** @name tags and tag directives */
     /** @{ */
 
-    /** Resolve tags in the tree such as `"!!str"` ->
-     * `"<tag:yaml.org,2002:str>"`, `"!foo"` ->
-     * `"<!foo>"` and custom tags as well, ie tags of the form
-     * `"!handle!tag"` for which there is a corresponding `"%%TAG"`
-     * directive
+    /** Resolve tags in the tree such as \c "!!str" ->
+     * \c "<tag:yaml.org,2002:str>", \c "!foo" -> \c "<!foo>" and custom tags
+     * as well, ie tags of the form \c "!handle!tag" for which there is a
+     * corresponding \c "%TAG" directive
      *
      * @param cache an object of type @ref TagCache to minimize memory
      *        usage by avoiding repeated instantiation of the resolved
@@ -678,7 +688,7 @@ public:
      *
      * @param all if true, resolve all tags; if false resolve only
      *        custom tags, ie those that have a prefix such as
-     *        `"!m!tag"` with a matching `"%TAG"` directive */
+     *        \c "!m!tag" with a matching \c "\%TAG" directive */
     void resolve_tags(TagCache &cache, bool all=true);
     void normalize_tags();
     void normalize_tags_long();
@@ -736,16 +746,6 @@ public:
 
 public:
 
-    #if defined(__clang__) // NOLINT
-    #   pragma clang diagnostic push
-    #   pragma clang diagnostic ignored "-Wnull-dereference"
-    #elif defined(__GNUC__)
-    #   pragma GCC diagnostic push
-    #   if __GNUC__ >= 6
-    #       pragma GCC diagnostic ignored "-Wnull-dereference"
-    #   endif
-    #endif
-
     //! create and insert a new sibling of n. insert after "after"
     C4_ALWAYS_INLINE id_type insert_sibling(id_type node, id_type after)
     {
@@ -766,28 +766,6 @@ public:
 
     /** remove all the node's children, but keep the node itself */
     void remove_children(id_type node);
-
-    /** change the @p type of the node to one of MAP, SEQ or VAL.  @p
-     * type must have one and only one of MAP,SEQ,VAL; @p type may
-     * possibly have KEY, but if it does, then the @p node must also
-     * have KEY. Changing to the same type is a no-op. Otherwise,
-     * changing to a different type will initialize the node with an
-     * empty value of the desired type: changing to VAL will
-     * initialize with a null scalar (~), changing to MAP will
-     * initialize with an empty map ({}), and changing to SEQ will
-     * initialize with an empty seq ([]). */
-    bool change_type(id_type node, NodeType type);
-
-    bool change_type(id_type node, type_bits type)
-    {
-        return change_type(node, (NodeType)type);
-    }
-
-    #if defined(__clang__)
-    #   pragma clang diagnostic pop
-    #elif defined(__GNUC__)
-    #   pragma GCC diagnostic pop
-    #endif
 
 public:
 
@@ -823,6 +801,12 @@ public:
      * If the root is already a stream, this is a no-op.
      */
     void set_root_as_stream();
+
+    bool change_type(id_type node, NodeType type);
+    bool change_type(id_type node, type_bits type)
+    {
+        return change_type(node, (NodeType)type);
+    }
 
 public:
 
@@ -943,16 +927,14 @@ public:
         substr cp = alloc_arena(s.len);
         _RYML_ASSERT_VISIT_(m_callbacks, cp.len == s.len, this, NONE);
         _RYML_ASSERT_VISIT_(m_callbacks, !s.overlaps(cp), this, NONE);
-        #if (!defined(__clang__)) && (defined(__GNUC__) && __GNUC__ >= 10)
         C4_SUPPRESS_WARNING_GCC_PUSH
+        #if (!defined(__clang__)) && (defined(__GNUC__) && __GNUC__ >= 10)
         C4_SUPPRESS_WARNING_GCC("-Wstringop-overflow=") // no need for terminating \0
         C4_SUPPRESS_WARNING_GCC("-Wrestrict") // there's an assert to ensure no violation of restrict behavior
         #endif
         if(s.len)
             memcpy(cp.str, s.str, s.len);
-        #if (!defined(__clang__)) && (defined(__GNUC__) && __GNUC__ >= 10)
         C4_SUPPRESS_WARNING_GCC_POP
-        #endif
         return cp;
     }
 
@@ -1134,8 +1116,7 @@ public:
         if(f & KEY)
         {
             _RYML_ASSERT_VISIT_(m_callbacks, !is_root(node), this, node);
-            auto pid = parent(node); C4_UNUSED(pid);
-            _RYML_ASSERT_VISIT_(m_callbacks, is_map(pid), this, node);
+            _RYML_ASSERT_VISIT_(m_callbacks, is_map(parent(node)), this, node);
         }
         if((f & VAL) && !is_root(node))
         {

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -506,8 +506,6 @@ public:
         return false;
     }
 
-    RYML_DEPRECATED("use has_other_siblings()") static bool has_siblings(id_type /*node*/) { return true; }
-
     /** @} */
 
 public:
@@ -613,17 +611,72 @@ public:
     /** @name node type modifiers */
     /** @{ */
 
-    void to_keyval(id_type node, csubstr key, csubstr val, type_bits more_flags=0);
-    void to_map(id_type node, csubstr key, type_bits more_flags=0);
-    void to_seq(id_type node, csubstr key, type_bits more_flags=0);
-    void to_val(id_type node, csubstr val, type_bits more_flags=0);
-    void to_map(id_type node, type_bits more_flags=0);
-    void to_seq(id_type node, type_bits more_flags=0);
-    void to_doc(id_type node, type_bits more_flags=0);
-    void to_stream(id_type node, type_bits more_flags=0);
+    void set_stream(id_type node)
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, is_root(node), this, node);
+        _RYML_ASSERT_VISIT_(m_callbacks, (_p(node)->m_type & (DOC|MAP|VAL)) == 0, this, node);
+        _p(node)->m_type |= STREAM;
+    }
 
-    void set_key(id_type node, csubstr key) { _RYML_ASSERT_VISIT_(m_callbacks, has_key(node), this, node); _p(node)->m_key.scalar = key; }
-    void set_val(id_type node, csubstr val) { _RYML_ASSERT_VISIT_(m_callbacks, has_val(node), this, node); _p(node)->m_val.scalar = val; }
+    void set_doc(id_type node)
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, is_root(node) || (is_root(parent(node)) && is_stream(parent(node))), this, node);
+        _p(node)->m_type |= DOC;
+    }
+
+    void set_val(id_type node, csubstr val) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (_p(node)->m_type & (SEQ|MAP)) == 0, this, node);
+        _RYML_ASSERT_VISIT_(m_callbacks, (parent(node) == NONE || (_p(parent(node))->m_type & (SEQ|MAP))), this, node);
+        NodeData *C4_RESTRICT nd = _p(node);
+        nd->m_type |= VAL;
+        nd->m_val.scalar = val;
+    }
+    void set_val(id_type node, csubstr val, NodeType more_flags) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (_p(node)->m_type & (SEQ|MAP)) == 0, this, node);
+        _RYML_ASSERT_VISIT_(m_callbacks, (parent(node) == NONE || (_p(parent(node))->m_type & (SEQ|MAP))), this, node);
+        NodeData *C4_RESTRICT nd = _p(node);
+        nd->m_type |= VAL|more_flags;
+        nd->m_val.scalar = val;
+    }
+
+    void set_key(id_type node, csubstr key) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (parent(node) != NONE && (_p(parent(node))->m_type & MAP)), this, node);
+        NodeData *C4_RESTRICT nd = _p(node);
+        nd->m_type |= KEY;
+        nd->m_key.scalar = key;
+    }
+    void set_key(id_type node, csubstr key, NodeType more_flags) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (parent(node) != NONE && (_p(parent(node))->m_type & MAP)), this, node);
+        NodeData *C4_RESTRICT nd = _p(node);
+        nd->m_type |= KEY|more_flags;
+        nd->m_key.scalar = key;
+    }
+
+    void set_seq(id_type node) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (_p(node)->m_type & (VAL|MAP)) == 0, this, node);
+        _p(node)->m_type |= SEQ;
+    }
+    void set_seq(id_type node, NodeType more_flags) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, ((_p(node)->m_type|more_flags) & (VAL|MAP)) == 0, this, node);
+        _p(node)->m_type |= SEQ|more_flags;
+    }
+
+    void set_map(id_type node) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, (_p(node)->m_type & (VAL|SEQ)) == 0, this, node);
+        _p(node)->m_type |= MAP;
+    }
+    void set_map(id_type node, NodeType more_flags) RYML_NOEXCEPT
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, ((_p(node)->m_type|more_flags) & (VAL|SEQ)) == 0, this, node);
+        _p(node)->m_type |= MAP|more_flags;
+    }
 
     void set_key_tag(id_type node, csubstr tag) { _RYML_ASSERT_VISIT_(m_callbacks, has_key(node), this, node); _p(node)->m_key.tag = tag; _add_flags(node, KEYTAG); }
     void set_val_tag(id_type node, csubstr tag) { _RYML_ASSERT_VISIT_(m_callbacks, has_val(node) || is_container(node), this, node); _p(node)->m_val.tag = tag; _add_flags(node, VALTAG); }
@@ -1133,94 +1186,10 @@ public:
 
     void _set_flags(id_type node, NodeType_e f) { _check_next_flags(node, f); _p(node)->m_type = f; }
     void _set_flags(id_type node, type_bits  f) { _check_next_flags(node, f); _p(node)->m_type = f; }
-
     void _add_flags(id_type node, NodeType_e f) { NodeData *d = _p(node); type_bits fb = f |  d->m_type; _check_next_flags(node, fb); d->m_type = (NodeType_e) fb; }
-    void _add_flags(id_type node, type_bits  f) { NodeData *d = _p(node);                f |= d->m_type; _check_next_flags(node,  f); d->m_type = f; }
-
+    void _add_flags(id_type node, type_bits  f) { NodeData *d = _p(node); f |= d->m_type; _check_next_flags(node,  f); d->m_type = f; }
     void _rem_flags(id_type node, NodeType_e f) { NodeData *d = _p(node); type_bits fb = d->m_type & ~f; _check_next_flags(node, fb); d->m_type = (NodeType_e) fb; }
-    void _rem_flags(id_type node, type_bits  f) { NodeData *d = _p(node);            f = d->m_type & ~f; _check_next_flags(node,  f); d->m_type = f; }
-
-    void _set_key(id_type node, csubstr key, type_bits more_flags=0)
-    {
-        _p(node)->m_key.scalar = key;
-        _add_flags(node, KEY|more_flags);
-    }
-    void _set_key(id_type node, NodeScalar const& key, type_bits more_flags=0)
-    {
-        _p(node)->m_key = key;
-        _add_flags(node, KEY|more_flags);
-    }
-
-    void _set_val(id_type node, csubstr val, type_bits more_flags=0)
-    {
-        _RYML_ASSERT_VISIT_(m_callbacks, num_children(node) == 0, this, node);
-        _RYML_ASSERT_VISIT_(m_callbacks, !is_seq(node) && !is_map(node), this, node);
-        _p(node)->m_val.scalar = val;
-        _add_flags(node, VAL|more_flags);
-    }
-    void _set_val(id_type node, NodeScalar const& val, type_bits more_flags=0)
-    {
-        _RYML_ASSERT_VISIT_(m_callbacks, num_children(node) == 0, this, node);
-        _RYML_ASSERT_VISIT_(m_callbacks,  ! is_container(node), this, node);
-        _p(node)->m_val = val;
-        _add_flags(node, VAL|more_flags);
-    }
-
-    void _set(id_type node, NodeInit const& i)
-    {
-        _RYML_ASSERT_VISIT_(m_callbacks, i._check(), this, node);
-        NodeData *n = _p(node);
-        _RYML_ASSERT_VISIT_(m_callbacks, n->m_key.scalar.empty() || i.key.scalar.empty() || i.key.scalar == n->m_key.scalar, this, node);
-        _add_flags(node, i.type);
-        if(n->m_key.scalar.empty())
-        {
-            if( ! i.key.scalar.empty())
-            {
-                _set_key(node, i.key.scalar);
-            }
-        }
-        n->m_key.tag = i.key.tag;
-        n->m_val = i.val;
-    }
-
-    void _set_parent_as_container_if_needed(id_type in)
-    {
-        NodeData const* n = _p(in);
-        id_type ip = parent(in);
-        if(ip != NONE)
-        {
-            if( ! (is_seq(ip) || is_map(ip)))
-            {
-                if((in == first_child(ip)) && (in == last_child(ip)))
-                {
-                    if( ! n->m_key.empty() || has_key(in))
-                    {
-                        _add_flags(ip, MAP);
-                    }
-                    else
-                    {
-                        _add_flags(ip, SEQ);
-                    }
-                }
-            }
-        }
-    }
-
-    void _seq2map(id_type node)
-    {
-        _RYML_ASSERT_VISIT_(m_callbacks, is_seq(node), this, node);
-        for(id_type i = first_child(node); i != NONE; i = next_sibling(i))
-        {
-            NodeData *C4_RESTRICT ch = _p(i);
-            if(ch->m_type.is_keyval())
-                continue;
-            ch->m_type.add(KEY);
-            ch->m_key = ch->m_val;
-        }
-        auto *C4_RESTRICT n = _p(node);
-        n->m_type.rem(SEQ);
-        n->m_type.add(MAP);
-    }
+    void _rem_flags(id_type node, type_bits  f) { NodeData *d = _p(node); f = d->m_type & ~f; _check_next_flags(node,  f); d->m_type = f; }
 
     id_type _do_reorder(id_type *node, id_type count);
 
@@ -1307,13 +1276,11 @@ private:
 
     void _clear_range(id_type first, id_type num);
 
-public:
     id_type _claim();
-private:
-    void   _claim_root();
-    void   _release(id_type node);
-    void   _free_list_add(id_type node);
-    void   _free_list_rem(id_type node);
+    void    _claim_root();
+    void    _release(id_type node);
+    void    _free_list_add(id_type node);
+    void    _free_list_rem(id_type node);
 
     void _set_hierarchy(id_type node, id_type parent, id_type after_sibling);
     void _rem_hierarchy(id_type node);
@@ -1337,9 +1304,52 @@ public:
     TagDirectives m_tag_directives;
 
 public:
-    /** @cond dev */
-    RYML_DEPRECATED("use Tree::resolve_tags(TagCache&)") void resolve_tags() { TagCache cache; resolve_tags(cache); }
-    /** @endcond */
+
+    /** @cond dev */ // LCOV_EXCL_START
+    C4_SUPPRESS_WARNING_GCC_CLANG_PUSH
+    C4_SUPPRESS_WARNING_MSVC_PUSH
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated")
+    C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
+    C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
+    RYML_DEPRECATED("use has_other_siblings()") static bool has_siblings(id_type /*node*/) { return true; }
+    RYML_DEPRECATED("use set_key()+set_val()") void to_keyval(id_type node, csubstr key, csubstr val, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_key()+set_map()") void to_map(id_type node, csubstr key, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_key()+set_seq()") void to_seq(id_type node, csubstr key, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_val()") void to_val(id_type node, csubstr val, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_map()") void to_map(id_type node, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_seq()") void to_seq(id_type node, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_doc()") void to_doc(id_type node, type_bits more_flags=0);
+    RYML_DEPRECATED("use set_stream()") void to_stream(id_type node, type_bits more_flags=0);
+    RYML_DEPRECATED("use resolve_tags(TagCache&)") void resolve_tags() { TagCache cache; resolve_tags(cache); }
+    RYML_DEPRECATED("") void _set(id_type node, NodeInit const& i)
+    {
+        _RYML_ASSERT_VISIT_(m_callbacks, i._check(), this, node);
+        NodeData *n = _p(node);
+        _RYML_ASSERT_VISIT_(m_callbacks, n->m_key.scalar.empty() || i.key.scalar.empty() || i.key.scalar == n->m_key.scalar, this, node);
+        _add_flags(node, i.type);
+        if(n->m_key.scalar.empty())
+        {
+            if( ! i.key.scalar.empty())
+            {
+                set_key(node, i.key.scalar);
+            }
+        }
+        n->m_key.tag = i.key.tag;
+        n->m_val = i.val;
+    }
+    RYML_DEPRECATED("") void _set_key(id_type node, NodeScalar const& key, NodeType more_flags=0)
+    {
+        _p(node)->m_key = key;
+        _add_flags(node, KEY|more_flags);
+    }
+    RYML_DEPRECATED("") void _set_val(id_type node, NodeScalar const& val, NodeType more_flags=0)
+    {
+        _p(node)->m_val = val;
+        _add_flags(node, VAL|more_flags);
+    }
+    C4_SUPPRESS_WARNING_MSVC_POP
+    C4_SUPPRESS_WARNING_GCC_CLANG_POP
+    /** @endcond */ // LCOV_EXCL_STOP
 };
 
 

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -163,8 +163,8 @@ C4_MUST_BE_TRIVIAL_COPY(NodeScalar);
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** convenience class to initialize nodes */
-struct NodeInit
+/** @cond dev */ // LCOV_EXCL_START
+struct RYML_DEPRECATED("") NodeInit
 {
 
     NodeType   type;
@@ -223,6 +223,7 @@ public:
         return true;
     }
 };
+/** @endcond */ // LCOV_EXCL_STOP
 
 
 //-----------------------------------------------------------------------------

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -877,6 +877,11 @@ public:
     /** get the current arena */
     substr arena() { return m_arena.first(m_arena_pos); } // NOLINT(readability-make-member-function-const)
 
+    /** get the free space at the end of the arena */
+    csubstr arena_rem() const { return m_arena.sub(m_arena_pos); }
+    /** get the free space at the end of the arena */
+    substr arena_rem() { return m_arena.sub(m_arena_pos); } // NOLINT(readability-make-member-function-const)
+
     /** return true if the given substring is part of the tree's string arena */
     C4_ALWAYS_INLINE bool in_arena(csubstr s) const
     {

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -950,7 +950,7 @@ public:
      * existing arena, and thus change the contents of individual
      * nodes, and thus cost O(numnodes)+O(arenasize). To avoid this
      * cost, ensure that the arena is reserved to an appropriate size
-     * using .reserve_arena().
+     * using @ref Tree::reserve_arena().
      *
      * @see reserve_arena() */
     substr alloc_arena(size_t sz)
@@ -991,8 +991,8 @@ public:
     substr _grow_arena(size_t more)
     {
         size_t cap = m_arena.len + more;
+        cap = cap < RYML_DEFAULT_TREE_ARENA_CAPACITY_START ? RYML_DEFAULT_TREE_ARENA_CAPACITY_START : cap;
         cap = cap < 2 * m_arena.len ? 2 * m_arena.len : cap;
-        cap = cap < 64 ? 64 : cap;
         reserve_arena(cap);
         return m_arena.sub(m_arena_pos);
     }

--- a/test/test_anchor.cpp
+++ b/test/test_anchor.cpp
@@ -220,7 +220,7 @@ orig3: &orig3 {and: more}
 copy: {}
 )");
     NodeRef seq = t["copy"]["<<"];
-    seq |= SEQ;
+    seq.set_seq();
     seq.append_child().set_val_ref("orig1");
     seq.append_child().set_val_ref("orig2");
     seq.append_child().set_val_ref("orig3");
@@ -380,7 +380,7 @@ Tree github566_make_map(NodeType_e root_style)
 {
     Tree tree;
     NodeRef root = tree.rootref();
-    root |= MAP|root_style;
+    root.set_map(root_style);
     root.set_val_anchor("ref0");
     root["a"] = "1";
     NodeRef self = root["self"];
@@ -393,7 +393,7 @@ Tree github566_make_seq(NodeType_e root_style)
 {
     Tree tree;
     NodeRef root = tree.rootref();
-    root |= SEQ|root_style;
+    root.set_seq(root_style);
     root.set_val_anchor("ref0");
     root[0] = "1";
     root[1].set_val("*ref0");

--- a/test/test_anchor.cpp
+++ b/test/test_anchor.cpp
@@ -132,12 +132,12 @@ TEST(anchors, programatic_key_ref)
     t._rem_flags(t.root_id(), CONTAINER_STYLE);
     t._add_flags(t.root_id(), BLOCK);
     NodeRef r = t.rootref();
-    r["kanchor"] = "2";
+    r["kanchor"].set_val("2");
     r["kanchor"].set_key_anchor("kanchor");
-    r["vanchor"] = "3";
+    r["vanchor"].set_val("3");
     r["vanchor"].set_val_anchor("vanchor");
-    r["*kanchor"] = "4";
-    r["*vanchor"] = "5";
+    r["*kanchor"].set_val("4");
+    r["*vanchor"].set_val("5");
     NodeRef ch = r.append_child();
     ch.set_key_ref("kanchor");
     ch.set_val("6");
@@ -167,9 +167,9 @@ TEST(anchors, programatic_val_ref)
     Tree t = parse_in_arena("{}");
     t._rem_flags(t.root_id(), CONTAINER_STYLE);
     t._add_flags(t.root_id(), BLOCK);
-    t["kanchor"] = "2";
+    t["kanchor"].set_val("2");
     t["kanchor"].set_key_anchor("kanchor");
-    t["vanchor"] = "3";
+    t["vanchor"].set_val("3");
     t["vanchor"].set_val_anchor("vanchor");
     t["kref"].set_val_ref("kanchor");
     t["vref"].set_val_ref("vanchor");
@@ -197,7 +197,7 @@ notref: {}
     t["copy"]["<<"].set_val_ref("orig");
     t["notcopy"]["test"].set_val_ref("orig");
     t["notcopy"]["<<"].set_val_ref("orig");
-    t["notref"]["<<"] = "*orig";
+    t["notref"]["<<"].set_val("*orig");
     _c4dbg_tree(t);
     EXPECT_EQ(emitrs_yaml<std::string>(t), R"(orig: &orig {foo: bar,baz: bat}
 copy: {<<: *orig}
@@ -258,8 +258,8 @@ TEST(anchors, set_ref_leading_star_is_optional)
 {
     Tree t = parse_in_arena("{}");
 
-    t["*without"] = "0";
-    t["*with"] = "1";
+    t["*without"].set_val("0");
+    t["*with"].set_val("1");
     EXPECT_EQ(emitrs_yaml<std::string>(t), R"({'*without': 0,'*with': 1})");
 
     t["*without"].set_key_ref("without");
@@ -382,7 +382,7 @@ Tree github566_make_map(NodeType_e root_style)
     NodeRef root = tree.rootref();
     root.set_map(root_style);
     root.set_val_anchor("ref0");
-    root["a"] = "1";
+    root["a"].set_val("1");
     NodeRef self = root["self"];
     self.set_val("*ref0");
     self.set_val_ref("ref0");
@@ -395,7 +395,7 @@ Tree github566_make_seq(NodeType_e root_style)
     NodeRef root = tree.rootref();
     root.set_seq(root_style);
     root.set_val_anchor("ref0");
-    root[0] = "1";
+    root[0].set_val("1");
     root[1].set_val("*ref0");
     root[1].set_val_ref("ref0");
     return tree;

--- a/test/test_basic.cpp
+++ b/test/test_basic.cpp
@@ -47,9 +47,9 @@ TEST(general, emitting)
     std::string cmpbuf;
 
     Tree tree;
-    auto r = tree.rootref();
+    NodeRef r = tree;
 
-    r |= MAP;  // this is needed to make the root a map
+    r.set_map();  // this is needed to make the root a map
 
     r["foo"] = "1"; // ryml works only with strings.
     // Note that the tree will be __pointing__ at the
@@ -57,8 +57,8 @@ TEST(general, emitting)
     // to make sure they have at least the same
     // lifetime as the tree.
 
-    auto s = r["seq"]; // does not change the tree until s is written to.
-    s |= SEQ;
+    NodeRef s = r["seq"]; // does not change the tree until s is written to.
+    s.set_seq();
     r["seq"].append_child() = "bar0"; // value of this child is now __pointing__ at "bar0"
     r["seq"].append_child() = "bar1";
     r["seq"].append_child() = "bar2";

--- a/test/test_basic.cpp
+++ b/test/test_basic.cpp
@@ -51,7 +51,7 @@ TEST(general, emitting)
 
     r.set_map();  // this is needed to make the root a map
 
-    r["foo"] = "1"; // ryml works only with strings.
+    r["foo"].set_val("1"); // ryml works only with strings.
     // Note that the tree will be __pointing__ at the
     // strings "foo" and "1" used here. You need
     // to make sure they have at least the same
@@ -59,9 +59,9 @@ TEST(general, emitting)
 
     NodeRef s = r["seq"]; // does not change the tree until s is written to.
     s.set_seq();
-    r["seq"].append_child() = "bar0"; // value of this child is now __pointing__ at "bar0"
-    r["seq"].append_child() = "bar1";
-    r["seq"].append_child() = "bar2";
+    r["seq"].append_child().set_val("bar0"); // value of this child is now __pointing__ at "bar0"
+    r["seq"].append_child().set_val("bar1");
+    r["seq"].append_child().set_val("bar2");
 
     //print_tree(tree);
 

--- a/test/test_doc.cpp
+++ b/test/test_doc.cpp
@@ -22,9 +22,8 @@ TEST(simple_doc, issue_251)
     {
         Tree tree;
         NodeRef root = tree.rootref();
-        root |= MAP;
-        root["test"] = "...";
-        root["test"] |= VAL_SQUO;
+        root.set_map();
+        root["test"].set_val("...", VAL_SQUO);
         std::string s = emitrs_yaml<std::string>(tree);
         test_check_emit_check(to_csubstr(s), [](Tree const &t){
             EXPECT_EQ(t["test"].val(), "...");

--- a/test/test_emit.cpp
+++ b/test/test_emit.cpp
@@ -1614,10 +1614,10 @@ TEST(emit, percent_is_quoted)
 {
     Tree ti = parse_in_arena("{}");
     ASSERT_TRUE(ti.rootref().is_map());
-    ti["%ROOT"] = "%VAL";
+    ti["%ROOT"].set_val("%VAL");
     ti["%ROOT2"].set_seq();
-    ti["%ROOT2"][0] = "%VAL";
-    ti["%ROOT2"][1] = "%VAL";
+    ti["%ROOT2"][0].set_val("%VAL");
+    ti["%ROOT2"][1].set_val("%VAL");
     std::string yaml = emitrs_yaml<std::string>(ti);
     test_check_emit_check(to_csubstr(yaml), [](Tree const &t){
         ASSERT_TRUE(t.rootref().is_map());
@@ -1636,13 +1636,13 @@ TEST(emit, at_is_quoted__issue_309)
 {
     Tree ti = parse_in_arena("{at: [], backtick: []}");
     ti["at"][0] << "@test";
-    ti["at"][1] = "@test2";
+    ti["at"][1].set_val("@test2");
     ti["at"][2] << "@";
-    ti["at"][3] = "@";
+    ti["at"][3].set_val("@");
     ti["backtick"][0] << "`test";
-    ti["backtick"][1] = "`test2";
+    ti["backtick"][1].set_val("`test2");
     ti["backtick"][2] << "`";
-    ti["backtick"][3] = "`";
+    ti["backtick"][3].set_val("`");
     std::string yaml = emitrs_yaml<std::string>(ti);
     test_check_emit_check(to_csubstr(yaml), [](Tree const &t){
         ASSERT_TRUE(t.rootref().is_map());
@@ -1675,15 +1675,15 @@ TEST(emit, at_is_quoted_only_in_the_beggining__issue_320)
     ti["at"].append_child() << "@test";
     ti["at"].append_child() << "t@est";
     ti["at"].append_child() << "test@";
-    ti["at"].append_child() = "@test2";
-    ti["at"].append_child() = "t@est2";
-    ti["at"].append_child() = "test2@";
+    ti["at"].append_child().set_val("@test2");
+    ti["at"].append_child().set_val("t@est2");
+    ti["at"].append_child().set_val("test2@");
     ti["backtick"].append_child() << "`test";
     ti["backtick"].append_child() << "t`est";
     ti["backtick"].append_child() << "test`";
-    ti["backtick"].append_child() = "`test2";
-    ti["backtick"].append_child() = "t`est2";
-    ti["backtick"].append_child() = "test2`";
+    ti["backtick"].append_child().set_val("`test2");
+    ti["backtick"].append_child().set_val("t`est2");
+    ti["backtick"].append_child().set_val("test2`");
     std::string yaml = emitrs_yaml<std::string>(ti);
     test_check_emit_check(to_csubstr(yaml), [](Tree const &t){
         ASSERT_TRUE(t.rootref().is_map());

--- a/test/test_emit.cpp
+++ b/test/test_emit.cpp
@@ -277,19 +277,17 @@ TEST(emit_block_seq, ambiguous_plain_emitted_as_squo)
     {
         Tree t;
         NodeRef r = t.rootref();
-        r |= SEQ|BLOCK;
-        r[0] = ": odd";
-        r[0] |= VAL_PLAIN;
-        r[1] = ":\todd";
-        r[1] |= VAL_PLAIN;
+        r.set_seq(BLOCK);
+        r[0].set_val(": odd", VAL_PLAIN);
+        r[1].set_val(":\todd", VAL_PLAIN);
         EXPECT_EQ(emitrs_yaml<std::string>(t), "- : odd\n- :\todd\n");
     }
     {
         Tree t;
         NodeRef r = t.rootref();
-        r |= SEQ|BLOCK;
-        r[0] = ": odd";
-        r[1] = ":\todd";
+        r.set_seq(BLOCK);
+        r[0].set_val(": odd");
+        r[1].set_val(":\todd");
         EXPECT_FALSE(r[0].is_val_plain());
         EXPECT_FALSE(r[1].is_val_plain());
         EXPECT_EQ(emitrs_yaml<std::string>(t), "- ': odd'\n- ':\todd'\n");
@@ -301,23 +299,21 @@ TEST(emit_block_map, ambiguous_plain_emitted_as_squo)
     {
         Tree t;
         NodeRef r = t.rootref();
-        r |= MAP|BLOCK;
+        r.set_map(BLOCK);
         r[0].set_key(": odd");
-        r[0] = ": odd";
+        r[0].set_val(": odd");
         r[1].set_key(":\todd");
-        r[1] = ":\todd";
+        r[1].set_val(":\todd");
         EXPECT_EQ(emitrs_yaml<std::string>(t), "': odd': ': odd'\n':\todd': ':\todd'\n");
     }
     {
         Tree t;
         NodeRef r = t.rootref();
-        r |= MAP|BLOCK;
-        r[0].set_key(": odd");
-        r[0] = ": odd";
-        r[0] |= KEY_PLAIN|VAL_PLAIN;
-        r[1].set_key(":\todd");
-        r[1] = ":\todd";
-        r[1] |= KEY_PLAIN|VAL_PLAIN;
+        r.set_map(BLOCK);
+        r[0].set_key(": odd", KEY_PLAIN);
+        r[0].set_val(": odd", VAL_PLAIN);
+        r[1].set_key(":\todd", KEY_PLAIN);
+        r[1].set_val(":\todd", VAL_PLAIN);
         EXPECT_EQ(emitrs_yaml<std::string>(t), ": odd: : odd\n:\todd: :\todd\n");
     }
 }
@@ -1619,7 +1615,7 @@ TEST(emit, percent_is_quoted)
     Tree ti = parse_in_arena("{}");
     ASSERT_TRUE(ti.rootref().is_map());
     ti["%ROOT"] = "%VAL";
-    ti["%ROOT2"] |= SEQ;
+    ti["%ROOT2"].set_seq();
     ti["%ROOT2"][0] = "%VAL";
     ti["%ROOT2"][1] = "%VAL";
     std::string yaml = emitrs_yaml<std::string>(ti);

--- a/test/test_github_issues.cpp
+++ b/test/test_github_issues.cpp
@@ -348,13 +348,13 @@ TEST(github, 31)
 {
     Tree tree;
     NodeRef r = tree.rootref();
-    r |= MAP;
+    r.set_map();
 
     auto meas = r["meas"];
-    meas |= MAP;
+    meas.set_map();
 
     auto plist = meas["createParameterList"];
-    plist |= SEQ;
+    plist.set_seq();
 
     {
         NodeRef lumi = plist.append_child();
@@ -364,7 +364,7 @@ TEST(github, 31)
 
     {
         NodeRef lumi = plist.append_child();
-        lumi |= MAP;
+        lumi.set_map();
         lumi["value"] << 1;
         lumi["relErr"] << 0.1;
         EXPECT_TRUE(lumi.is_map());
@@ -374,7 +374,7 @@ TEST(github, 31)
         ExpectError::check_assert_visit(&tree, [&](){
             NodeRef lumi = plist.append_child();
             lumi << "Lumi";
-            lumi |= MAP;
+            lumi.set_map();
         });
     }
 
@@ -382,14 +382,14 @@ TEST(github, 31)
         ExpectError::check_assert_visit(&tree, [&](){
             NodeRef lumi = plist.append_child();
             lumi << "Lumi";
-            lumi |= SEQ;
+            lumi.set_seq();
         });
     }
 
     {
         ExpectError::check_assert_visit(&tree, [&](){
             NodeRef lumi = plist.append_child();
-            lumi |= MAP;
+            lumi.set_map();
             lumi << "Lumi";
         });
     }

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -666,7 +666,7 @@ TEST(parse_json, empty_lines_on_seq)
 ])";
     Tree expected;
     NodeRef root = expected.rootref();
-    root |= SEQ|FLOW_SL;
+    root.set_seq(FLOW_SL);
     root.append_child() = "0";
     root.append_child() = "1";
     root.append_child() = "2";
@@ -695,11 +695,11 @@ TEST(parse_json, empty_lines_on_map)
 })";
     Tree expected;
     NodeRef root = expected.rootref();
-    root |= MAP|FLOW_SL;
-    root.append_child({"0", "0"});
-    root.append_child({"1", "1"});
-    root.append_child({"2", "2"});
-    root.append_child({"3", "3"});
+    root.set_map(FLOW_SL);
+    (root.append_child() = key("0")) = "0";
+    (root.append_child() = key("1")) = "1";
+    (root.append_child() = key("2")) = "2";
+    (root.append_child() = key("3")) = "3";
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -709,11 +709,13 @@ TEST(parse_json, seq_nested_on_map)
     csubstr json = R"({"seq":[0,1],"key":val})";
     Tree expected;
     NodeRef root = expected.rootref();
-    root |= MAP|FLOW_SL;
-    NodeRef seq = root.append_child({KEYSEQ, "seq"});
+    root.set_map(FLOW_SL);
+    NodeRef seq = root.append_child();
+    seq = key("seq");
+    seq.set_seq();
     seq.append_child() = "0";
     seq.append_child() = "1";
-    root.append_child({"key", "val"});
+    (root.append_child() = key("key")) = "val";
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -723,8 +725,9 @@ TEST(parse_json, seq_nested_on_seq_with_trailing_comma)
     csubstr json = R"([[0,1,],2,3,])";
     Tree expected;
     NodeRef root = expected.rootref();
-    root |= SEQ|FLOW_SL;
-    NodeRef seq = root.append_child(SEQ);
+    root.set_seq(FLOW_SL);
+    NodeRef seq = root.append_child();
+    seq.set_seq();
     seq.append_child() = "0";
     seq.append_child() = "1";
     root.append_child() = "2";

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -49,8 +49,8 @@ TEST(serialize, type_as_str)
 {
     c4::yml::Tree t;
 
-    auto r = t.rootref();
-    r |= c4::yml::MAP;
+    c4::yml::NodeRef r = t;
+    r.set_map();
 
     vec2<int> v2in{10, 11};
     vec2<int> v2out;
@@ -95,9 +95,9 @@ TEST(general, emitting)
     std::string cmpbuf2;
 
     Tree tree;
-    auto r = tree.rootref();
+    NodeRef r = tree;
 
-    r |= MAP;  // this is needed to make the root a map
+    r.set_map();  // this is needed to make the root a map
 
     r["foo"] = "1"; // ryml works only with strings.
     // Note that the tree will be __pointing__ at the
@@ -105,8 +105,8 @@ TEST(general, emitting)
     // to make sure they have at least the same
     // lifetime as the tree.
 
-    auto s = r["seq"]; // does not change the tree until s is written to.
-    s |= SEQ;
+    NodeRef s = r["seq"]; // does not change the tree until s is written to.
+    s.set_seq();
     r["seq"].append_child() = "bar0"; // value of this child is now __pointing__ at "bar0"
     r["seq"].append_child() = "bar1";
     r["seq"].append_child() = "bar2";
@@ -192,7 +192,7 @@ TEST(emit_json, issue72)
     Tree t;
     NodeRef r = t.rootref();
 
-    r |= MAP;
+    r.set_map();
     r["1"] = "null";
     r["2"] = "true";
     r["3"] = "false";

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -99,7 +99,7 @@ TEST(general, emitting)
 
     r.set_map();  // this is needed to make the root a map
 
-    r["foo"] = "1"; // ryml works only with strings.
+    r["foo"].set_val("1"); // ryml works only with strings.
     // Note that the tree will be __pointing__ at the
     // strings "foo" and "1" used here. You need
     // to make sure they have at least the same
@@ -107,9 +107,9 @@ TEST(general, emitting)
 
     NodeRef s = r["seq"]; // does not change the tree until s is written to.
     s.set_seq();
-    r["seq"].append_child() = "bar0"; // value of this child is now __pointing__ at "bar0"
-    r["seq"].append_child() = "bar1";
-    r["seq"].append_child() = "bar2";
+    r["seq"].append_child().set_val("bar0"); // value of this child is now __pointing__ at "bar0"
+    r["seq"].append_child().set_val("bar1");
+    r["seq"].append_child().set_val("bar2");
 
     //print_tree(tree);
 
@@ -193,12 +193,12 @@ TEST(emit_json, issue72)
     NodeRef r = t.rootref();
 
     r.set_map();
-    r["1"] = "null";
-    r["2"] = "true";
-    r["3"] = "false";
-    r["null"] = "1";
-    r["true"] = "2";
-    r["false"] = "3";
+    r["1"].set_val("null");
+    r["2"].set_val("true");
+    r["3"].set_val("false");
+    r["null"].set_val("1");
+    r["true"].set_val("2");
+    r["false"].set_val("3");
 
     std::string out;
     emitrs_json(t, &out);
@@ -225,7 +225,7 @@ TEST(emit_json, issue121)
 TEST(emit_json, issue291)
 {
     Tree t = parse_json_in_arena("{}");
-    t["james"] = "045";
+    t["james"].set_val("045");
     auto s = emitrs_json<std::string>(t);
     EXPECT_EQ(s, "{\"james\": \"045\"}");
 }
@@ -248,15 +248,15 @@ TEST(emit_json, issue292)
     EXPECT_FALSE(csubstr("1.2.3").is_integer());
     EXPECT_FALSE(csubstr("1.2.3").is_real());
     Tree t = parse_json_in_arena("{}");
-    t["james"] = "0.0.0";
+    t["james"].set_val("0.0.0");
     EXPECT_EQ(emitrs_json<std::string>(t), "{\"james\": \"0.0.0\"}");
-    t["james"] = "0.1.0";
+    t["james"].set_val("0.1.0");
     EXPECT_EQ(emitrs_json<std::string>(t), "{\"james\": \"0.1.0\"}");
-    t["james"] = "0.6.1";
+    t["james"].set_val("0.6.1");
     EXPECT_EQ(emitrs_json<std::string>(t), "{\"james\": \"0.6.1\"}");
-    t["james"] = "1.1.9";
+    t["james"].set_val("1.1.9");
     EXPECT_EQ(emitrs_json<std::string>(t), "{\"james\": \"1.1.9\"}");
-    t["james"] = "1.2.3";
+    t["james"].set_val("1.2.3");
     EXPECT_EQ(emitrs_json<std::string>(t), "{\"james\": \"1.2.3\"}");
 }
 
@@ -275,13 +275,13 @@ comment: |
 TEST(emit_json, issue297_escaped_chars)
 {
     Tree t = parse_json_in_arena("{}");
-    t["quote"] = "abc\"def";
-    t["newline"] = "abc\ndef";
-    t["tab"] = "abc\tdef";
-    t["carriage"] = "abc\rdef";
-    t["backslash"] = "abc\\def";
-    t["backspace"] = "abc\bdef";
-    t["formfeed"] = "abc\fdef";
+    t["quote"].set_val("abc\"def");
+    t["newline"].set_val("abc\ndef");
+    t["tab"].set_val("abc\tdef");
+    t["carriage"].set_val("abc\rdef");
+    t["backslash"].set_val("abc\\def");
+    t["backspace"].set_val("abc\bdef");
+    t["formfeed"].set_val("abc\fdef");
     std::string expected = R"({"quote": "abc\"def","newline": "abc\ndef","tab": "abc\tdef","carriage": "abc\rdef","backslash": "abc\\def","backspace": "abc\bdef","formfeed": "abc\fdef"})";
     auto actual = emitrs_json<std::string>(t);
     EXPECT_EQ(actual, expected);
@@ -618,7 +618,7 @@ TEST(parse_json, error_on_bare_keyval)
 TEST(parse_json, scalar_src_dquoted)
 {
     Tree expected;
-    expected.rootref() = "dquoted";
+    expected.rootref().set_val("dquoted");
     Tree actual = parse_json_in_arena("\"dquoted\"");
     test_compare(expected, actual);
 }
@@ -626,7 +626,7 @@ TEST(parse_json, scalar_src_dquoted)
 TEST(parse_json, scalar_src_plain)
 {
     Tree expected;
-    expected.rootref() = "true";
+    expected.rootref().set_val("true");
     Tree actual = parse_json_in_arena("true");
     test_compare(expected, actual);
 }
@@ -635,7 +635,7 @@ TEST(parse_json, leading_whitespace_scalar_dquoted)
 {
     csubstr json = "    \n   \"dquoted\"";
     Tree expected;
-    expected.rootref() = "dquoted";
+    expected.rootref().set_val("dquoted");
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -644,7 +644,7 @@ TEST(parse_json, leading_whitespace_scalar_src_plain)
 {
     csubstr json = "    \n   true";
     Tree expected;
-    expected.rootref() = "true";
+    expected.rootref().set_val("true");
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -667,10 +667,10 @@ TEST(parse_json, empty_lines_on_seq)
     Tree expected;
     NodeRef root = expected.rootref();
     root.set_seq(FLOW_SL);
-    root.append_child() = "0";
-    root.append_child() = "1";
-    root.append_child() = "2";
-    root.append_child() = "3";
+    root.append_child().set_val("0");
+    root.append_child().set_val("1");
+    root.append_child().set_val("2");
+    root.append_child().set_val("3");
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -696,10 +696,10 @@ TEST(parse_json, empty_lines_on_map)
     Tree expected;
     NodeRef root = expected.rootref();
     root.set_map(FLOW_SL);
-    (root.append_child() = key("0")) = "0";
-    (root.append_child() = key("1")) = "1";
-    (root.append_child() = key("2")) = "2";
-    (root.append_child() = key("3")) = "3";
+    { NodeRef ch = root.append_child(); ch.set_key("0"); ch.set_val("0"); }
+    { NodeRef ch = root.append_child(); ch.set_key("1"); ch.set_val("1"); }
+    { NodeRef ch = root.append_child(); ch.set_key("2"); ch.set_val("2"); }
+    { NodeRef ch = root.append_child(); ch.set_key("3"); ch.set_val("3"); }
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -711,11 +711,11 @@ TEST(parse_json, seq_nested_on_map)
     NodeRef root = expected.rootref();
     root.set_map(FLOW_SL);
     NodeRef seq = root.append_child();
-    seq = key("seq");
+    seq.set_key("seq");
     seq.set_seq();
-    seq.append_child() = "0";
-    seq.append_child() = "1";
-    (root.append_child() = key("key")) = "val";
+    seq.append_child().set_val("0");
+    seq.append_child().set_val("1");
+    root["key"].set_val("val");
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }
@@ -728,10 +728,10 @@ TEST(parse_json, seq_nested_on_seq_with_trailing_comma)
     root.set_seq(FLOW_SL);
     NodeRef seq = root.append_child();
     seq.set_seq();
-    seq.append_child() = "0";
-    seq.append_child() = "1";
-    root.append_child() = "2";
-    root.append_child() = "3";
+    seq.append_child().set_val("0");
+    seq.append_child().set_val("1");
+    root.append_child().set_val("2");
+    root.append_child().set_val("3");
     Tree actual = parse_json_in_arena(json);
     test_compare(expected, actual);
 }

--- a/test/test_lib/test_case.cpp
+++ b/test/test_lib/test_case.cpp
@@ -422,6 +422,21 @@ void ExpectError::check_error_visit(Tree const* tree, fntestref fn, id_type expe
     check_error_visit(const_cast<Tree*>(tree), fn, expected_id);
 }
 
+void ExpectError::check_assert_basic(Tree const* tree, fntestref fn, bool only_basic)
+{
+    check_assert_basic(const_cast<Tree*>(tree), fn, only_basic);
+}
+
+void ExpectError::check_assert_parse(Tree const* tree, fntestref fn, Location const& expected_location)
+{
+    check_assert_parse(const_cast<Tree*>(tree), fn, expected_location);
+}
+
+void ExpectError::check_assert_visit(Tree const* tree, fntestref fn, id_type expected_id)
+{
+    check_assert_visit(const_cast<Tree*>(tree), fn, expected_id);
+}
+
 void ExpectError::check_error_basic(Tree *tree, fntestref fn, bool only_basic)
 {
     auto context = ExpectError(ExpectedErrorType::err_basic, tree);
@@ -501,13 +516,13 @@ void ExpectError::check_error_parse(Tree *tree, fntestref fn, Location const& ex
     {
         FAIL() << "got an unexpected exception";
     }, )
-    if(context.m_error == ExpectedErrorType::err_none)
+    if(context.m_error != ExpectedErrorType::err_none)
     {
-        FAIL() << "no error occurred";
+        EXPECT_EQ(context.m_error, ExpectedErrorType::err_parse);
     }
     else
     {
-        EXPECT_EQ(context.m_error, ExpectedErrorType::err_parse);
+        FAIL() << "no error occurred";
     }
 }
 
@@ -537,19 +552,19 @@ void ExpectError::check_error_visit(Tree *tree, fntestref fn, id_type id)
     }
     C4_IF_EXCEPTIONS_(catch(std::exception const& exc)
     {
-        FAIL() << "got an unexpected exception:" << exc.what() << "\n";
+        FAIL() << "got an unexpected exception:\n" << exc.what() << "\n";
     }, )
     C4_IF_EXCEPTIONS_(catch(...)
     {
         FAIL() << "got an unexpected exception";
     }, )
-    if(context.m_error == ExpectedErrorType::err_none)
+    if(context.m_error != ExpectedErrorType::err_none)
     {
-        FAIL() << "no error occurred";
+        EXPECT_EQ(context.m_error, ExpectedErrorType::err_visit);
     }
     else
     {
-        EXPECT_EQ(context.m_error, ExpectedErrorType::err_visit);
+        FAIL() << "no error occurred";
     }
 }
 

--- a/test/test_lib/test_case.cpp
+++ b/test/test_lib/test_case.cpp
@@ -70,6 +70,21 @@ id_type _num_leaves(Tree const& t, id_type node)
 }
 
 
+void test_compare(ConstNodeRef const& actual, ConstNodeRef const& expected,
+                  const char *actual_name, const char *expected_name,
+                  type_bits cmp_mask)
+{
+    if(actual.is_root() && expected.is_root())
+        test_compare(*actual.tree(), *expected.tree(),
+                     actual_name, expected_name,
+                     cmp_mask);
+    else
+        test_compare(*actual.tree(), actual.id(),
+                     *expected.tree(), expected.id(),
+                     0,
+                     actual_name, expected_name,
+                     cmp_mask);
+}
 void test_compare(Tree const& actual, Tree const& expected,
                   const char *actual_name, const char *expected_name,
                   type_bits cmp_mask)
@@ -79,7 +94,11 @@ void test_compare(Tree const& actual, Tree const& expected,
         return;
     EXPECT_EQ(actual.size(), expected.size());
     EXPECT_EQ(_num_leaves(actual, actual.root_id()), _num_leaves(expected, expected.root_id()));
-    test_compare(actual, actual.root_id(), expected, expected.root_id(), 0, actual_name, expected_name, cmp_mask);
+    test_compare(actual, actual.root_id(),
+                 expected, expected.root_id(),
+                 0,
+                 actual_name, expected_name,
+                 cmp_mask);
 }
 
 
@@ -120,9 +139,7 @@ void test_compare(Tree const& actual, id_type node_actual,
     EXPECT_EQ(actual.has_val_tag(node_actual), expected.has_val_tag(node_expected));
     if(actual.has_val_tag(node_actual) && expected.has_val_tag(node_expected))
     {
-        csubstr actual_tag = actual.val_tag(node_actual);
-        csubstr expected_tag = expected.val_tag(node_expected);
-        EXPECT_EQ(actual_tag, expected_tag);
+        EXPECT_EQ(actual.val_tag(node_actual), expected.val_tag(node_expected));
     }
 
     EXPECT_EQ(actual.has_key_anchor(node_actual), expected.has_key_anchor(node_expected));
@@ -404,7 +421,7 @@ void ExpectError::check_success(Tree *tree, fntestref fn)
     {
         FAIL() << "check expected success: failed!";
     }
-    ASSERT_EQ(context.m_error, ExpectedErrorType::err_none);
+    EXPECT_EQ(context.m_error, ExpectedErrorType::err_none);
 }
 
 void ExpectError::check_error_basic(Tree const* tree, fntestref fn, bool only_basic)
@@ -747,9 +764,148 @@ void print_test_tree(const char *message, TestCaseNode const& t)
     printf("--------------------------------------\n");
 }
 
+void test_invariants(NodeType ty)
+{
+    #define EXPECT_ALL(v, flags) EXPECT_EQ(((v) & (flags)), flags)
+    #define EXPECT_ONE(v, flags, one) EXPECT_EQ(((v) & (flags)), one)
+    #define EXPECT_ANY(v, flags) EXPECT_NE(((v) & (flags)), 0)
+    #define EXPECT_NONE(v, flags) EXPECT_EQ(((v) & (flags)), 0)
+    type_bits STREAMONLY = (STREAM & ~SEQ);
+    if(ty & (KEYNIL|KEYREF|KEY_STYLE))
+    {
+        EXPECT_ALL(ty, KEY);
+    }
+    if(ty & (VALNIL|VALREF|VAL_STYLE))
+    {
+        EXPECT_ALL(ty, VAL);
+    }
+    if(ty & (KEYTAG|KEYANCH))
+    {
+        EXPECT_ALL(ty, KEY);
+    }
+    if(ty & (VALTAG|VALANCH))
+    {
+        EXPECT_ANY(ty, VAL|SEQ|MAP);
+    }
+    if(ty & KEYREF)
+    {
+        EXPECT_NONE(ty, KEYTAG|KEYANCH|KEY_STYLE);
+    }
+    if(ty & VALREF)
+    {
+        EXPECT_NONE(ty, VALTAG|VALANCH|VAL_STYLE|CONTAINER_STYLE);
+    }
+    if(ty & VAL)
+    {
+        EXPECT_NONE(ty, MAP|SEQ|STREAM|CONTAINER_STYLE);
+    }
+    if(ty & MAP)
+    {
+        EXPECT_NONE(ty, VAL|SEQ|STREAM|VAL_STYLE);
+    }
+    if(ty & SEQ)
+    {
+        EXPECT_NONE(ty, VAL|MAP|VAL_STYLE);
+    }
+    if(ty & DOC)
+    {
+        EXPECT_NONE(ty, STREAMONLY|KEY);
+    }
+    if(ty & STREAMONLY)
+    {
+        EXPECT_NONE(ty, DOC|MAP|KEY);
+    }
+    if(ty & (MAP|SEQ|VAL))
+    {
+        if(ty & MAP)
+        {
+            EXPECT_ONE(ty, MAP|SEQ|VAL, MAP);
+        }
+        if(ty & SEQ)
+        {
+            EXPECT_ONE(ty, MAP|SEQ|VAL, SEQ);
+        }
+        if(ty & VAL)
+        {
+            EXPECT_ONE(ty, MAP|SEQ|VAL, VAL);
+        }
+    }
+    if(ty & CONTAINER_STYLE)
+    {
+        EXPECT_NONE(ty, VAL);
+        if(ty & FLOW_SL)
+        {
+            EXPECT_ONE(ty, CONTAINER_STYLE, FLOW_SL);
+        }
+        if(ty & FLOW_ML1)
+        {
+            EXPECT_ONE(ty, CONTAINER_STYLE, FLOW_ML1);
+        }
+        if(ty & FLOW_MLN)
+        {
+            EXPECT_ONE(ty, CONTAINER_STYLE, FLOW_MLN);
+        }
+        if(ty & FLOW_SPC)
+        {
+            EXPECT_ANY(ty, FLOW_MLX);
+        }
+        if(ty & BLOCK)
+        {
+            EXPECT_ONE(ty, CONTAINER_STYLE, BLOCK);
+        }
+    }
+    if(ty & KEY_STYLE)
+    {
+        if(ty & KEY_PLAIN)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_PLAIN);
+        }
+        if(ty & KEY_SQUO)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_SQUO);
+        }
+        if(ty & KEY_DQUO)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_DQUO);
+        }
+        if(ty & KEY_LITERAL)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_LITERAL);
+        }
+        if(ty & KEY_FOLDED)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_FOLDED);
+        }
+    }
+    if(ty & VAL_STYLE)
+    {
+        if(ty & KEY_PLAIN)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_PLAIN);
+        }
+        if(ty & KEY_SQUO)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_SQUO);
+        }
+        if(ty & KEY_DQUO)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_DQUO);
+        }
+        if(ty & KEY_LITERAL)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_LITERAL);
+        }
+        if(ty & KEY_FOLDED)
+        {
+            EXPECT_ONE(ty, KEY_STYLE, KEY_FOLDED);
+        }
+    }
+}
+
 void test_invariants(ConstNodeRef const& n)
 {
     SCOPED_TRACE(n.id());
+    test_invariants(n.type());
     if(n.is_root())
     {
         EXPECT_FALSE(n.has_other_siblings());
@@ -763,6 +919,14 @@ void test_invariants(ConstNodeRef const& n)
     {
         EXPECT_TRUE(n.is_container());
         EXPECT_FALSE(n.is_val());
+    }
+    if(n.has_key())
+    {
+        EXPECT_TRUE(n.parent().readable());
+        if(n.parent().readable())
+        {
+            EXPECT_TRUE(n.parent().is_map());
+        }
     }
     // check sibling reciprocity
     for(ConstNodeRef s : n.siblings())
@@ -789,6 +953,10 @@ void test_invariants(ConstNodeRef const& n)
             EXPECT_TRUE(n.parent().is_seq());
             EXPECT_TRUE(n.parent().is_stream());
         }
+        if(n.parent().is_map())
+        {
+            EXPECT_TRUE(n.has_key());
+        }
     }
     else
     {
@@ -813,6 +981,16 @@ void test_invariants(ConstNodeRef const& n)
             if(ch.type() != NOTYPE)
             {
                 EXPECT_TRUE(ch.has_key());
+            }
+        }
+    }
+    if(n.is_stream() && !n.is_seq())
+    {
+        for(ConstNodeRef ch : n.children())
+        {
+            if(ch.type() != NOTYPE)
+            {
+                EXPECT_TRUE(ch.is_doc());
             }
         }
     }
@@ -865,8 +1043,6 @@ void test_invariants(ConstNodeRef const& n)
     {
         test_invariants(ch);
     }
-
-    #undef _MORE_INFO
 }
 
 
@@ -929,8 +1105,8 @@ void test_invariants(Tree const& t)
     size_t count = test_tree_invariants(t.rootref());
     EXPECT_EQ(count, t.size());
 
-    check_invariants(t);
     test_invariants(t.rootref());
+    check_invariants(t);
 
     if(!testing::UnitTest::GetInstance()->current_test_info()->result()->Passed())
     {

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -124,6 +124,10 @@ struct CaseData;
 Case const* get_case(csubstr name);
 CaseData* get_data(csubstr name);
 
+
+void test_compare(ConstNodeRef const& actual, ConstNodeRef const& expected,
+                  const char *actual_name="actual", const char *expected_name="expected",
+                  type_bits cmp_mask=_TYMASK);
 void test_compare(Tree const& actual, Tree const& expected,
                   const char *actual_name="actual", const char *expected_name="expected",
                   type_bits cmp_mask=_TYMASK);
@@ -134,6 +138,7 @@ void test_compare(Tree const& actual, id_type node_actual,
 
 void test_arena_not_shared(Tree const& a, Tree const& b);
 
+void test_invariants(NodeType ty);
 void test_invariants(Tree const& t);
 void test_invariants(ConstNodeRef const& n);
 

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -256,6 +256,12 @@ inline c4::substr replace_all(c4::csubstr pattern, c4::csubstr repl, c4::csubstr
 
 enum class ExpectedErrorType : int { err_none = 0, err_basic = 1, err_parse = 2, err_visit = 3, err_any = 7 };
 
+#define RYML_EXPECT_ERROR(...)                  \
+    do {                                        \
+        SCOPED_TRACE("here");                   \
+        ExpectError:: __VA_ARGS__ ;             \
+    } while(0)
+
 struct ExpectError
 {
     ExpectedErrorType m_error;
@@ -280,23 +286,26 @@ struct ExpectError
     static void check_assert(ExpectedErrorType errtype,             fntestref fn, Location const& loc={}) { check_error(errtype, nullptr, fn, loc); };
     static void check_assert(ExpectedErrorType errtype, Tree *tree, fntestref fn, Location const& loc={});
 
-    static void check_error_basic(            fntestref fn, bool only_basic=true) { check_error_basic((const Tree*)nullptr, fn, only_basic); }
+    static void check_error_basic(            fntestref fn, bool only_basic=true) { check_error_basic((Tree*)nullptr, fn, only_basic); }
     static void check_error_basic(Tree *tree, fntestref fn, bool only_basic=true);
     static void check_error_basic(Tree const *tree, fntestref fn, bool only_basic=true);
-    static void check_assert_basic(            fntestref fn, bool only_basic=true) { check_assert_parse(nullptr, fn, only_basic); }
+    static void check_assert_basic(            fntestref fn, bool only_basic=true) { check_assert_parse((Tree*)nullptr, fn, only_basic); }
     static void check_assert_basic(Tree *tree, fntestref fn, bool only_basic=true);
+    static void check_assert_basic(Tree const* tree, fntestref fn, bool only_basic=true);
 
-    static void check_error_parse(            fntestref fn, Location const& expected={}) { check_error_parse((const Tree*)nullptr, fn, expected); }
+    static void check_error_parse(            fntestref fn, Location const& expected={}) { check_error_parse((Tree*)nullptr, fn, expected); }
     static void check_error_parse(Tree *tree, fntestref fn, Location const& expected={});
     static void check_error_parse(Tree const *tree, fntestref fn, Location const& expected={});
-    static void check_assert_parse(            fntestref fn, Location const& expected={}) { check_assert_parse(nullptr, fn, expected); }
+    static void check_assert_parse(            fntestref fn, Location const& expected={}) { check_assert_parse((Tree*)nullptr, fn, expected); }
     static void check_assert_parse(Tree *tree, fntestref fn, Location const& expected={});
+    static void check_assert_parse(Tree const *tree, fntestref fn, Location const& expected={});
 
-    static void check_error_visit(            fntestref fn, id_type id=npos) { check_error_visit((const Tree*)nullptr, fn, id); }
+    static void check_error_visit(            fntestref fn, id_type id=npos) { check_error_visit((Tree*)nullptr, fn, id); }
     static void check_error_visit(Tree *tree, fntestref fn, id_type id=npos);
     static void check_error_visit(Tree const *tree, fntestref fn, id_type id=npos);
-    static void check_assert_visit(            fntestref fn, id_type id=npos) { check_assert_visit(nullptr, fn, id); }
+    static void check_assert_visit(            fntestref fn, id_type id=npos) { check_assert_visit((Tree*)nullptr, fn, id); }
     static void check_assert_visit(Tree *tree, fntestref fn, id_type id=npos);
+    static void check_assert_visit(Tree const *tree, fntestref fn, id_type id=npos);
 };
 
 

--- a/test/test_noderef.cpp
+++ b/test/test_noderef.cpp
@@ -33,38 +33,49 @@ TEST(NodeRef, general)
 
     NodeRef root(&t);
 
-    //using S = csubstr;
-    //using V = NodeScalar;
-    using N = NodeInit;
-
-    root = N{MAP};
-    root.append_child({"a", "0"});
-    root.append_child({MAP, "b"});
-    root["b"].append_child({SEQ, "seq"});
-    root["b"]["seq"].append_child({"0"});
-    root["b"]["seq"].append_child({"1"});
-    root["b"]["seq"].append_child({"2"});
-    root["b"]["seq"].append_child({NodeScalar{"!!str", "3"}});
-    auto ch4 = root["b"]["seq"][3].append_sibling({"4"});
+    root.set_map();
+    (root.append_child() = key("a")) = "0";
+    root["b"].set_map();
+    root["b"]["seq"].set_seq();
+    root["b"]["seq"][0] = "0";
+    root["b"]["seq"][1] = "1";
+    root["b"]["seq"][2] = "2";
+    (root["b"]["seq"][3] = "3").set_val_tag("!!str");
+    (root["b"]["seq"][3] = "3").set_val_tag("!!str");
+    NodeRef ch4 = root["b"]["seq"][3].append_sibling() = "4";
     EXPECT_EQ(ch4.id(), root["b"]["seq"][4].id());
     EXPECT_EQ(ch4.get(), root["b"]["seq"][4].get());
+    {
+        const NodeRef constch4 = ch4;
+        auto *nd = constch4.get();
+        EXPECT_EQ(nd, ch4.get());
+        static_assert(std::is_same<decltype(nd), NodeData const*>::value, "must be const");
+    }
     EXPECT_EQ((type_bits)root["b"]["seq"][4].type(), (type_bits)VAL);
     EXPECT_EQ(root["b"]["seq"][4].val(), "4");
-    root["b"]["seq"].append_sibling({NodeScalar{"!!str", "aaa"}, NodeScalar{"!!int", "0"}});
+    NodeRef aaa = root["b"]["seq"].append_sibling();
+    aaa.set_key("aaa");
+    aaa.set_key_tag("!!str");
+    aaa.set_val("0");
+    aaa.set_val_tag("!!int");
     EXPECT_EQ((type_bits)root["b"]["seq"][4].type(), (type_bits)VAL);
-    EXPECT_EQ(root["b"]["seq"][4].val(), "4");
+    EXPECT_EQ((type_bits)aaa.type(), (type_bits)(KEY|VAL|KEYTAG|VALTAG));
+    aaa.set_val("0", VAL_DQUO);
+    EXPECT_EQ((type_bits)aaa.type(), (type_bits)(KEY|VAL|KEYTAG|VALTAG|VAL_DQUO));
+    aaa.set_key("aaa", KEY_SQUO);
+    EXPECT_EQ((type_bits)aaa.type(), (type_bits)(KEY|VAL|KEYTAG|VALTAG|KEY_SQUO|VAL_DQUO));
 
     root["b"]["key"] = "val";
-    auto seq = root["b"]["seq"];
-    auto seq2 = root["b"]["seq2"];
+    NodeRef seq = root["b"]["seq"];
+    NodeRef seq2 = root["b"]["seq2"];
     EXPECT_TRUE(seq2.is_seed());
-    root["b"]["seq2"] = N(SEQ);
+    root["b"]["seq2"].set_seq();
     seq2 = root["b"]["seq2"];
     EXPECT_FALSE(seq2.is_seed());
     EXPECT_TRUE(seq2.is_seq());
     EXPECT_EQ(seq2.num_children(), 0);
     EXPECT_EQ(root["b"]["seq2"].get(), seq2.get());
-    auto seq20 = seq2[0];
+    NodeRef seq20 = seq2[0];
     EXPECT_TRUE(seq20.is_seed());
     EXPECT_TRUE(seq2[0].is_seed());
     EXPECT_EQ(seq2.num_children(), 0);
@@ -88,16 +99,20 @@ TEST(NodeRef, general)
     root["b"]["seq2"][2] = "02";
     root["b"]["seq2"][3] = "03";
     int iv = 0;
-    root["b"]["seq2"][4] << 55; root["b"]["seq2"][4] >> iv;
+    root["b"]["seq2"][4] << 55;
+    root["b"]["seq2"][4] >> iv;
     EXPECT_EQ(iv, 55);
     size_t zv = 0;
-    root["b"]["seq2"][5] << size_t(55); root["b"]["seq2"][5] >> zv;
+    root["b"]["seq2"][5] << size_t(55);
+    root["b"]["seq2"][5] >> zv;
     EXPECT_EQ(zv, size_t(55));
     float fv = 0;
-    root["b"]["seq2"][6] << 2.0f; root["b"]["seq2"][6] >> fv;
+    root["b"]["seq2"][6] << 2.0f;
+    root["b"]["seq2"][6] >> fv;
     EXPECT_EQ(fv, 2.f);
-    float dv = 0;
-    root["b"]["seq2"][7] << 2.0; root["b"]["seq2"][7] >> dv;
+    double dv = 0;
+    root["b"]["seq2"][7] << 2.0;
+    root["b"]["seq2"][7] >> dv;
     EXPECT_EQ(dv, 2.0);
 
     EXPECT_EQ(root["b"]["key"].key(), "key");
@@ -225,30 +240,40 @@ TEST(NodeRef, valid_vs_seed_vs_readable)
     EXPECT_FALSE(none.readable());
 }
 
+namespace {
 const auto errbasic = ExpectedErrorType::err_basic;
 const auto errvisit = ExpectedErrorType::err_visit;
 const auto errany = ExpectedErrorType::err_any;
 
+// define these functions here to minimize the binary size
+using errfn = std::function<void()>;
+C4_NO_INLINE void check_assert(ExpectedErrorType errty, Tree *tree, errfn const& fn) noexcept
+{
+    ExpectError::check_assert(errty, tree, fn);
+}
+C4_NO_INLINE void check_success(Tree *tree, errfn const& fn) noexcept
+{
+    ExpectError::check_success(tree, fn);
+}
 #define _TEST_FAIL_(errtype, tree, method_expr) \
     {                                           \
         SCOPED_TRACE(#method_expr);             \
-        ExpectError::check_assert(errtype, tree, [&]{ \
+        check_assert(errtype, tree, [&]{        \
             auto ret = (method_expr);           \
-            C4_DONT_OPTIMIZE(ret);              \
+            (void)ret;                          \
         });                                     \
     }
-#define _TEST_FAIL(tree, method_expr) _TEST_FAIL_(errbasic)
 #define _TEST_SUCCEED(tree, method_expr)        \
     {                                           \
         SCOPED_TRACE(#method_expr);             \
-        ExpectError::check_success(tree, [&]{   \
+        check_success(tree, [&]{                \
             auto ret = (method_expr);           \
-            C4_DONT_OPTIMIZE(ret);              \
+            (void)ret;                          \
         });                                     \
     }
 
 template<class NodeT>
-void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype)
+C4_NO_INLINE void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype) noexcept
 {
     _TEST_SUCCEED(tree, node.get())
     _TEST_FAIL_(errtype, tree, node.type())
@@ -296,6 +321,8 @@ void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype)
     _TEST_FAIL_(errtype, tree, node.is_flow_mln())
     _TEST_FAIL_(errtype, tree, node.is_flow_mlx())
     _TEST_FAIL_(errtype, tree, node.has_flow_space())
+    _TEST_FAIL_(errtype, tree, node.key_style())
+    _TEST_FAIL_(errtype, tree, node.val_style())
     _TEST_FAIL_(errtype, tree, node.is_key_styled())
     _TEST_FAIL_(errtype, tree, node.is_val_styled())
     _TEST_FAIL_(errtype, tree, node.is_key_literal())
@@ -334,6 +361,8 @@ void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype)
     _TEST_FAIL_(errtype, tree, node.num_children())
     _TEST_FAIL_(errtype, tree, node.num_siblings())
     _TEST_FAIL_(errtype, tree, node.num_other_siblings())
+    _TEST_FAIL_(errtype, tree, node.depth_asc())
+    _TEST_FAIL_(errtype, tree, node.depth_desc())
     _TEST_FAIL_(errtype, tree, node["key"])
     _TEST_FAIL_(errtype, tree, node[0])
     _TEST_FAIL_(errtype, tree, node.at("key"))
@@ -343,6 +372,8 @@ void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype)
     _TEST_FAIL_(errtype, tree, node >> key(val))
     _TEST_FAIL_(errtype, tree, node >> fmt::base64(val))
     _TEST_FAIL_(errtype, tree, node >> key(fmt::base64(val)))
+    //_TEST_FAIL_(errtype, tree, node.deserialize_key(fmt::base64(val)))
+    //_TEST_FAIL_(errtype, tree, node.deserialize(fmt::base64(val)))
     _TEST_FAIL_(errtype, tree, node.get_if("key", &val));
     _TEST_FAIL_(errtype, tree, node.get_if("key", &val, 0));
     const NodeT const_node = node;
@@ -374,24 +405,28 @@ void test_fail_read(Tree *tree, NodeT node, ExpectedErrorType errtype)
     }
 }
 template<class NodeT>
-void test_fail_read_subject(Tree *tree, NodeT node, NodeT subject, ExpectedErrorType errtype)
+C4_NO_INLINE void test_fail_read_subject(Tree *tree, NodeT node, NodeT subject, ExpectedErrorType errtype) noexcept
 {
     SCOPED_TRACE("here");
     if(node.readable())
     {
         _TEST_SUCCEED(tree, node.has_child(subject))
         _TEST_SUCCEED(tree, node.has_sibling(subject))
+        _TEST_SUCCEED(tree, node.is_ancestor(subject))
     }
     else
     {
         _TEST_FAIL_(errtype, tree, node.has_child(subject))
         _TEST_FAIL_(errtype, tree, node.has_sibling(subject))
+        _TEST_FAIL_(errtype, tree, node.is_ancestor(subject))
     }
     _TEST_FAIL_(errtype, tree, node.child_pos(subject))
     _TEST_FAIL_(errtype, tree, node.sibling_pos(subject))
 }
-#undef _TEST_FAIL_READ
-#undef _TEST_SUCCEED_READ
+#undef _TEST_FAIL_
+#undef _TEST_SUCCEED
+} // namespace
+
 
 TEST(NodeRef, cannot_read_from_invalid)
 {
@@ -424,6 +459,10 @@ TEST(ConstNodeRef, cannot_read_from_invalid)
     EXPECT_FALSE(const_none.is_seed());
     EXPECT_FALSE(const_none.readable());
     test_fail_read(nullptr, const_none, errbasic);
+    test_fail_read(nullptr, NodeRef{}, errbasic);
+    const NodeRef nnone;
+    test_fail_read<NodeRef>(nullptr, nnone, errbasic);
+    test_fail_read<const NodeRef>(nullptr, nnone, errbasic);
     test_fail_read_subject(nullptr, const_none, const_none, errany);
     Tree tree = parse_in_arena("foo: bar");
     ConstNodeRef foo = tree["foo"];
@@ -482,11 +521,6 @@ TEST(ConstNodeRef, cannot_read_from_seed_subject)
     test_fail_read_subject(&tree, foo, const_none, errvisit);
 }
 
-
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-//-----------------------------------------------------------------------------
-
 void noderef_check_tree(ConstNodeRef const& root)
 {
     test_invariants(*root.tree());
@@ -514,21 +548,7 @@ TEST(NodeRef, append_child_1)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
-    root.append_child({"0"});
-    root.append_child({"1"});
-    root.append_child({"2"});
-    root.append_child({"3"});
-    root.append_child({"4"});
-    root.append_child({"5"});
-    noderef_check_tree(root);
-}
-
-TEST(NodeRef, append_child_2)
-{
-    Tree t;
-    NodeRef root(&t);
-    root |= SEQ;
+    root.set_seq();
     root.append_child() = "0";
     root.append_child() = "1";
     root.append_child() = "2";
@@ -538,17 +558,31 @@ TEST(NodeRef, append_child_2)
     noderef_check_tree(root);
 }
 
+TEST(NodeRef, append_child_2)
+{
+    Tree t;
+    NodeRef root(&t);
+    root.set_seq();
+    root.append_child() << "0";
+    root.append_child() << "1";
+    root.append_child() << "2";
+    root.append_child() << "3";
+    root.append_child() << "4";
+    root.append_child() << "5";
+    noderef_check_tree(root);
+}
+
 TEST(NodeRef, append_sibling_1)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
-    NodeRef first = root.append_child({"0"});
-    first.append_sibling({"1"});
-    first.append_sibling({"2"});
-    first.append_sibling({"3"});
-    first.append_sibling({"4"});
-    first.append_sibling({"5"});
+    root.set_seq();
+    NodeRef first = root.append_child() = "0";
+    first.append_sibling() = "1";
+    first.append_sibling() = "2";
+    first.append_sibling() = "3";
+    first.append_sibling() = "4";
+    first.append_sibling() = "5";
     noderef_check_tree(root);
 }
 
@@ -556,7 +590,7 @@ TEST(NodeRef, append_sibling_2)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
+    root.set_seq();
     NodeRef first = root.append_child() << "0";
     first.append_sibling() << "1";
     first.append_sibling() << "2";
@@ -570,13 +604,13 @@ TEST(NodeRef, prepend_child_1)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
-    root.prepend_child({"5"});
-    root.prepend_child({"4"});
-    root.prepend_child({"3"});
-    root.prepend_child({"2"});
-    root.prepend_child({"1"});
-    root.prepend_child({"0"});
+    root.set_seq();
+    root.prepend_child() << "5";
+    root.prepend_child() << "4";
+    root.prepend_child() << "3";
+    root.prepend_child() << "2";
+    root.prepend_child() << "1";
+    root.prepend_child() << "0";
     noderef_check_tree(root);
 }
 
@@ -584,7 +618,7 @@ TEST(NodeRef, prepend_child_2)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
+    root.set_seq();
     root.prepend_child() << "5";
     root.prepend_child() << "4";
     root.prepend_child() << "3";
@@ -598,23 +632,8 @@ TEST(NodeRef, prepend_sibling_1)
 {
     Tree t;
     NodeRef root(&t);
-    root |= SEQ;
-    NodeRef last = root.prepend_child({"5"});
-    last.prepend_sibling({"4"});
-    last.prepend_sibling({"3"});
-    last.prepend_sibling({"2"});
-    last.prepend_sibling({"1"});
-    last.prepend_sibling({"0"});
-    noderef_check_tree(root);
-}
-
-TEST(NodeRef, prepend_sibling_2)
-{
-    Tree t;
-    NodeRef root(&t);
-    root |= SEQ;
-    NodeRef last = root.prepend_child();
-    last = "5";
+    root.set_seq();
+    NodeRef last = root.prepend_child() = "5";
     last.prepend_sibling() = "4";
     last.prepend_sibling() = "3";
     last.prepend_sibling() = "2";
@@ -623,18 +642,32 @@ TEST(NodeRef, prepend_sibling_2)
     noderef_check_tree(root);
 }
 
+TEST(NodeRef, prepend_sibling_2)
+{
+    Tree t;
+    NodeRef root(&t);
+    root.set_seq();
+    NodeRef last = root.prepend_child() << "5";
+    last.prepend_sibling() << "4";
+    last.prepend_sibling() << "3";
+    last.prepend_sibling() << "2";
+    last.prepend_sibling() << "1";
+    last.prepend_sibling() << "0";
+    noderef_check_tree(root);
+}
+
 TEST(NodeRef, insert_child_1)
 {
     Tree t;
     NodeRef root(&t);
     NodeRef none(&t, NONE);
-    root |= SEQ;
-    root.insert_child({"3"}, none);
-    root.insert_child({"4"}, root[0]);
-    root.insert_child({"0"}, none);
-    root.insert_child({"5"}, root[2]);
-    root.insert_child({"1"}, root[0]);
-    root.insert_child({"2"}, root[1]);
+    root.set_seq();
+    root.insert_child(none) = "3";
+    root.insert_child(root[0]) = "4";
+    root.insert_child(none) = "0";
+    root.insert_child(root[2]) = "5";
+    root.insert_child(root[0]) = "1";
+    root.insert_child(root[1]) = "2";
     noderef_check_tree(root);
 }
 
@@ -643,7 +676,7 @@ TEST(NodeRef, insert_child_2)
     Tree t;
     NodeRef root(&t);
     NodeRef none(&t, NONE);
-    root |= SEQ;
+    root.set_seq();
     root.insert_child(none) << "3";
     root.insert_child(root[0]) << "4";
     root.insert_child(none) << "0";
@@ -658,13 +691,13 @@ TEST(NodeRef, insert_sibling_1)
     Tree t;
     NodeRef root(&t);
     NodeRef none(&t, NONE);
-    root |= SEQ;
-    NodeRef first = root.insert_child({"3"}, none);
-    first.insert_sibling({"4"}, root[0]);
-    first.insert_sibling({"0"}, none);
-    first.insert_sibling({"5"}, root[2]);
-    first.insert_sibling({"1"}, root[0]);
-    first.insert_sibling({"2"}, root[1]);
+    root.set_seq();
+    NodeRef first = root.insert_child(none) = "3";
+    first.insert_sibling(root[0]) = "4";
+    first.insert_sibling(none) = "0";
+    first.insert_sibling(root[2]) = "5";
+    first.insert_sibling(root[0]) = "1";
+    first.insert_sibling(root[1]) = "2";
     noderef_check_tree(root);
 }
 
@@ -673,7 +706,7 @@ TEST(NodeRef, insert_sibling_2)
     Tree t;
     NodeRef root(&t);
     NodeRef none(&t, NONE);
-    root |= SEQ;
+    root.set_seq();
     NodeRef first = root.insert_child(none) << "3";
     first.insert_sibling(root[0]) << "4";
     first.insert_sibling(none) << "0";
@@ -690,13 +723,13 @@ TEST(NodeRef, remove_child)
     NodeRef root(&t);
     NodeRef none(&t, NONE);
 
-    root |= SEQ;
-    root.insert_child({"3"}, none);
-    root.insert_child({"4"}, root[0]);
-    root.insert_child({"0"}, none);
-    root.insert_child({"5"}, root[2]);
-    root.insert_child({"1"}, root[0]);
-    root.insert_child({"2"}, root[1]);
+    root.set_seq();
+    root.insert_child(none) = "3";
+    root.insert_child(root[0]) = "4";
+    root.insert_child(none) = "0";
+    root.insert_child(root[2]) = "5";
+    root.insert_child(root[0]) = "1";
+    root.insert_child(root[1]) = "2";
 
     std::vector<int> vec({10, 20, 30, 40, 50, 60, 70, 80, 90});
     root.insert_child(root[0]) << vec; // 1
@@ -735,6 +768,81 @@ TEST(NodeRef, remove_child)
     noderef_check_tree(root);
 }
 
+TEST(NodeRef, clear_key)
+{
+    Tree tree = parse_in_arena("foo: bar");
+    ASSERT_TRUE(tree[0].type().has_key());
+    EXPECT_EQ(tree[0].key(), "foo");
+    tree[0].clear_key();
+    ASSERT_FALSE(tree[0].type().has_key());
+    {
+        NodeRef n;
+        ExpectError::check_assert_basic(&tree, [&] { n.clear_key(); });
+    }
+    {
+        NodeRef n = tree["not there"];
+        ExpectError::check_assert_visit(&tree, [&] { n.clear_key(); });
+    }
+}
+
+TEST(NodeRef, clear_val)
+{
+    Tree tree = parse_in_arena("foo: bar");
+    ASSERT_TRUE(tree[0].type().has_val());
+    EXPECT_EQ(tree[0].val(), "bar");
+    tree[0].clear_val();
+    ASSERT_FALSE(tree[0].type().has_val());
+    {
+        NodeRef n;
+        ExpectError::check_assert_basic(&tree, [&] { n.clear_val(); });
+    }
+    {
+        NodeRef n = tree["not there"];
+        ExpectError::check_assert_visit(&tree, [&] { n.clear_val(); });
+    }
+}
+
+TEST(NodeRef, clear_children)
+{
+    Tree tree = parse_in_arena("[0, 1, 2, 3, [4, 5, 6], 7]");
+    ASSERT_TRUE(tree[4].type().is_seq());
+    EXPECT_TRUE(tree[4].has_children());
+    EXPECT_EQ(tree[4].num_children(), 3);
+    tree[4].clear_children();
+    ASSERT_TRUE(tree[4].type().is_seq());
+    EXPECT_FALSE(tree[4].has_children());
+    EXPECT_EQ(tree[4].num_children(), 0);
+    {
+        NodeRef n;
+        ExpectError::check_assert_basic(&tree, [&] { n.clear_children(); });
+    }
+    {
+        NodeRef n = tree[21];
+        ExpectError::check_assert_visit(&tree, [&] { n.clear_children(); });
+    }
+}
+
+TEST(NodeRef, to_arena)
+{
+    csubstr yaml = "foo: bar";
+    Tree tree = parse_in_arena(yaml);
+    EXPECT_EQ(tree.arena(), yaml);
+    EXPECT_NE(tree.arena().str, yaml.str);
+    {
+        NodeRef n = tree;
+        n.to_arena(123);
+        EXPECT_EQ(tree.arena(), "foo: bar123");
+    }
+    {
+        NodeRef n;
+        ExpectError::check_assert_basic(&tree, [&] { n.to_arena(456); });
+    }
+    {
+        NodeRef n = tree["not there"];
+        ExpectError::check_success(&tree, [&] { n.to_arena(456); });
+        EXPECT_EQ(tree.arena(), "foo: bar123456");
+    }
+}
 
 TEST(NodeRef, remove_child__issue_356)
 {
@@ -779,7 +887,7 @@ TEST(NodeRef, move_in_same_parent)
     std::vector<std::vector<int>> vec2({{100, 200}, {300, 400}, {500, 600}, {700, 800, 900}});
     std::map<std::string, int> map2({{"foo", 100}, {"bar", 200}, {"baz", 300}});
 
-    r |= SEQ;
+    r.set_seq();
     r.append_child() << vec2;
     r.append_child() << map2;
     r.append_child() << "elm2";
@@ -792,7 +900,7 @@ TEST(NodeRef, move_in_same_parent)
     EXPECT_EQ(s.num_children(), vec2.size());
     EXPECT_EQ(m.num_children(), map2.size());
     //printf("fonix"); print_tree(t); emit_yaml(r);
-    r[0].move(r[1]);
+    r[0].move(r, r[1]);
     //printf("fonix"); print_tree(t); emit_yaml(r);
     EXPECT_EQ(r[0].get(), m.get());
     EXPECT_EQ(r[0].num_children(), map2.size());
@@ -811,21 +919,21 @@ TEST(NodeRef, move_in_same_parent_to_first_position)
     EXPECT_TRUE(r[2].val() == "3");
     EXPECT_TRUE(r[3].val() == "0");
     EXPECT_TRUE(r[4].val() == "4");
-    r[3].move({});
+    r[3].move(r, {});
     EXPECT_TRUE(r[0].val() == "0");
     EXPECT_TRUE(r[1].val() == "1");
     EXPECT_TRUE(r[2].val() == "2");
     EXPECT_TRUE(r[3].val() == "3");
     EXPECT_TRUE(r[4].val() == "4");
     test_invariants(t);
-    r[0].move({}); // should have no effect
+    r[0].move(r, {}); // should have no effect
     EXPECT_TRUE(r[0].val() == "0");
     EXPECT_TRUE(r[1].val() == "1");
     EXPECT_TRUE(r[2].val() == "2");
     EXPECT_TRUE(r[3].val() == "3");
     EXPECT_TRUE(r[4].val() == "4");
     test_invariants(t);
-    r[4].move({});
+    r[4].move(r, {});
     EXPECT_TRUE(r[0].val() == "4");
     EXPECT_TRUE(r[1].val() == "0");
     EXPECT_TRUE(r[2].val() == "1");
@@ -842,7 +950,7 @@ TEST(NodeRef, move_to_other_parent)
     std::vector<std::vector<int>> vec2({{100, 200}, {300, 400}, {500, 600}, {700, 800, 900}});
     std::map<std::string, int> map2({{"foo", 100}, {"bar", 200}, {"baz", 300}});
 
-    r |= SEQ;
+    r.set_seq();
     r.append_child() << vec2;
     r.append_child() << map2;
     r.append_child() << "elm2";
@@ -994,108 +1102,275 @@ TEST(NodeRef, move_to_other_tree_to_first_position)
     test_invariants(t1);
 }
 
+namespace {
+template<class Fn>
+C4_NO_INLINE void test_duplicate(ConstNodeRef orig, Fn const& fn, std::string const& expected_yaml) noexcept
+{
+    ConstNodeRef copy = fn();
+    test_compare(copy, orig, "copy", "orig");
+    EXPECT_EQ(emitrs_yaml<std::string>(*copy.tree()), expected_yaml);
+    if(testing::Test::HasFailure())
+    {
+        print_tree("orig node", *orig.tree(), orig.id());
+        print_tree("copy node", *copy.tree(), copy.id());
+        if(orig.tree() == copy.tree())
+        {
+            print_tree("full tree", *orig.tree());
+        }
+        else
+        {
+            print_tree("orig tree", *orig.tree());
+            print_tree("copy tree", *copy.tree());
+        }
+    }
+}
+} // namespace
+
+
 TEST(NodeRef, duplicate_to_same_tree)
 {
-    Tree t = parse_in_arena("[{a0: [b0, c0], a1: [b1, c1], a2: [b2, c2], a3: [b3, c3]}]");
-    auto checkseq = [](ConstNodeRef const& s){
-        ASSERT_EQ(s.num_children(), 4u);
-        ASSERT_EQ(s[0].num_children(), 2u);
-        ASSERT_EQ(s[1].num_children(), 2u);
-        ASSERT_EQ(s[2].num_children(), 2u);
-        ASSERT_EQ(s[3].num_children(), 2u);
-        EXPECT_EQ(s[0].key(), "a0");
-        EXPECT_EQ(s[0][0].val(), "b0");
-        EXPECT_EQ(s[0][1].val(), "c0");
-        EXPECT_EQ(s[1].key(), "a1");
-        EXPECT_EQ(s[1][0].val(), "b1");
-        EXPECT_EQ(s[1][1].val(), "c1");
-        EXPECT_EQ(s[2].key(), "a2");
-        EXPECT_EQ(s[2][0].val(), "b2");
-        EXPECT_EQ(s[2][1].val(), "c2");
-        EXPECT_EQ(s[3].key(), "a3");
-        EXPECT_EQ(s[3][0].val(), "b3");
-        EXPECT_EQ(s[3][1].val(), "c3");
-    };
+    csubstr yaml = "[{a0: [b0,c0]},{a1: [b1,c1]}]";
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("at the beginning");
-        t[0].duplicate({});
-        test_check_emit_check(t, [&checkseq](ConstNodeRef r){
-            checkseq(r[0]);
-            checkseq(r[1]);
-        });
+        {
+            SCOPED_TRACE("seq");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(t, {}); },
+                           "[[b0,c0],{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("seq, but tree");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return NodeRef{&t, t.duplicate(orig.id(), t.root_id(), NONE)}; },
+                           "[[b0,c0],{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(t, {}); },
+                           "[{a0: [b0,c0]},{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map, but tree");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0];
+            test_duplicate(orig,
+                           [&]{ return NodeRef{&t, t.duplicate(orig.id(), t.root_id(), NONE)}; },
+                           "[{a0: [b0,c0]},{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
     }
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("at the end");
-        t[0].duplicate(t.rootref().last_child());
-        test_check_emit_check(t, [&checkseq](ConstNodeRef r){
-            checkseq(r[0]);
-            checkseq(r[1]);
-            checkseq(r[2]);
-        });
+        {
+            SCOPED_TRACE("seq");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(t, t.rootref().last_child()); },
+                           "[{a0: [b0,c0]},{a1: [b1,c1]},[b0,c0]]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("seq, but tree");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return NodeRef{&t, t.duplicate(orig.id(), t.root_id(), t.last_child(t.root_id()))}; },
+                           "[{a0: [b0,c0]},{a1: [b1,c1]},[b0,c0]]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return t[0].duplicate(t, t.rootref().last_child()); },
+                           "[{a0: [b0,c0]},{a1: [b1,c1]},{a0: [b0,c0]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map, but tree");
+            Tree t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return NodeRef{&t, t.duplicate(t[0].id(), t.root_id(), t.last_child(t.root_id()))}; },
+                           "[{a0: [b0,c0]},{a1: [b1,c1]},{a0: [b0,c0]}]");
+        }
     }
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("in the middle");
-        t[0].duplicate(t.rootref().first_child());
-        test_check_emit_check(t, [&checkseq](ConstNodeRef r){
-            checkseq(r[0]);
-            checkseq(r[1]);
-            checkseq(r[2]);
-        });
+        {
+            SCOPED_TRACE("seq");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(t, t[0]); },
+                           "[{a0: [b0,c0]},[b0,c0],{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("seq, but tree");
+            Tree t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return NodeRef{&t, t.duplicate(orig.id(), t.root_id(), t[0].id())}; },
+                           "[{a0: [b0,c0]},[b0,c0],{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return t[0].duplicate(t, t[0]); },
+                           "[{a0: [b0,c0]},{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map, but tree");
+            Tree t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return NodeRef{&t, t.duplicate(t[0].id(), t.root_id(), t[0].id())}; },
+                           "[{a0: [b0,c0]},{a0: [b0,c0]},{a1: [b1,c1]}]");
+        }
     }
 }
 
 TEST(NodeRef, duplicate_to_different_tree)
 {
-    Tree t = parse_in_arena("[{a0: [b0, c0], a1: [b1, c1], a2: [b2, c2], a3: [b3, c3]}]");
-    auto checkseq = [](ConstNodeRef const& s){
-        ASSERT_EQ(s.num_children(), 4u);
-        ASSERT_EQ(s[0].num_children(), 2u);
-        ASSERT_EQ(s[1].num_children(), 2u);
-        ASSERT_EQ(s[2].num_children(), 2u);
-        ASSERT_EQ(s[3].num_children(), 2u);
-        EXPECT_EQ(s[0].key(), "a0");
-        EXPECT_EQ(s[0][0].val(), "b0");
-        EXPECT_EQ(s[0][1].val(), "c0");
-        EXPECT_EQ(s[1].key(), "a1");
-        EXPECT_EQ(s[1][0].val(), "b1");
-        EXPECT_EQ(s[1][1].val(), "c1");
-        EXPECT_EQ(s[2].key(), "a2");
-        EXPECT_EQ(s[2][0].val(), "b2");
-        EXPECT_EQ(s[2][1].val(), "c2");
-        EXPECT_EQ(s[3].key(), "a3");
-        EXPECT_EQ(s[3][0].val(), "b3");
-        EXPECT_EQ(s[3][1].val(), "c3");
-    };
-    auto check_orig = [&checkseq](ConstNodeRef const& r){
-        ASSERT_TRUE(r.is_seq());
-        ASSERT_GE(r.num_children(), 1u);
-        checkseq(r[0]);
-    };
-    Tree d = parse_in_arena("[]");
+    csubstr yaml = "[{a0: [b0,c0]},{a1: [b1,c1]}]";
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("at the beginning");
-        t[0].duplicate(d, {});
-        test_check_emit_check(t, check_orig);
-        test_check_emit_check(d, check_orig);
+        {
+            SCOPED_TRACE("seq");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(dst, {}); },
+                           "[[b0,c0],1,2]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            NodeRef orig = t[0];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(dst, {}); },
+                           "[{a0: [b0,c0]},1,2]");
+        }
     }
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("at the end");
-        t[0].duplicate(d, d.rootref().last_child());
-        test_check_emit_check(t, check_orig);
-        test_check_emit_check(d, check_orig);
-        test_check_emit_check(d, [&checkseq](ConstNodeRef r){
-            checkseq(r[1]);
-        });
+        {
+            SCOPED_TRACE("seq");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(dst, dst.rootref().last_child()); },
+                           "[1,2,[b0,c0]]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return t[0].duplicate(dst, dst.rootref().last_child()); },
+                           "[1,2,{a0: [b0,c0]}]");
+        }
     }
+    if(!testing::Test::HasFailure())
     {
         SCOPED_TRACE("in the middle");
-        t[0].duplicate(d, d.rootref().first_child());
-        test_check_emit_check(t, check_orig);
-        test_check_emit_check(d, check_orig);
-        test_check_emit_check(d, [&checkseq](ConstNodeRef r){
-            checkseq(r[1]);
-            checkseq(r[2]);
-        });
+        {
+            SCOPED_TRACE("seq");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            NodeRef orig = t[0]["a0"];
+            test_duplicate(orig,
+                           [&]{ return orig.duplicate(dst, dst[0]); },
+                           "[1,[b0,c0],2]");
+        }
+        if(!testing::Test::HasFailure())
+        {
+            SCOPED_TRACE("map");
+            Tree dst = parse_in_arena("[1,2]"), t = parse_in_arena(yaml);
+            test_duplicate(t[0],
+                           [&]{ return t[0].duplicate(dst, dst[0]); },
+                           "[1,{a0: [b0,c0]},2]");
+        }
+    }
+}
+
+namespace {
+C4_NO_INLINE void test_duplicate_children(ConstNodeRef orig, ConstNodeRef dstparent, ConstNodeRef after, std::string const& expected_yaml) noexcept
+{
+    ASSERT_TRUE(after.readable() || dstparent.readable());
+    for(id_type src_id = orig.first_child().id(),
+            dst_id = after.readable() ? after.next_sibling().id() : dstparent.first_child().id();
+        src_id != NONE && dst_id != NONE;
+        src_id = orig.tree()->next_sibling(src_id),
+        dst_id = dstparent.tree()->next_sibling(dst_id))
+    {
+        ConstNodeRef orig_child = {orig.tree(), src_id};
+        ConstNodeRef copy = {dstparent.tree(), dst_id};
+        test_compare(copy, orig_child, "copy", "orig");
+    }
+    EXPECT_EQ(emitrs_yaml<std::string>(*dstparent.tree()), expected_yaml);
+    if(testing::Test::HasFailure())
+    {
+        if(orig.tree() == after.tree())
+        {
+            print_tree("full tree", *orig.tree());
+        }
+        else
+        {
+            print_tree("orig tree", *orig.tree());
+            print_tree("copy tree", *dstparent.tree());
+        }
+    }
+}
+} // namespace
+
+
+TEST(NodeRef, duplicate_children_to_same_tree)
+{
+    csubstr yaml = "[{a0: [b0,c0]},{a1: [b1,c1]}]";
+    if(!testing::Test::HasFailure())
+    {
+        SCOPED_TRACE("at the beginning");
+        ConstNodeRef after = {};
+        Tree t = parse_in_arena(yaml);
+        NodeRef orig = t[0]["a0"];
+        orig.duplicate_children(t, after);
+        test_duplicate_children(orig, t, after, "[b0,c0,{a0: [b0,c0]},{a1: [b1,c1]}]");
+    }
+    if(!testing::Test::HasFailure())
+    {
+        SCOPED_TRACE("at the end");
+        Tree t = parse_in_arena(yaml);
+        NodeRef orig = t[0]["a0"];
+        ConstNodeRef after = t.rootref().last_child();
+        orig.duplicate_children(t, after);
+        test_duplicate_children(orig, t, after, "[{a0: [b0,c0]},{a1: [b1,c1]},b0,c0]");
+    }
+    if(!testing::Test::HasFailure())
+    {
+        SCOPED_TRACE("in the middle");
+        Tree t = parse_in_arena(yaml);
+        NodeRef orig = t[0]["a0"];
+        ConstNodeRef after = t[0];
+        orig.duplicate_children(t, after);
+        test_duplicate_children(orig, t, after, "[{a0: [b0,c0]},b0,c0,{a1: [b1,c1]}]");
     }
 }
 
@@ -1139,6 +1414,12 @@ TEST(NodeRef, vsConstNodeRef)
 }
 
 
+namespace {
+bool is_const_ref(NodeRef const&) { return false; }
+bool is_const_ref(ConstNodeRef const&) { return true; }
+} /// namespace
+
+
 // see https://github.com/biojppm/rapidyaml/issues/294
 TEST(NodeRef, overload_sets)
 {
@@ -1150,116 +1431,191 @@ TEST(NodeRef, overload_sets)
         ConstNodeRef const cn = t;
         EXPECT_EQ(n.doc(0), nc.doc(0));
         EXPECT_EQ(n.doc(0), cn.doc(0));
+        EXPECT_EQ(is_const_ref(n.doc(0)), false);
+        EXPECT_EQ(is_const_ref(cn.doc(0)), true);
     }
     Tree t = parse_in_arena("{iseq: [8, 10], imap: {a: b, c: d}}");
     NodeRef n = t;
     NodeRef const nc = t;
     ConstNodeRef const cn = t;
+    NodeRef n_iseq = n["iseq"];
+    NodeRef const nc_iseq = n["iseq"];
+    ConstNodeRef const cn_iseq = n["iseq"];
+    NodeRef n_imap = n["imap"];
+    NodeRef const nc_imap = n["imap"];
+    ConstNodeRef const cn_imap = n["imap"];
     // get()
     {
-        EXPECT_EQ(n["iseq"].get(), nc["iseq"].get());
-        EXPECT_EQ(n["iseq"].get(), cn["iseq"].get());
+        EXPECT_EQ(n_iseq.get(), nc_iseq.get());
+        EXPECT_EQ(n_iseq.get(), cn_iseq.get());
     }
     // parent()
     {
-        EXPECT_EQ(n["iseq"].parent(), nc["iseq"].parent());
-        EXPECT_EQ(n["iseq"].parent(), cn["iseq"].parent());
+        EXPECT_EQ(n_iseq.parent(), nc_iseq.parent());
+        EXPECT_EQ(n_iseq.parent(), cn_iseq.parent());
+        EXPECT_EQ(is_const_ref(n_iseq.parent()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.parent()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.parent()), true);
     }
     // child_pos()
     {
-        EXPECT_EQ(n["iseq"].child_pos(n["iseq"][0]), nc["iseq"].child_pos(n["iseq"][0]));
-        EXPECT_EQ(n["iseq"].child_pos(n["iseq"][0]), cn["iseq"].child_pos(n["iseq"][0]));
+        EXPECT_EQ(n_iseq.child_pos(n_iseq[0]), nc_iseq.child_pos(n_iseq[0]));
+        EXPECT_EQ(n_iseq.child_pos(n_iseq[0]), cn_iseq.child_pos(n_iseq[0]));
     }
     // num_children()
     {
-        EXPECT_EQ(n["iseq"].num_children(), nc["iseq"].num_children());
-        EXPECT_EQ(n["iseq"].num_children(), cn["iseq"].num_children());
+        EXPECT_EQ(n_iseq.num_children(), nc_iseq.num_children());
+        EXPECT_EQ(n_iseq.num_children(), cn_iseq.num_children());
     }
     // first_child()
     {
-        EXPECT_EQ(n["iseq"].first_child(), nc["iseq"].first_child());
-        EXPECT_EQ(n["iseq"].first_child(), cn["iseq"].first_child());
+        EXPECT_EQ(n_iseq.first_child(), nc_iseq.first_child());
+        EXPECT_EQ(n_iseq.first_child(), cn_iseq.first_child());
+        EXPECT_EQ(is_const_ref(n_iseq.first_child()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.first_child()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.first_child()), true);
     }
     // last_child()
     {
-        EXPECT_EQ(n["iseq"].last_child(), nc["iseq"].last_child());
-        EXPECT_EQ(n["iseq"].last_child(), cn["iseq"].last_child());
+        EXPECT_EQ(n_iseq.last_child(), nc_iseq.last_child());
+        EXPECT_EQ(n_iseq.last_child(), cn_iseq.last_child());
+        EXPECT_EQ(is_const_ref(n_iseq.last_child()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.last_child()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.last_child()), true);
     }
     // child()
     {
-        EXPECT_EQ(n["iseq"].child(0), nc["iseq"].child(0));
-        EXPECT_EQ(n["iseq"].child(0), cn["iseq"].child(0));
+        EXPECT_EQ(n_iseq.child(0), nc_iseq.child(0));
+        EXPECT_EQ(n_iseq.child(0), cn_iseq.child(0));
+        EXPECT_EQ(is_const_ref(n_iseq.child(0)), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.child(0)), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.child(0)), true);
     }
     // find_child()
     {
         EXPECT_EQ(n.find_child("iseq"), nc.find_child("iseq"));
         EXPECT_EQ(n.find_child("iseq"), cn.find_child("iseq"));
+        EXPECT_EQ(n_imap.find_child("a"), nc_imap.find_child("a"));
+        EXPECT_EQ(n_imap.find_child("a"), cn_imap.find_child("a"));
+        EXPECT_EQ(is_const_ref(n_imap.find_child("a")), false);
+        EXPECT_EQ(is_const_ref(cn_imap.find_child("a")), true);
+        EXPECT_EQ(is_const_ref(nc_imap.find_child("a")), true);
     }
     // prev_sibling()
     {
-        EXPECT_EQ(n["iseq"][1].prev_sibling(), nc["iseq"][1].prev_sibling());
-        EXPECT_EQ(n["iseq"][1].prev_sibling(), cn["iseq"][1].prev_sibling());
+        EXPECT_EQ(n_iseq[1].prev_sibling(), nc_iseq[1].prev_sibling());
+        EXPECT_EQ(n_iseq[1].prev_sibling(), cn_iseq[1].prev_sibling());
+        EXPECT_EQ(is_const_ref(n_iseq.prev_sibling()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.prev_sibling()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.prev_sibling()), true);
     }
     // next_sibling()
     {
-        EXPECT_EQ(n["iseq"][0].next_sibling(), nc["iseq"][0].next_sibling());
-        EXPECT_EQ(n["iseq"][0].next_sibling(), cn["iseq"][0].next_sibling());
+        EXPECT_EQ(n_iseq[0].next_sibling(), nc_iseq[0].next_sibling());
+        EXPECT_EQ(n_iseq[0].next_sibling(), cn_iseq[0].next_sibling());
+        EXPECT_EQ(is_const_ref(n_iseq.next_sibling()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.next_sibling()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.next_sibling()), true);
     }
     // first_sibling()
     {
-        EXPECT_EQ(n["iseq"][1].first_sibling(), nc["iseq"][1].first_sibling());
-        EXPECT_EQ(n["iseq"][1].first_sibling(), cn["iseq"][1].first_sibling());
+        EXPECT_EQ(n_iseq[1].first_sibling(), nc_iseq[1].first_sibling());
+        EXPECT_EQ(n_iseq[1].first_sibling(), cn_iseq[1].first_sibling());
+        EXPECT_EQ(is_const_ref(n_iseq.first_sibling()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.first_sibling()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.first_sibling()), true);
     }
     // last_sibling()
     {
-        EXPECT_EQ(n["iseq"][0].last_sibling(), nc["iseq"][0].last_sibling());
-        EXPECT_EQ(n["iseq"][0].last_sibling(), cn["iseq"][0].last_sibling());
+        EXPECT_EQ(n_iseq[0].last_sibling(), nc_iseq[0].last_sibling());
+        EXPECT_EQ(n_iseq[0].last_sibling(), cn_iseq[0].last_sibling());
+        EXPECT_EQ(is_const_ref(n_iseq.last_sibling()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.last_sibling()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.last_sibling()), true);
     }
     // sibling()
     {
-        EXPECT_EQ(n["iseq"][1].sibling(0), nc["iseq"][1].sibling(0));
-        EXPECT_EQ(n["iseq"][1].sibling(0), cn["iseq"][1].sibling(0));
+        EXPECT_EQ(n_iseq[1].sibling(0), nc_iseq[1].sibling(0));
+        EXPECT_EQ(n_iseq[1].sibling(0), cn_iseq[1].sibling(0));
+        EXPECT_EQ(is_const_ref(n_iseq.sibling(0)), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.sibling(0)), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.sibling(0)), true);
     }
     // find_sibling()
     {
-        EXPECT_EQ(n["iseq"].find_sibling("imap"), nc["iseq"].find_sibling("imap"));
-        EXPECT_EQ(n["iseq"].find_sibling("imap"), cn["iseq"].find_sibling("imap"));
+        EXPECT_EQ(n_iseq.find_sibling("imap"), nc_iseq.find_sibling("imap"));
+        EXPECT_EQ(n_iseq.find_sibling("imap"), cn_iseq.find_sibling("imap"));
+        EXPECT_EQ(n_imap.find_sibling("a"), nc_imap.find_sibling("a"));
+        EXPECT_EQ(n_imap.find_sibling("a"), cn_imap.find_sibling("a"));
+        EXPECT_EQ(is_const_ref(n_imap.find_sibling("a")), false);
+        EXPECT_EQ(is_const_ref(cn_imap.find_sibling("a")), true);
+        EXPECT_EQ(is_const_ref(nc_imap.find_sibling("a")), true);
+    }
+    // ancestor_doc()
+    {
+        EXPECT_EQ(n_iseq[1].ancestor_doc(), nc_iseq[1].ancestor_doc());
+        EXPECT_EQ(n_iseq[1].ancestor_doc(), cn_iseq[1].ancestor_doc());
+        EXPECT_EQ(is_const_ref(n_iseq.ancestor_doc()), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.ancestor_doc()), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.ancestor_doc()), true);
     }
     // operator[](csubstr)
     {
         EXPECT_EQ(n["iseq"].id(), nc["iseq"].id());
         EXPECT_EQ(n["iseq"].id(), cn["iseq"].id());
+        EXPECT_EQ(is_const_ref(n["iseq"]), false);
+        EXPECT_EQ(is_const_ref(cn["iseq"]), true);
+        EXPECT_EQ(is_const_ref(nc["iseq"]), true);
     }
     // operator[](size_t)
     {
-        EXPECT_EQ(n["iseq"][0].id(), nc["iseq"][0].id());
-        EXPECT_EQ(n["iseq"][0].id(), cn["iseq"][0].id());
+        EXPECT_EQ(n_iseq[0].id(), nc_iseq[0].id());
+        EXPECT_EQ(n_iseq[0].id(), cn_iseq[0].id());
+        EXPECT_EQ(is_const_ref(n_iseq[0]), false);
+        EXPECT_EQ(is_const_ref(cn_iseq[0]), true);
+        EXPECT_EQ(is_const_ref(nc_iseq[0]), true);
+    }
+    // at(csubstr)
+    {
+        EXPECT_EQ(n.at("iseq").id(), nc.at("iseq").id());
+        EXPECT_EQ(n.at("iseq").id(), cn.at("iseq").id());
+        EXPECT_EQ(is_const_ref(n.at("iseq")), false);
+        EXPECT_EQ(is_const_ref(cn.at("iseq")), true);
+        EXPECT_EQ(is_const_ref(nc.at("iseq")), true);
+    }
+    // at(size_t)
+    {
+        EXPECT_EQ(n_iseq.at(0).id(), nc_iseq.at(0).id());
+        EXPECT_EQ(n_iseq.at(0).id(), cn_iseq.at(0).id());
+        EXPECT_EQ(is_const_ref(n_iseq.at(0)), false);
+        EXPECT_EQ(is_const_ref(cn_iseq.at(0)), true);
+        EXPECT_EQ(is_const_ref(nc_iseq.at(0)), true);
     }
     // begin()
     {
-        EXPECT_EQ(n["iseq"].begin().m_child_id, nc["iseq"].begin().m_child_id);
-        EXPECT_EQ(n["iseq"].begin().m_child_id, cn["iseq"].begin().m_child_id);
+        EXPECT_EQ(n_iseq.begin().m_child_id, nc_iseq.begin().m_child_id);
+        EXPECT_EQ(n_iseq.begin().m_child_id, cn_iseq.begin().m_child_id);
     }
     // end()
     {
-        EXPECT_EQ(n["iseq"].end().m_child_id, nc["iseq"].end().m_child_id);
-        EXPECT_EQ(n["iseq"].end().m_child_id, cn["iseq"].end().m_child_id);
+        EXPECT_EQ(n_iseq.end().m_child_id, nc_iseq.end().m_child_id);
+        EXPECT_EQ(n_iseq.end().m_child_id, cn_iseq.end().m_child_id);
     }
     // cbegin()
     {
-        EXPECT_EQ(n["iseq"].cbegin().m_child_id, nc["iseq"].cbegin().m_child_id);
-        EXPECT_EQ(n["iseq"].cbegin().m_child_id, cn["iseq"].cbegin().m_child_id);
-        EXPECT_EQ(n["iseq"].cbegin().m_child_id, n["iseq"].begin().m_child_id);
-        EXPECT_EQ(nc["iseq"].cbegin().m_child_id, nc["iseq"].begin().m_child_id);
-        EXPECT_EQ(cn["iseq"].cbegin().m_child_id, cn["iseq"].begin().m_child_id);
+        EXPECT_EQ(n_iseq.cbegin().m_child_id, nc_iseq.cbegin().m_child_id);
+        EXPECT_EQ(n_iseq.cbegin().m_child_id, cn_iseq.cbegin().m_child_id);
+        EXPECT_EQ(n_iseq.cbegin().m_child_id, n_iseq.begin().m_child_id);
+        EXPECT_EQ(nc_iseq.cbegin().m_child_id, nc_iseq.begin().m_child_id);
+        EXPECT_EQ(cn_iseq.cbegin().m_child_id, cn_iseq.begin().m_child_id);
     }
     // cend()
     {
-        EXPECT_EQ(n["iseq"].cend().m_child_id, nc["iseq"].cend().m_child_id);
-        EXPECT_EQ(n["iseq"].cend().m_child_id, cn["iseq"].cend().m_child_id);
-        EXPECT_EQ(n["iseq"].cend().m_child_id, n["iseq"].end().m_child_id);
-        EXPECT_EQ(nc["iseq"].cend().m_child_id, nc["iseq"].end().m_child_id);
-        EXPECT_EQ(cn["iseq"].cend().m_child_id, cn["iseq"].end().m_child_id);
+        EXPECT_EQ(n_iseq.cend().m_child_id, nc_iseq.cend().m_child_id);
+        EXPECT_EQ(n_iseq.cend().m_child_id, cn_iseq.cend().m_child_id);
+        EXPECT_EQ(n_iseq.cend().m_child_id, n_iseq.end().m_child_id);
+        EXPECT_EQ(nc_iseq.cend().m_child_id, nc_iseq.end().m_child_id);
+        EXPECT_EQ(cn_iseq.cend().m_child_id, cn_iseq.end().m_child_id);
     }
     // children()
     {
@@ -1320,19 +1676,19 @@ TEST(NodeRef, overload_sets)
     {
         {
             std::vector<csubstr> actual;
-            for(auto it = n["iseq"].begin(); it != n["iseq"].end(); ++it)
+            for(auto it = n_iseq.begin(); it != n_iseq.end(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto it = nc["iseq"].begin(); it != nc["iseq"].end(); ++it)
+            for(auto it = nc_iseq.begin(); it != nc_iseq.end(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto it = cn["iseq"].begin(); it != cn["iseq"].end(); ++it)
+            for(auto it = cn_iseq.begin(); it != cn_iseq.end(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
@@ -1341,19 +1697,19 @@ TEST(NodeRef, overload_sets)
     {
         {
             std::vector<csubstr> actual;
-            for(auto it = n["iseq"].cbegin(); it != n["iseq"].cend(); ++it)
+            for(auto it = n_iseq.cbegin(); it != n_iseq.cend(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto it = nc["iseq"].cbegin(); it != nc["iseq"].cend(); ++it)
+            for(auto it = nc_iseq.cbegin(); it != nc_iseq.cend(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto it = cn["iseq"].cbegin(); it != cn["iseq"].cend(); ++it)
+            for(auto it = cn_iseq.cbegin(); it != cn_iseq.cend(); ++it)
                 actual.push_back((*it).val());
             EXPECT_EQ(expected, actual);
         }
@@ -1362,19 +1718,19 @@ TEST(NodeRef, overload_sets)
     {
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].children())
+            for(auto r : n_iseq.children())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].children())
+            for(auto r : n_iseq.children())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].children())
+            for(auto r : n_iseq.children())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }
@@ -1383,19 +1739,19 @@ TEST(NodeRef, overload_sets)
     {
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].cchildren())
+            for(auto r : n_iseq.cchildren())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].cchildren())
+            for(auto r : n_iseq.cchildren())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }
         {
             std::vector<csubstr> actual;
-            for(auto r : n["iseq"].cchildren())
+            for(auto r : n_iseq.cchildren())
                 actual.push_back(r.val());
             EXPECT_EQ(expected, actual);
         }

--- a/test/test_noderef.cpp
+++ b/test/test_noderef.cpp
@@ -34,15 +34,16 @@ TEST(NodeRef, general)
     NodeRef root(&t);
 
     root.set_map();
-    (root.append_child() = key("a")) = "0";
+    { NodeRef ch = root.append_child(); ch.set_key("a"); ch.set_val("0"); }
     root["b"].set_map();
     root["b"]["seq"].set_seq();
-    root["b"]["seq"][0] = "0";
-    root["b"]["seq"][1] = "1";
-    root["b"]["seq"][2] = "2";
-    (root["b"]["seq"][3] = "3").set_val_tag("!!str");
-    (root["b"]["seq"][3] = "3").set_val_tag("!!str");
-    NodeRef ch4 = root["b"]["seq"][3].append_sibling() = "4";
+    root["b"]["seq"][0].set_val("0");
+    root["b"]["seq"][1].set_val("1");
+    root["b"]["seq"][2].set_val("2");
+    { NodeRef ch = root["b"]["seq"][3]; ch.set_val("3"); ch.set_val_tag("!!str"); }
+    { NodeRef ch = root["b"]["seq"][3]; ch.set_val("3"); ch.set_val_tag("!!str"); }
+    NodeRef ch4 = root["b"]["seq"][3].append_sibling();
+    ch4.set_val("4");
     EXPECT_EQ(ch4.id(), root["b"]["seq"][4].id());
     EXPECT_EQ(ch4.get(), root["b"]["seq"][4].get());
     {
@@ -65,7 +66,7 @@ TEST(NodeRef, general)
     aaa.set_key("aaa", KEY_SQUO);
     EXPECT_EQ((type_bits)aaa.type(), (type_bits)(KEY|VAL|KEYTAG|VALTAG|KEY_SQUO|VAL_DQUO));
 
-    root["b"]["key"] = "val";
+    root["b"]["key"].set_val("val");
     NodeRef seq = root["b"]["seq"];
     NodeRef seq2 = root["b"]["seq2"];
     EXPECT_TRUE(seq2.is_seed());
@@ -84,20 +85,20 @@ TEST(NodeRef, general)
     EXPECT_NE(seq.get(), seq2.get());
     seq20 = root["b"]["seq2"][0];
     EXPECT_TRUE(seq20.is_seed());
-    root["b"]["seq2"][0] = "00";
+    root["b"]["seq2"][0].set_val("00");
     seq20 = root["b"]["seq2"][0];
     EXPECT_FALSE(seq20.is_seed());
     NodeRef before = root["b"]["key"];
     EXPECT_EQ(before.key(), "key");
     EXPECT_EQ(before.val(), "val");
-    root["b"]["seq2"][1] = "01";
+    root["b"]["seq2"][1].set_val("01");
     NodeRef after = root["b"]["key"];
     EXPECT_EQ(before.key(), "key");
     EXPECT_EQ(before.val(), "val");
     EXPECT_EQ(after.key(), "key");
     EXPECT_EQ(after.val(), "val");
-    root["b"]["seq2"][2] = "02";
-    root["b"]["seq2"][3] = "03";
+    root["b"]["seq2"][2].set_val("02");
+    root["b"]["seq2"][3].set_val("03");
     int iv = 0;
     root["b"]["seq2"][4] << 55;
     root["b"]["seq2"][4] >> iv;
@@ -549,12 +550,12 @@ TEST(NodeRef, append_child_1)
     Tree t;
     NodeRef root(&t);
     root.set_seq();
-    root.append_child() = "0";
-    root.append_child() = "1";
-    root.append_child() = "2";
-    root.append_child() = "3";
-    root.append_child() = "4";
-    root.append_child() = "5";
+    root.append_child().set_val("0");
+    root.append_child().set_val("1");
+    root.append_child().set_val("2");
+    root.append_child().set_val("3");
+    root.append_child().set_val("4");
+    root.append_child().set_val("5");
     noderef_check_tree(root);
 }
 
@@ -563,12 +564,12 @@ TEST(NodeRef, append_child_2)
     Tree t;
     NodeRef root(&t);
     root.set_seq();
-    root.append_child() << "0";
-    root.append_child() << "1";
-    root.append_child() << "2";
-    root.append_child() << "3";
-    root.append_child() << "4";
-    root.append_child() << "5";
+    root.append_child().set_val( "0");
+    root.append_child().set_val( "1");
+    root.append_child().set_val( "2");
+    root.append_child().set_val( "3");
+    root.append_child().set_val( "4");
+    root.append_child().set_val( "5");
     noderef_check_tree(root);
 }
 
@@ -577,12 +578,13 @@ TEST(NodeRef, append_sibling_1)
     Tree t;
     NodeRef root(&t);
     root.set_seq();
-    NodeRef first = root.append_child() = "0";
-    first.append_sibling() = "1";
-    first.append_sibling() = "2";
-    first.append_sibling() = "3";
-    first.append_sibling() = "4";
-    first.append_sibling() = "5";
+    NodeRef first = root.append_child();
+    first.set_val("0");
+    first.append_sibling().set_val("1");
+    first.append_sibling().set_val("2");
+    first.append_sibling().set_val("3");
+    first.append_sibling().set_val("4");
+    first.append_sibling().set_val("5");
     noderef_check_tree(root);
 }
 
@@ -633,12 +635,13 @@ TEST(NodeRef, prepend_sibling_1)
     Tree t;
     NodeRef root(&t);
     root.set_seq();
-    NodeRef last = root.prepend_child() = "5";
-    last.prepend_sibling() = "4";
-    last.prepend_sibling() = "3";
-    last.prepend_sibling() = "2";
-    last.prepend_sibling() = "1";
-    last.prepend_sibling() = "0";
+    NodeRef last = root.prepend_child();
+    last.set_val("5");
+    last.prepend_sibling().set_val("4");
+    last.prepend_sibling().set_val("3");
+    last.prepend_sibling().set_val("2");
+    last.prepend_sibling().set_val("1");
+    last.prepend_sibling().set_val("0");
     noderef_check_tree(root);
 }
 
@@ -662,12 +665,12 @@ TEST(NodeRef, insert_child_1)
     NodeRef root(&t);
     NodeRef none(&t, NONE);
     root.set_seq();
-    root.insert_child(none) = "3";
-    root.insert_child(root[0]) = "4";
-    root.insert_child(none) = "0";
-    root.insert_child(root[2]) = "5";
-    root.insert_child(root[0]) = "1";
-    root.insert_child(root[1]) = "2";
+    root.insert_child(none).set_val("3");
+    root.insert_child(root[0]).set_val("4");
+    root.insert_child(none).set_val("0");
+    root.insert_child(root[2]).set_val("5");
+    root.insert_child(root[0]).set_val("1");
+    root.insert_child(root[1]).set_val("2");
     noderef_check_tree(root);
 }
 
@@ -692,12 +695,13 @@ TEST(NodeRef, insert_sibling_1)
     NodeRef root(&t);
     NodeRef none(&t, NONE);
     root.set_seq();
-    NodeRef first = root.insert_child(none) = "3";
-    first.insert_sibling(root[0]) = "4";
-    first.insert_sibling(none) = "0";
-    first.insert_sibling(root[2]) = "5";
-    first.insert_sibling(root[0]) = "1";
-    first.insert_sibling(root[1]) = "2";
+    NodeRef first = root.insert_child(none);
+    first.set_val("3");
+    first.insert_sibling(root[0]).set_val("4");
+    first.insert_sibling(none).set_val("0");
+    first.insert_sibling(root[2]).set_val("5");
+    first.insert_sibling(root[0]).set_val("1");
+    first.insert_sibling(root[1]).set_val("2");
     noderef_check_tree(root);
 }
 
@@ -724,12 +728,12 @@ TEST(NodeRef, remove_child)
     NodeRef none(&t, NONE);
 
     root.set_seq();
-    root.insert_child(none) = "3";
-    root.insert_child(root[0]) = "4";
-    root.insert_child(none) = "0";
-    root.insert_child(root[2]) = "5";
-    root.insert_child(root[0]) = "1";
-    root.insert_child(root[1]) = "2";
+    root.insert_child(none).set_val("3");
+    root.insert_child(root[0]).set_val("4");
+    root.insert_child(none).set_val("0");
+    root.insert_child(root[2]).set_val("5");
+    root.insert_child(root[0]).set_val("1");
+    root.insert_child(root[1]).set_val("2");
 
     std::vector<int> vec({10, 20, 30, 40, 50, 60, 70, 80, 90});
     root.insert_child(root[0]) << vec; // 1

--- a/test/test_number.cpp
+++ b/test/test_number.cpp
@@ -139,7 +139,7 @@ static bool fleq(T a, T b)
 TEST(number, nan_0)
 {
     Tree t;
-    t.rootref() |= SEQ;
+    t.rootref().set_seq();
     t[0] << std::numeric_limits<float>::quiet_NaN();
     t[1] << std::numeric_limits<double>::quiet_NaN();
     EXPECT_EQ(t[0].val(), ".nan");
@@ -244,7 +244,7 @@ set:
 TEST(number, inf_0)
 {
     Tree t;
-    t.rootref() |= SEQ;
+    t.rootref().set_seq();
     const float finf = std::numeric_limits<float>::infinity();
     const double dinf = std::numeric_limits<double>::infinity();
     t[0] << finf;

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -3183,6 +3183,310 @@ TEST_F(ParseToMapBlockTest, map_block_ref__to__map_flow__new_child)
 }
 
 
+//-----------------------------------------------------------------------------
+
+struct TmpParser
+{
+    EventHandlerTree handler;
+    Parser parser;
+    TmpParser(bool with_handler=true) : handler(get_callbacks()), parser(&handler)
+    {
+        if(!with_handler)
+            // hack for the test: set the handler to null only after constructing
+            parser.m_evt_handler = nullptr;
+    }
+};
+TEST(ParseSetupError, on_null_tree_and_parser)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    Tree dummy;
+    NodeRef node;
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_place(nullptr         ,        src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_place(nullptr         , file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_arena(nullptr         ,       csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_arena(nullptr         , file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_place(nullptr    ,        src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_place(nullptr    , file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_arena(nullptr    ,       csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_arena(nullptr    , file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_place(nullptr         ,        src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_place(nullptr         , file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_arena(nullptr         ,       csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_in_arena(nullptr         , file, csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_place(nullptr    ,        src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_place(nullptr    , file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_arena(nullptr    ,       csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ parse_json_in_arena(nullptr    , file, csrc, node); }));
+}
+TEST(ParseSetupError, on_null_tree)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    Tree dummy;
+    NodeRef node;
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; tmp.handler.reset(nullptr, NONE); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_place(                         src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_place(                  file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_arena(                        csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_arena(                  file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_place(                    src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_place(             file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_arena(                   csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_arena(             file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_place(                         src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_place(                  file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_arena(                        csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_in_arena(                  file, csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_place(                    src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_place(             file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_arena(                   csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ /*          */ parse_json_in_arena(             file, csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, node); }));
+    RYML_EXPECT_ERROR(check_error_basic(&dummy, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, node); }));
+}
+TEST(ParseSetupError, on_empty_tree)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    Tree dummy;
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_in_place(                         src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_in_place(                  file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_in_arena(                        csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_in_arena(                  file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_in_place(&tmp.parser,             src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_json_in_place(                    src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_json_in_place(             file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_json_in_arena(                   csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); /*          */ parse_json_in_arena(             file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_json_in_place(&tmp.parser,        src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_success(&dummy, [&]{ Tree tree(0); TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, &tree); }));
+}
+TEST(ParseSetupError, on_invalid_node)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; tmp.handler.reset(&tree, NONE); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                         src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                  file,  src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                        csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                  file, csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(                    src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(             file,  src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(                   csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(             file, csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, node); }, NONE)); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                         src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                  file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                        csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                  file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(                    src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(             file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(                   csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(             file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree(0); ASSERT_TRUE(tree.empty()); NodeRef node(&tree, NONE); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; tmp.handler.reset(&tree, tree.capacity()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                         src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                  file,  src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                        csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                  file, csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(                    src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(             file,  src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(                   csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(             file, csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, node); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                         src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_place(                  file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                        csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_in_arena(                  file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,             src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_place(&tmp.parser,      file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,            csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_in_arena(&tmp.parser,      file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(                    src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_place(             file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(                   csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ /*          */ parse_json_in_arena(             file, csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser,        src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_place(&tmp.parser, file,  src, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser,       csrc, &tree, node.id()); }, node.id())); }
+    { Tree tree; ASSERT_GT(tree.capacity(), 0); NodeRef node(&tree, tree.capacity()); RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ TmpParser tmp; parse_json_in_arena(&tmp.parser, file, csrc, &tree, node.id()); }, node.id())); }
+}
+TEST(ParseSetupError, on_null_parser)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    Tree tree; NodeRef root = tree;
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_place(nullptr,                   src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_place(nullptr,            file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_arena(nullptr,                  csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_arena(nullptr,            file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_place(nullptr,              src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_place(nullptr,       file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_arena(nullptr,             csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_arena(nullptr,       file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_place(nullptr,                   src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_place(nullptr,            file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_arena(nullptr,                  csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_in_arena(nullptr,            file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_place(nullptr,              src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_place(nullptr,       file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_arena(nullptr,             csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ parse_json_in_arena(nullptr,       file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_in_place(nullptr,             src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_in_place(nullptr,      file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_in_arena(nullptr,            csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_in_arena(nullptr,      file, csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_json_in_place(nullptr,        src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_json_in_place(nullptr, file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_json_in_arena(nullptr,       csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ (void)parse_json_in_arena(nullptr, file, csrc); }));
+}
+TEST(ParseSetupError, on_null_handler)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    Tree tree;
+    NodeRef root = tree;
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,                   src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,            file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,                  csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,            file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,              src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,       file,  src, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,             csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,       file, csrc, nullptr); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,                   src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,            file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,                  csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,            file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,              src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,       file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,             csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,       file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,                   src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,            file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,                  csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,            file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,              src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,       file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,             csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,       file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_place(&tmp.parser,             src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_place(&tmp.parser,      file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_arena(&tmp.parser,            csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_arena(&tmp.parser,      file, csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_place(&tmp.parser,        src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_place(&tmp.parser, file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_arena(&tmp.parser,       csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_arena(&tmp.parser, file, csrc); }));
+}
+TEST(ParseSetupError, on_bad_src)
+{
+    csubstr file = "file";
+    substr   src;
+    csubstr csrc;
+    src.len = 1;
+    csrc.len = 1;
+    src.str = nullptr;
+    csrc.str = nullptr;
+    Tree tree;
+    NodeRef root = tree;
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_place(                  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_place(           file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_arena(                 csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_arena(           file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_place(             src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_place(      file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_arena(            csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_arena(      file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_place(                  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_place(           file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_arena(                 csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_in_arena(           file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_place(             src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_place(      file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_arena(            csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  parse_json_in_arena(      file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_in_place(            src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_in_place(     file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_in_arena(           csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_in_arena(     file, csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_json_in_place(       src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_json_in_place(file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_json_in_arena(      csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{  (void)parse_json_in_arena(file, csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,                   src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,            file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,                  csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,            file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,              src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,       file,  src, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,             csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,       file, csrc, &tree); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,                   src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_place(&tmp.parser,            file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,                  csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_in_arena(&tmp.parser,            file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,              src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_place(&tmp.parser,       file,  src, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,             csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); parse_json_in_arena(&tmp.parser,       file, csrc, root); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_place(&tmp.parser,             src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_place(&tmp.parser,      file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_arena(&tmp.parser,            csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_in_arena(&tmp.parser,      file, csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_place(&tmp.parser,        src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_place(&tmp.parser, file,  src); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_arena(&tmp.parser,       csrc); }));
+    RYML_EXPECT_ERROR(check_error_basic(&tree, [&]{ TmpParser tmp(/*handler*/false); (void)parse_json_in_arena(&tmp.parser, file, csrc); }));
+}
 
 
 } // namespace yml

--- a/test/test_parser.cpp
+++ b/test/test_parser.cpp
@@ -19,17 +19,18 @@ namespace yml {
 C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wold-style-cast")
 
 // undefined below
-#define testlc(lc, buf, offs, begins_with_, rem_, full_) \
-    {                                                               \
-        RYML_TRACE_FMT("offs={}", offs);                            \
-        substr sub = buf.sub(offs);                                 \
-        if(!to_csubstr(begins_with_).empty())                       \
-        {                                                           \
-            EXPECT_TRUE(sub.begins_with(begins_with_)) << buf.sub(offs); \
-        }                                                           \
-        lc.reset_with_next_line(buf, offs);                         \
-        EXPECT_EQ(lc.rem, csubstr(rem_));                           \
-        EXPECT_EQ(lc.full, csubstr(full_));                         \
+#define testlc(lc, buf, offs, begins_with_, rem_, full_)    \
+    {                                                       \
+        RYML_TRACE_FMT("offs={}", offs);                    \
+        substr sub = buf.sub(offs);                         \
+        if(!csubstr(begins_with_).empty())                  \
+        {                                                   \
+            EXPECT_TRUE(sub.begins_with(begins_with_))      \
+                << buf.sub(offs);                           \
+        }                                                   \
+        lc.reset_with_next_line(buf, offs);                 \
+        EXPECT_EQ(lc.rem, csubstr(rem_));                   \
+        EXPECT_EQ(lc.full, csubstr(full_));                 \
     }
 
 TEST(LineContents, basic)
@@ -633,11 +634,12 @@ TEST(Parser, alloc_arena)
     Parser parser(&evt_handler);
     evt_handler.reset(&tree, tree.root_id());
     evt_handler.start_parse("filename", substr{});
-    substr bufa = evt_handler.alloc_arena(64);
+    size_t force_realloc = 512;
+    substr bufa = evt_handler.alloc_arena(force_realloc);
     bufa.fill('a');
     csubstr prev = bufa;
     csubstr prev_arena = tree.arena();
-    substr bufb = parser._alloc_arena(64, &bufa);
+    substr bufb = parser._alloc_arena(force_realloc, &bufa);
     csubstr curr_arena = tree.arena();
     EXPECT_NE(prev_arena.str, curr_arena.str);
     EXPECT_NE(prev.str, bufa.str);
@@ -898,17 +900,24 @@ protected:
     void SetUp() override
     {
         NodeRef root = ref.rootref();
-        root |= MAP;
-        root |= FLOW_SL;
+        root.set_map(FLOW_SL);
         NodeRef keyval = root.append_child();
         NodeRef keyseq = root.append_child();
         keyval << key("this") << "is";
         keyseq << key("a");
-        keyseq |= SEQ;
+        keyseq.set_seq();
         keyseq.append_child() << "yaml";
         keyseq.append_child() << "example";
     }
 
+    void check_tree(Tree const& actual)
+    {
+        // armv4/armv5 -O3 builds were assuming the arena had its
+        // original size (0). prevent it this way:
+        csubstr expected_arena = actual.arena();
+        C4_DONT_OPTIMIZE(expected_arena);
+        check_tree(actual, expected_arena);
+    }
     void check_tree(Tree const& actual, csubstr expected_arena)
     {
         ASSERT_TRUE(actual.rootref().is_map());
@@ -918,11 +927,21 @@ protected:
         EXPECT_EQ(actual["a"].key(), "a");
         EXPECT_EQ(actual["a"][0].val(), "yaml");
         EXPECT_EQ(actual["a"][1].val(), "example");
-        EXPECT_TRUE(actual["this"].key().is_sub(expected_arena));
-        EXPECT_TRUE(actual["this"].val().is_sub(expected_arena));
-        EXPECT_TRUE(actual["a"].key().is_sub(expected_arena));
-        EXPECT_TRUE(actual["a"][0].val().is_sub(expected_arena));
-        EXPECT_TRUE(actual["a"][1].val().is_sub(expected_arena));
+        #define EXPECT_IN_ARENA(expr, arena)    \
+        {                                       \
+            RYML_TRACE_FMT("is_sub={}\n"        \
+                "    {}=[{}]~~~{}~~~\n"         \
+                "    {}=[{}]~~~{}~~~",          \
+                (expr).is_sub(arena),           \
+                #expr, (expr).len, expr,        \
+                #arena, (arena).len, arena);    \
+            EXPECT_TRUE((expr).is_sub(arena));  \
+        }
+        EXPECT_IN_ARENA(actual["this"].key(), expected_arena);
+        EXPECT_IN_ARENA(actual["this"].val(), expected_arena);
+        EXPECT_IN_ARENA(actual["a"].key(), expected_arena);
+        EXPECT_IN_ARENA(actual["a"][0].val(), expected_arena);
+        EXPECT_IN_ARENA(actual["a"][1].val(), expected_arena);
         if(expected_arena.str != actual.arena().str)
         {
             EXPECT_TRUE(actual.arena().empty());
@@ -1044,45 +1063,61 @@ TEST_F(ParseOverloadYamlTest, in_arena_noparser_1_1)
 {
     const Tree actual = parse_in_arena(cyaml);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_1_2)
 {
     const Tree actual = parse_in_arena(filename, cyaml);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_2_1)
 {
     Tree actual;
     parse_in_arena(cyaml, &actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_2_2)
 {
     Tree actual;
     parse_in_arena(filename, cyaml, &actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_3_1)
 {
     Tree actual;
     parse_in_arena(cyaml, &actual, actual.root_id());
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_3_2)
 {
     Tree actual;
     parse_in_arena(filename, cyaml, &actual, actual.root_id());
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 // workaround for optimizer problem in armv4 and armv5 with -O3: when
-// the calling the parser overloads that take a NodeRef, the compiler
-// optimizes the tree away
+// calling the parser overloads that take a NodeRef, the compiler
+// optimizes the tree away, assuming it did not change.
 static C4_NO_INLINE void ensure_compiler_knows_tree_was_changed(Tree *t)
 {
     C4_DONT_OPTIMIZE(*t);
@@ -1094,7 +1129,11 @@ TEST_F(ParseOverloadYamlTest, in_arena_noparser_4_1)
     parse_in_arena(cyaml, actual.rootref());
     ensure_compiler_knows_tree_was_changed(&actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadYamlTest, in_arena_noparser_4_2)
 {
@@ -1102,7 +1141,11 @@ TEST_F(ParseOverloadYamlTest, in_arena_noparser_4_2)
     parse_in_arena(filename, cyaml, actual.rootref());
     ensure_compiler_knows_tree_was_changed(&actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 
 TEST_F(ParseOverloadYamlTest, in_arena_parser_1_1)
@@ -1179,17 +1222,24 @@ protected:
     void SetUp() override
     {
         NodeRef root = ref.rootref();
-        root |= MAP;
-        root |= FLOW_SL;
+        root.set_map(FLOW_SL);
         NodeRef keyval = root.append_child();
         NodeRef keyseq = root.append_child();
         keyval << key("this") << "is";
         keyseq << key("a");
-        keyseq |= SEQ;
+        keyseq.set_seq();
         keyseq.append_child() << "json";
         keyseq.append_child() << "example";
     }
 
+    void check_tree(Tree const& actual)
+    {
+        // armv4/armv5 -O3 builds were assuming the arena had its
+        // original size (0). prevent it this way:
+        csubstr expected_arena = actual.arena();
+        C4_DONT_OPTIMIZE(expected_arena);
+        check_tree(actual, expected_arena);
+    }
     void check_tree(Tree const& actual, csubstr expected_arena)
     {
         ASSERT_TRUE(actual.rootref().is_map());
@@ -1338,28 +1388,44 @@ TEST_F(ParseOverloadJsonTest, in_arena_noparser_2_1)
     Tree actual;
     parse_json_in_arena(cjson, &actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadJsonTest, in_arena_noparser_2_2)
 {
     Tree actual;
     parse_json_in_arena(filename, cjson, &actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadJsonTest, in_arena_noparser_3_1)
 {
     Tree actual;
     parse_json_in_arena(cjson, &actual, actual.root_id());
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadJsonTest, in_arena_noparser_3_2)
 {
     Tree actual;
     parse_json_in_arena(filename, cjson, &actual, actual.root_id());
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadJsonTest, in_arena_noparser_4_1)
 {
@@ -1367,7 +1433,11 @@ TEST_F(ParseOverloadJsonTest, in_arena_noparser_4_1)
     parse_json_in_arena(cjson, actual.rootref());
     ensure_compiler_knows_tree_was_changed(&actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 TEST_F(ParseOverloadJsonTest, in_arena_noparser_4_2)
 {
@@ -1375,7 +1445,11 @@ TEST_F(ParseOverloadJsonTest, in_arena_noparser_4_2)
     parse_json_in_arena(filename, cjson, actual.rootref());
     ensure_compiler_knows_tree_was_changed(&actual);
     test_compare(actual, ref);
-    check_tree(actual, actual.arena());
+    // in armv4/armv5, this was failing because inside check_tree(),
+    // the arena had len==0!
+    //check_tree(actual, actual.arena());
+    // so do this:
+    check_tree(actual);
 }
 
 TEST_F(ParseOverloadJsonTest, in_arena_parser_1_1)
@@ -1502,10 +1576,10 @@ protected:
     void SetUp() override
     {
         dst_val.rootref().set_val("val");
-        dst_map_flow.rootref() |= MAP|FLOW_SL;
-        dst_map_blck.rootref() |= MAP|BLOCK;
-        dst_seq_flow.rootref() |= SEQ|FLOW_SL;
-        dst_seq_blck.rootref() |= SEQ|BLOCK;
+        dst_map_flow.rootref().set_map(FLOW_SL);
+        dst_map_blck.rootref().set_map(BLOCK);
+        dst_seq_flow.rootref().set_seq(FLOW_SL);
+        dst_seq_blck.rootref().set_seq(BLOCK);
     }
 
 };
@@ -1844,9 +1918,9 @@ TEST_F(ParseToMapFlowTest, empty__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, empty__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(empty), dst);
-    EXPECT_FALSE(dst.has_val());
+    EXPECT_FALSE(dst.readable());
 }
 
 
@@ -1859,9 +1933,9 @@ TEST_F(ParseToMapFlowTest, whitespace__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, whitespace__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(whitespace), dst);
-    EXPECT_FALSE(dst.has_val());
+    EXPECT_FALSE(dst.readable());
 }
 
 
@@ -1876,7 +1950,7 @@ TEST_F(ParseToMapFlowTest, val_plain__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_plain__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_plain), dst);
     const Tree expected = parse_in_arena("dst: this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -1896,7 +1970,7 @@ TEST_F(ParseToMapFlowTest, val_plain_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_plain_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_plain_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -1916,7 +1990,7 @@ TEST_F(ParseToMapFlowTest, val_plain_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_plain_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_plain_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -1936,7 +2010,7 @@ TEST_F(ParseToMapFlowTest, val_squo__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_squo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_squo), dst);
     const Tree expected = parse_in_arena("dst: this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -1956,7 +2030,7 @@ TEST_F(ParseToMapFlowTest, val_squo_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_squo_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_squo_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -1976,7 +2050,7 @@ TEST_F(ParseToMapFlowTest, val_squo_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_squo_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_squo_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -1996,7 +2070,7 @@ TEST_F(ParseToMapFlowTest, val_dquo__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_dquo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_dquo), dst);
     const Tree expected = parse_in_arena("dst: this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2016,7 +2090,7 @@ TEST_F(ParseToMapFlowTest, val_dquo_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_dquo_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_dquo_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2036,7 +2110,7 @@ TEST_F(ParseToMapFlowTest, val_dquo_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_dquo_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_dquo_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2056,7 +2130,7 @@ TEST_F(ParseToMapFlowTest, val_literal__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_literal__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_literal), dst);
     const Tree expected = parse_in_arena("dst: this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2076,7 +2150,7 @@ TEST_F(ParseToMapFlowTest, val_literal_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_literal_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_literal_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2096,7 +2170,7 @@ TEST_F(ParseToMapFlowTest, val_literal_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_literal_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_literal_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2116,7 +2190,7 @@ TEST_F(ParseToMapFlowTest, val_folded__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_folded__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_folded), dst);
     const Tree expected = parse_in_arena("dst: this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2136,7 +2210,7 @@ TEST_F(ParseToMapFlowTest, val_folded_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_folded_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_folded_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2156,7 +2230,7 @@ TEST_F(ParseToMapFlowTest, val_folded_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_folded_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_folded_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2176,7 +2250,7 @@ TEST_F(ParseToMapFlowTest, val_ref__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, val_ref_to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(val_ref), dst);
     const Tree expected = parse_in_arena("dst: *ref");
     _c4dbg_tree("expected", expected);
@@ -2195,7 +2269,7 @@ TEST_F(ParseToMapFlowTest, seq_flow__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, seq_flow__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(seq_flow), dst);
     const Tree expected = parse_in_arena("dst: [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2214,7 +2288,7 @@ TEST_F(ParseToMapFlowTest, seq_flow_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, seq_flow_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(seq_flow_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2233,7 +2307,7 @@ TEST_F(ParseToMapFlowTest, seq_flow_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, seq_flow_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(seq_flow_tag), dst);
     const Tree expected = parse_in_arena("dst: !!seq [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2252,7 +2326,7 @@ TEST_F(ParseToMapFlowTest, seq_blck__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, seq_blck__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(seq_blck), dst);
     const Tree expected = parse_in_arena("dst: [seq, block, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2273,7 +2347,7 @@ TEST_F(ParseToMapFlowTest, map_flow__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_flow__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_flow), dst);
     const Tree expected = parse_in_arena("{dst: {map: flow, yes: it is}}");
     _c4dbg_tree("expected", expected);
@@ -2302,7 +2376,7 @@ TEST_F(ParseToMapFlowTest, map_flow_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_flow_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_flow_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor\n  map: flow\n  yes: it is\n");
     _c4dbg_tree("expected", expected);
@@ -2323,7 +2397,7 @@ TEST_F(ParseToMapFlowTest, map_flow_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_flow_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_flow_tag), dst);
     const Tree expected = parse_in_arena("dst: !!map\n  map: flow\n  yes: it is\n");
     _c4dbg_tree("expected", expected);
@@ -2344,7 +2418,7 @@ TEST_F(ParseToMapFlowTest, map_block_keyless__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_keyless__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_keyless), dst);
     const Tree expected = parse_in_arena("dst : { : block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2365,7 +2439,7 @@ TEST_F(ParseToMapFlowTest, map_block_plain__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_plain__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_plain), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2386,7 +2460,7 @@ TEST_F(ParseToMapFlowTest, map_block_squo__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_squo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_squo), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2407,7 +2481,7 @@ TEST_F(ParseToMapFlowTest, map_block_dquo__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_dquo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_dquo), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2428,7 +2502,7 @@ TEST_F(ParseToMapFlowTest, map_block_literal__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_literal__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_literal), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2449,7 +2523,7 @@ TEST_F(ParseToMapFlowTest, map_block_folded__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_folded__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_folded), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2470,7 +2544,7 @@ TEST_F(ParseToMapFlowTest, map_block_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2491,7 +2565,7 @@ TEST_F(ParseToMapFlowTest, map_block_tag__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_tag), dst);
     const Tree expected = parse_in_arena("dst: !!map {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2512,7 +2586,7 @@ TEST_F(ParseToMapFlowTest, map_block_ref__to__map_flow__root)
 
 TEST_F(ParseToMapFlowTest, map_block_ref__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_flow.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_flow["dst"];
     parse_in_arena(to_csubstr(map_blck_ref), dst);
     const Tree expected = parse_in_arena("dst: {*map : block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -2538,7 +2612,7 @@ TEST_F(ParseToMapBlockTest, val_plain__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_plain__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_plain), dst);
     const Tree expected = parse_in_arena("dst: this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -2558,7 +2632,7 @@ TEST_F(ParseToMapBlockTest, val_plain_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_plain_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_plain_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -2578,7 +2652,7 @@ TEST_F(ParseToMapBlockTest, val_plain_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_plain_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_plain_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a plain val");
     _c4dbg_tree("expected", expected);
@@ -2598,7 +2672,7 @@ TEST_F(ParseToMapBlockTest, val_squo__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_squo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_squo), dst);
     const Tree expected = parse_in_arena("dst: this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -2618,7 +2692,7 @@ TEST_F(ParseToMapBlockTest, val_squo_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_squo_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_squo_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -2638,7 +2712,7 @@ TEST_F(ParseToMapBlockTest, val_squo_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_squo_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_squo_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a squo val");
     _c4dbg_tree("expected", expected);
@@ -2658,7 +2732,7 @@ TEST_F(ParseToMapBlockTest, val_dquo__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_dquo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_dquo), dst);
     const Tree expected = parse_in_arena("dst: this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2678,7 +2752,7 @@ TEST_F(ParseToMapBlockTest, val_dquo_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_dquo_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_dquo_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2698,7 +2772,7 @@ TEST_F(ParseToMapBlockTest, val_dquo_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_dquo_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_dquo_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a dquo val");
     _c4dbg_tree("expected", expected);
@@ -2718,7 +2792,7 @@ TEST_F(ParseToMapBlockTest, val_literal__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_literal__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_literal), dst);
     const Tree expected = parse_in_arena("dst: this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2738,7 +2812,7 @@ TEST_F(ParseToMapBlockTest, val_literal_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_literal_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_literal_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2758,7 +2832,7 @@ TEST_F(ParseToMapBlockTest, val_literal_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_literal_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_literal_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a literal val");
     _c4dbg_tree("expected", expected);
@@ -2778,7 +2852,7 @@ TEST_F(ParseToMapBlockTest, val_folded__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_folded__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_folded), dst);
     const Tree expected = parse_in_arena("dst: this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2798,7 +2872,7 @@ TEST_F(ParseToMapBlockTest, val_folded_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_folded_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_folded_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2818,7 +2892,7 @@ TEST_F(ParseToMapBlockTest, val_folded_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_folded_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_folded_tag), dst);
     const Tree expected = parse_in_arena("dst: !!str this is a folded val");
     _c4dbg_tree("expected", expected);
@@ -2838,7 +2912,7 @@ TEST_F(ParseToMapBlockTest, val_ref__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, val_ref_to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(val_ref), dst);
     const Tree expected = parse_in_arena("dst: *ref");
     _c4dbg_tree("expected", expected);
@@ -2857,7 +2931,7 @@ TEST_F(ParseToMapBlockTest, seq_flow__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, seq_flow__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(seq_flow), dst);
     const Tree expected = parse_in_arena("dst: [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2876,7 +2950,7 @@ TEST_F(ParseToMapBlockTest, seq_flow_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, seq_flow_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(seq_flow_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2895,7 +2969,7 @@ TEST_F(ParseToMapBlockTest, seq_flow_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, seq_flow_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(seq_flow_tag), dst);
     const Tree expected = parse_in_arena("dst: !!seq [seq, flow, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2914,7 +2988,7 @@ TEST_F(ParseToMapBlockTest, seq_blck__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, seq_blck__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(seq_blck), dst);
     const Tree expected = parse_in_arena("dst: [seq, block, yes, it is]");
     _c4dbg_tree("expected", expected);
@@ -2935,7 +3009,7 @@ TEST_F(ParseToMapBlockTest, map_flow__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_flow__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_flow), dst);
     const Tree expected = parse_in_arena("dst:\n  map: flow\n  yes: it is\n");
     _c4dbg_tree("expected", expected);
@@ -2964,7 +3038,7 @@ TEST_F(ParseToMapBlockTest, map_flow_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_flow_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_flow_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor\n  map: flow\n  yes: it is\n");
     _c4dbg_tree("expected", expected);
@@ -2985,7 +3059,7 @@ TEST_F(ParseToMapBlockTest, map_flow_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_flow_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_flow_tag), dst);
     const Tree expected = parse_in_arena("dst: !!map\n  map: flow\n  yes: it is\n");
     _c4dbg_tree("expected", expected);
@@ -3006,7 +3080,7 @@ TEST_F(ParseToMapBlockTest, map_block_keyless__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_keyless__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_keyless), dst);
     const Tree expected = parse_in_arena("dst : { : block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3027,7 +3101,7 @@ TEST_F(ParseToMapBlockTest, map_block_plain__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_plain__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_plain), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3048,7 +3122,7 @@ TEST_F(ParseToMapBlockTest, map_block_squo__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_squo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_squo), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3069,7 +3143,7 @@ TEST_F(ParseToMapBlockTest, map_block_dquo__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_dquo__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_dquo), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3090,7 +3164,7 @@ TEST_F(ParseToMapBlockTest, map_block_literal__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_literal__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_literal), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3111,7 +3185,7 @@ TEST_F(ParseToMapBlockTest, map_block_folded__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_folded__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_folded), dst);
     const Tree expected = parse_in_arena("dst: {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3132,7 +3206,7 @@ TEST_F(ParseToMapBlockTest, map_block_anchor__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_anchor__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_anchor), dst);
     const Tree expected = parse_in_arena("dst: &anchor {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3153,7 +3227,7 @@ TEST_F(ParseToMapBlockTest, map_block_tag__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_tag__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_tag), dst);
     const Tree expected = parse_in_arena("dst: !!map {map: block, yes: it is}");
     _c4dbg_tree("expected", expected);
@@ -3174,7 +3248,7 @@ TEST_F(ParseToMapBlockTest, map_block_ref__to__map_flow__root)
 
 TEST_F(ParseToMapBlockTest, map_block_ref__to__map_flow__new_child)
 {
-    NodeRef dst = dst_map_blck.rootref().append_child({KEY, "dst"});
+    NodeRef dst = dst_map_blck["dst"];
     parse_in_arena(to_csubstr(map_blck_ref), dst);
     const Tree expected = parse_in_arena("dst: {*map : block, yes: it is}");
     _c4dbg_tree("expected", expected);

--- a/test/test_scalar_dquoted.cpp
+++ b/test/test_scalar_dquoted.cpp
@@ -852,9 +852,8 @@ TEST(double_quoted, github253)
     {
         Tree tree;
         NodeRef root = tree.rootref();
-        root |= MAP;
-        root["t"] = "t't\\nt";
-        root["t"] |= VAL_DQUO;
+        root.set_map();
+        root["t"].set_val("t't\\nt", VAL_DQUO);
         std::string s = emitrs_yaml<std::string>(tree);
         Tree tree2 = parse_in_arena(to_csubstr(s));
         EXPECT_EQ(tree2["t"].val(), tree["t"].val());
@@ -862,9 +861,8 @@ TEST(double_quoted, github253)
     {
         Tree tree;
         NodeRef root = tree.rootref();
-        root |= MAP;
-        root["t"] = "t't\\nt";
-        root["t"] |= VAL_SQUO;
+        root.set_map();
+        root["t"].set_val("t't\\nt", VAL_SQUO);
         std::string s = emitrs_yaml<std::string>(tree);
         Tree tree2 = parse_in_arena(to_csubstr(s));
         EXPECT_EQ(tree2["t"].val(), tree["t"].val());
@@ -872,9 +870,8 @@ TEST(double_quoted, github253)
     {
         Tree tree;
         NodeRef root = tree.rootref();
-        root |= MAP;
-        root["s"] = "t\rt";
-        root["s"] |= VAL_DQUO;
+        root.set_map();
+        root["s"].set_val("t\rt", VAL_DQUO);
         std::string s = emitrs_yaml<std::string>(tree);
         EXPECT_EQ(s, "s: \"t\\rt\"\n");
         Tree tree2 = parse_in_arena(to_csubstr(s));

--- a/test/test_scalar_dquoted.cpp
+++ b/test/test_scalar_dquoted.cpp
@@ -453,7 +453,7 @@ TEST(double_quoted, leading_whitespace)
         Tree t = parse_in_arena("\"\"");
         ASSERT_TRUE(t.rootref().is_val());
         ASSERT_TRUE(t.rootref().type().is_val_dquo());
-        t.rootref() = val;
+        t.rootref().set_val(val);
         emitrs_yaml<std::string>(t, &emitted);
         _c4dbgpf("emitted: ~~~{}~~~", to_csubstr(emitted));
     }

--- a/test/test_scalar_literal.cpp
+++ b/test/test_scalar_literal.cpp
@@ -848,9 +848,9 @@ TEST(block_literal, emit_does_not_add_lines_to_multi_at_end_1_0)
     csubstr v0 = "\n";
     csubstr v1 = "\n";
     csubstr v2 = "last";
-    r.append_child() = v0;
-    r.append_child() = v1;
-    r.append_child() = v2;
+    r.append_child().set_val(v0);
+    r.append_child().set_val(v1);
+    r.append_child().set_val(v2);
     test_check_emit_check(t, [&](Tree const& out){
         EXPECT_EQ(out[0].val(), v0);
         EXPECT_EQ(out[1].val(), v1);
@@ -866,9 +866,9 @@ TEST(block_literal, emit_does_not_add_lines_to_multi_at_end_1)
     csubstr v0 = "\n\n";
     csubstr v1 = "\n\n";
     csubstr v2 = "last";
-    r.append_child() = v0;
-    r.append_child() = v1;
-    r.append_child() = v2;
+    r.append_child().set_val(v0);
+    r.append_child().set_val(v1);
+    r.append_child().set_val(v2);
     test_check_emit_check(t, [&](Tree const& out){
         EXPECT_EQ(out[0].val(), v0);
         EXPECT_EQ(out[1].val(), v1);

--- a/test/test_scalar_literal.cpp
+++ b/test/test_scalar_literal.cpp
@@ -844,7 +844,7 @@ TEST(block_literal, emit_does_not_add_lines_to_multi_at_end_1_0)
 {
     Tree t;
     NodeRef r = t.rootref();
-    r |= SEQ|BLOCK;
+    r.set_seq(BLOCK);
     csubstr v0 = "\n";
     csubstr v1 = "\n";
     csubstr v2 = "last";
@@ -862,7 +862,7 @@ TEST(block_literal, emit_does_not_add_lines_to_multi_at_end_1)
 {
     Tree t;
     NodeRef r = t.rootref();
-    r |= SEQ|BLOCK;
+    r.set_seq(BLOCK);
     csubstr v0 = "\n\n";
     csubstr v1 = "\n\n";
     csubstr v2 = "last";

--- a/test/test_scalar_null.cpp
+++ b/test/test_scalar_null.cpp
@@ -777,8 +777,8 @@ TEST(empty_scalar, std_string)
     Tree tree = parse_in_arena("{ser: {}, eq: {}}");
     tree["ser"]["stdstr"] << stdss;
     tree["ser"]["nullss"] << nullss;
-    tree["eq"]["stdstr"] = stdss;
-    tree["eq"]["nullss"] = nullss;
+    tree["eq"]["stdstr"].set_val(stdss);
+    tree["eq"]["nullss"].set_val(nullss);
     EXPECT_EQ(emitrs_yaml<std::string>(tree),
               "{ser: {stdstr: '',nullss: },eq: {stdstr: '',nullss: }}");
 }
@@ -924,42 +924,42 @@ TEST(empty_scalar, build_zero_length_string)
 
     {
         NodeRef quoted = addseq("s-quoted");
-        (quoted.append_child() = ""    ).set_val_style(VAL_SQUO);
+        quoted.append_child().set_val("", VAL_SQUO);
         (quoted.append_child() << ""   ).set_val_style(VAL_SQUO);
-        (quoted.append_child() = empty ).set_val_style(VAL_SQUO);
+        quoted.append_child().set_val(empty, VAL_SQUO);
         (quoted.append_child() << empty).set_val_style(VAL_SQUO);
-        (quoted.append_child() = stdss ).set_val_style(VAL_SQUO);
+        quoted.append_child().set_val(stdss, VAL_SQUO);
         (quoted.append_child() << stdss).set_val_style(VAL_SQUO);
     }
     {
         NodeRef quoted = addseq("d-quoted");
-        {NodeRef r = quoted.append_child(); r = ""      ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r.set_val("", VAL_DQUO);}
         {NodeRef r = quoted.append_child(); r << ""     ; r.set_val_style(VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r = empty   ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r.set_val(empty, VAL_DQUO);}
         {NodeRef r = quoted.append_child(); r << empty  ; r.set_val_style(VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r = stdss   ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r.set_val(stdss, VAL_DQUO);}
         {NodeRef r = quoted.append_child(); r << stdss  ; r.set_val_style(VAL_DQUO);}
     }
     {
         NodeRef quoted_null = addseq("quoted_null");
-        {NodeRef r = quoted_null.append_child(); r = nullss  ; r.set_val_style(VAL_SQUO);}
+        {NodeRef r = quoted_null.append_child(); r.set_val(nullss, VAL_SQUO);}
         {NodeRef r = quoted_null.append_child(); r << nullss ; r.set_val_style(VAL_SQUO);}
         {NodeRef r = quoted_null.append_child(); r << nullptr; r.set_val_style(VAL_SQUO);}
     }
     {
         NodeRef non_quoted = addseq("nonquoted");
-        non_quoted.append_child() = "";
+        non_quoted.append_child().set_val("");
         non_quoted.append_child() << "";
-        non_quoted.append_child() = empty;
+        non_quoted.append_child().set_val(empty);
         non_quoted.append_child() << empty;
-        non_quoted.append_child() = stdss;
+        non_quoted.append_child().set_val(stdss);
         non_quoted.append_child() << stdss;
     }
     {
         NodeRef non_quoted_null = addseq("nonquoted_null");
-        non_quoted_null.append_child() = nullss;
+        non_quoted_null.append_child().set_val(nullss);
         non_quoted_null.append_child() << nullss;
-        non_quoted_null.append_child() = nullptr;
+        non_quoted_null.append_child().set_val(nullptr);
         non_quoted_null.append_child() << nullptr;
     }
 

--- a/test/test_scalar_null.cpp
+++ b/test/test_scalar_null.cpp
@@ -921,30 +921,30 @@ TEST(empty_scalar, build_zero_length_string)
     // = and << must have exactly the same behavior where nullity is
     // regarded
 
+
     {
         NodeRef quoted = addseq("s-quoted");
-        {NodeRef r = quoted.append_child(); r = ""      ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted.append_child(); r << ""     ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted.append_child(); r = empty   ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted.append_child(); r << empty  ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted.append_child(); r = stdss   ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted.append_child(); r << stdss  ; r.set_type(r.type() | VAL_SQUO);}
+        (quoted.append_child() = ""    ).set_val_style(VAL_SQUO);
+        (quoted.append_child() << ""   ).set_val_style(VAL_SQUO);
+        (quoted.append_child() = empty ).set_val_style(VAL_SQUO);
+        (quoted.append_child() << empty).set_val_style(VAL_SQUO);
+        (quoted.append_child() = stdss ).set_val_style(VAL_SQUO);
+        (quoted.append_child() << stdss).set_val_style(VAL_SQUO);
     }
     {
         NodeRef quoted = addseq("d-quoted");
-        {NodeRef r = quoted.append_child(); r = ""      ; r.set_type(r.type() | VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r << ""     ; r.set_type(r.type() | VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r = empty   ; r.set_type(r.type() | VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r << empty  ; r.set_type(r.type() | VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r = stdss   ; r.set_type(r.type() | VAL_DQUO);}
-        {NodeRef r = quoted.append_child(); r << stdss  ; r.set_type(r.type() | VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r = ""      ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r << ""     ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r = empty   ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r << empty  ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r = stdss   ; r.set_val_style(VAL_DQUO);}
+        {NodeRef r = quoted.append_child(); r << stdss  ; r.set_val_style(VAL_DQUO);}
     }
     {
         NodeRef quoted_null = addseq("quoted_null");
-        {NodeRef r = quoted_null.append_child(); r = nullss  ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted_null.append_child(); r << nullss ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted_null.append_child(); r = nullptr ; r.set_type(r.type() | VAL_SQUO);}
-        {NodeRef r = quoted_null.append_child(); r << nullptr; r.set_type(r.type() | VAL_SQUO);}
+        {NodeRef r = quoted_null.append_child(); r = nullss  ; r.set_val_style(VAL_SQUO);}
+        {NodeRef r = quoted_null.append_child(); r << nullss ; r.set_val_style(VAL_SQUO);}
+        {NodeRef r = quoted_null.append_child(); r << nullptr; r.set_val_style(VAL_SQUO);}
     }
     {
         NodeRef non_quoted = addseq("nonquoted");

--- a/test/test_scalar_null.cpp
+++ b/test/test_scalar_null.cpp
@@ -901,8 +901,8 @@ TEST(empty_scalar, build_zero_length_string)
 {
     Tree tr;
     NodeRef root = tr.rootref();
-    root |= MAP;
-    auto addseq = [&root](csubstr name) { NodeRef n = root[name]; n |= SEQ; return n; };
+    root.set_map();
+    auto addseq = [&root](csubstr name) { NodeRef n = root[name]; n.set_seq(); return n; };
 
     // try both with nonnull-zero-length and null-zero-length
     std::string stdstr;

--- a/test/test_serialize.cpp
+++ b/test/test_serialize.cpp
@@ -56,8 +56,8 @@ TEST(serialize, type_as_str)
 {
     c4::yml::Tree t;
 
-    auto r = t.rootref();
-    r |= c4::yml::MAP;
+    c4::yml::NodeRef r = t;
+    r.set_map();
 
     vec2<int> v2in{10, 11};
     vec2<int> v2out{1, 2};
@@ -302,18 +302,18 @@ mapflow: {*id0 : *id1,next: *id2}
 )";
 
     Tree tree;
-    tree.rootref() |= MAP;
-    tree["anchors"] |= SEQ;
+    tree.rootref().set_map();
+    tree["anchors"].set_seq();
     tree["anchors"][0] = "val0";
     tree["anchors"][0].set_val_anchor("id0");
-    tree["anchors"][1] |= MAP;
+    tree["anchors"][1].set_map();
     tree["anchors"][1].set_val_anchor("id1");
     tree["anchors"][1]["key1"] = "val1";
-    tree["anchors"][2] |= SEQ;
+    tree["anchors"][2].set_seq();
     tree["anchors"][2].set_val_anchor("id2");
     tree["anchors"][2][0] = "val2";
     auto setseq = [](NodeRef n, NodeType style){
-        n |= SEQ|style;
+        n.set_seq(style);
         n[0] = "id0";
         n[0].set_val_ref("id0");
         n[1] = "id1";
@@ -322,7 +322,7 @@ mapflow: {*id0 : *id1,next: *id2}
         n[2].set_val_ref("id2");
     };
     auto setmap = [](NodeRef n, NodeType style){
-        n |= MAP|style;
+        n.set_map(style);
         n["*id0"] = "id0";
         n["*id0"].set_key_ref("id0");
         n["*id0"].set_val_ref("id1");
@@ -472,7 +472,7 @@ void test442(csubstr input, csubstr expected, NodeType style_flag)
         T obj = {};  // T is a scalar type like int, char, double, etc.
         tree[0] >> obj;
         Tree out_tree;
-        out_tree.rootref() |= SEQ;
+        out_tree.rootref().set_seq();
         out_tree[0] << obj;
         out_tree[0].set_val_style(style_flag);
         EXPECT_EQ(expected_str, emitrs_yaml<std::string>(out_tree));
@@ -488,7 +488,7 @@ void test442(csubstr input, csubstr expected, NodeType style_flag)
         T obj = {};  // T is a scalar type like int, char, double, etc.
         tree["val"] >> obj;
         Tree out_tree;
-        out_tree.rootref() |= MAP;
+        out_tree.rootref().set_map();
         out_tree["val"] << obj;
         out_tree["val"].set_val_style(style_flag);
         EXPECT_EQ(expected_str, emitrs_yaml<std::string>(out_tree));

--- a/test/test_serialize.cpp
+++ b/test/test_serialize.cpp
@@ -304,29 +304,29 @@ mapflow: {*id0 : *id1,next: *id2}
     Tree tree;
     tree.rootref().set_map();
     tree["anchors"].set_seq();
-    tree["anchors"][0] = "val0";
+    tree["anchors"][0].set_val("val0");
     tree["anchors"][0].set_val_anchor("id0");
     tree["anchors"][1].set_map();
     tree["anchors"][1].set_val_anchor("id1");
-    tree["anchors"][1]["key1"] = "val1";
+    tree["anchors"][1]["key1"].set_val("val1");
     tree["anchors"][2].set_seq();
     tree["anchors"][2].set_val_anchor("id2");
-    tree["anchors"][2][0] = "val2";
+    tree["anchors"][2][0].set_val("val2");
     auto setseq = [](NodeRef n, NodeType style){
         n.set_seq(style);
-        n[0] = "id0";
+        n[0].set_val("id0");
         n[0].set_val_ref("id0");
-        n[1] = "id1";
+        n[1].set_val("id1");
         n[1].set_val_ref("id1");
-        n[2] = "id2";
+        n[2].set_val("id2");
         n[2].set_val_ref("id2");
     };
     auto setmap = [](NodeRef n, NodeType style){
         n.set_map(style);
-        n["*id0"] = "id0";
+        n["*id0"].set_val("id0");
         n["*id0"].set_key_ref("id0");
         n["*id0"].set_val_ref("id1");
-        n["next"] = "id2";
+        n["next"].set_val("id2");
         n["next"].set_val_ref("id2");
     };
     setseq(tree["seq"], BLOCK);

--- a/test/test_style.cpp
+++ b/test/test_style.cpp
@@ -330,7 +330,7 @@ TEST(style, noflags)
     };
     auto setval = [](NodeRef n, csubstr key, csubstr val){
         NodeRef ch = n[key];
-        ch = val;
+        ch.set_val(val);
         test_key_nostyle(ch);
         test_val_nostyle(ch);
     };
@@ -361,18 +361,18 @@ TEST(style, noflags)
         NodeRef n = setcont(r["leading_ws"], MAP);
         {
             NodeRef sl = setcont(n["singleline"], MAP);
-            sl["space"] = " foo";
-            sl["tab"] = "\tfoo";
-            sl["space_and_tab0"] = " \tfoo";
-            sl["space_and_tab1"] = "\t foo";
+            sl["space"].set_val(" foo");
+            sl["tab"].set_val("\tfoo");
+            sl["space_and_tab0"].set_val(" \tfoo");
+            sl["space_and_tab1"].set_val("\t foo");
         }
         {
             NodeRef ml = setcont(n["multiline"], MAP);
-            ml["beg_________"] = "\n \tfoo";
-            ml["beg_mid_____"] = "\n \tfoo\nbar";
-            ml["beg_mid_end1"] = "\n \tfoo\nbar\n";
-            ml["beg_mid_end2"] = "\n \tfoo\nbar\n\n";
-            ml["beg_mid_end3"] = "\n \tfoo\nbar\n\n\n";
+            ml["beg_________"].set_val("\n \tfoo");
+            ml["beg_mid_____"].set_val("\n \tfoo\nbar");
+            ml["beg_mid_end1"].set_val("\n \tfoo\nbar\n");
+            ml["beg_mid_end2"].set_val("\n \tfoo\nbar\n\n");
+            ml["beg_mid_end3"].set_val("\n \tfoo\nbar\n\n\n");
         }
     }
     std::string emitted = emit2str(orig);

--- a/test/test_style.cpp
+++ b/test/test_style.cpp
@@ -323,7 +323,8 @@ void check_same_emit(Tree const& expected)
 TEST(style, noflags)
 {
     auto setcont = [](NodeRef n, NodeType t){
-        n |= t;
+        n.create();
+        n.tree()->_add_flags(n.id(), t);
         test_container_nostyle(n);
         return n;
     };

--- a/test/test_tag.cpp
+++ b/test/test_tag.cpp
@@ -1472,14 +1472,15 @@ TEST(tags, setting)
 {
     Tree t;
     id_type rid = t.root_id();
-    t.to_map(rid);
+    t.set_map(rid);
     t.set_val_tag(rid, "!valtag");
     EXPECT_EQ(t.val_tag(rid), "!valtag");
 
     // a keymap
     {
         id_type child = t.append_child(rid);
-        t.to_seq(child, "key2");
+        t.set_seq(child);
+        t.set_key(child, "key2");
         t.set_key_tag(child, "!keytag");
         t.set_val_tag(child, "!valtag2");
         EXPECT_TRUE(t.has_key(child));
@@ -1492,7 +1493,8 @@ TEST(tags, setting)
     // a keyseq
     {
         id_type child = t.append_child(rid);
-        t.to_seq(child, "key2");
+        t.set_seq(child);
+        t.set_key(child, "key2");
         t.set_key_tag(child, "!keytag");
         t.set_val_tag(child, "!valtag2");
         EXPECT_TRUE(t.has_key(child));
@@ -1505,7 +1507,8 @@ TEST(tags, setting)
     // a keyval
     {
         id_type child = t.append_child(rid);
-        t.to_keyval(child, "key", "val");
+        t.set_key(child, "key");
+        t.set_val(child, "val");
         t.set_key_tag(child, "!keytag");
         t.set_val_tag(child, "!valtag");
         EXPECT_TRUE(t.has_key(child));
@@ -1521,7 +1524,7 @@ TEST(tags, setting)
         id_type seqid = t[1].id();
         ASSERT_TRUE(t.is_seq(seqid));
         id_type child = t.append_child(seqid);
-        t.to_val(child, "val");
+        t.set_val(child, "val");
         t.set_val_tag(child, "!valtag");
         EXPECT_FALSE(t.has_key(child));
         EXPECT_TRUE(t.has_val(child));

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -1117,6 +1117,33 @@ void verify_error_(csubstr src, Function &&fn, ExpectedErrorType errtype=Expecte
 
 
 constexpr const ExpectedErrorType visit = ExpectedErrorType::err_visit;
+
+TEST(Tree, get)
+{
+    Tree t = parse_in_arena("[0, 1, 2, 3]");
+    Tree const& ct = t;
+    {
+        EXPECT_EQ(t.get(NONE), nullptr);
+        EXPECT_EQ(t.id(t.get(NONE)), NONE);
+        EXPECT_EQ(t.id(t.get(0)), 0);
+        EXPECT_EQ(t.id(t.get(1)), 1);
+        EXPECT_EQ(t.id(t.get(2)), 2);
+        EXPECT_EQ(t.id(t.get(3)), 3);
+        EXPECT_EQ(t.id(t.get(4)), 4);
+        verify_assertion(t, [](Tree & tree){ return tree.get(tree.capacity()); }, visit);
+    }
+    {
+        EXPECT_EQ(ct.get(NONE), nullptr);
+        EXPECT_EQ(ct.id(ct.get(NONE)), NONE);
+        EXPECT_EQ(ct.id(ct.get(0)), 0);
+        EXPECT_EQ(ct.id(ct.get(1)), 1);
+        EXPECT_EQ(ct.id(ct.get(2)), 2);
+        EXPECT_EQ(ct.id(ct.get(3)), 3);
+        EXPECT_EQ(ct.id(ct.get(4)), 4);
+        verify_assertion(t, [&](Tree &){ return ct.get(ct.capacity()); }, visit);
+    }
+}
+
 TEST(Tree, ref)
 {
     Tree t = parse_in_arena("[0, 1, 2, 3]");
@@ -1174,11 +1201,13 @@ TEST(Tree, operator_square_brackets_seq)
     Tree t = parse_in_arena("[0, 1, 2, 3, 4]");
     Tree &m = t;
     Tree const& cm = t;
+    EXPECT_EQ(m[0].tree(), &t);
     EXPECT_EQ(m[0].val(), "0");
     EXPECT_EQ(m[1].val(), "1");
     EXPECT_EQ(m[2].val(), "2");
     EXPECT_EQ(m[3].val(), "3");
     EXPECT_EQ(m[4].val(), "4");
+    EXPECT_EQ(cm[0].tree(), &t);
     EXPECT_EQ(cm[0].val(), "0");
     EXPECT_EQ(cm[1].val(), "1");
     EXPECT_EQ(cm[2].val(), "2");
@@ -1187,8 +1216,8 @@ TEST(Tree, operator_square_brackets_seq)
     //
     verify_assertion(t, [&](Tree const&){ return cm[m.capacity()]; }, visit);
     verify_assertion(t, [&](Tree const&){ return cm[NONE]; }, visit);
-    verify_assertion(t, [&](Tree const&){ return cm[0][0]; }, visit);
-    verify_assertion(t, [&](Tree const&){ return cm["a"]; }, visit);
+    verify_assertion(t, [&](Tree const&){ return m[5][0]; }, visit);
+    verify_assertion(t, [&](Tree const&){ return m[5]["a"]; }, visit);
 }
 
 TEST(Tree, operator_square_brackets_map)
@@ -1208,7 +1237,7 @@ TEST(Tree, operator_square_brackets_map)
     EXPECT_EQ(cm["e"].val(), "4");
     //
     verify_assertion(t, [&](Tree const&){ return cm["f"]; }, visit);
-    verify_assertion(t, [&](Tree const&){ return cm["g"]["h"]; }, visit);
+    verify_assertion(t, [&](Tree const&){ return m["f"]["h"]; }, visit);
 }
 
 TEST(Tree, noderef_at_seq)
@@ -1253,7 +1282,7 @@ TEST(Tree, noderef_at_seq)
     EXPECT_EQ(to_be_removed.id(), 5);
     EXPECT_EQ(to_be_removed_orig.id(), 5);
     m.remove_child(to_be_removed);
-    EXPECT_EQ(to_be_removed.id(), 5); // it is stale now
+    EXPECT_EQ(to_be_removed.id(), NONE); // it is stale now
     EXPECT_EQ(to_be_removed_orig.id(), 5); // it is stale now
     EXPECT_EQ(m.num_children(), 4);
     EXPECT_TRUE(m.at(4).is_seed());
@@ -3652,9 +3681,13 @@ seq: &seq [*valref, bar]
     //
     EXPECT_TRUE(t.has_sibling(map_id, "map"));
     EXPECT_TRUE(t.has_sibling(map_id, "seq"));
+    EXPECT_TRUE(t.has_sibling(map_id, map.id()));
+    EXPECT_TRUE(t.has_sibling(map_id, seq.id()));
     EXPECT_FALSE(t.has_sibling(map_id, "..."));
     EXPECT_TRUE(t.has_sibling(seq_id, "map"));
     EXPECT_TRUE(t.has_sibling(seq_id, "seq"));
+    EXPECT_TRUE(t.has_sibling(seq_id, map.id()));
+    EXPECT_TRUE(t.has_sibling(seq_id, seq.id()));
     EXPECT_FALSE(t.has_sibling(seq_id, "..."));
     //
     EXPECT_EQ(t.find_sibling(map_id, "map"), t.find_child(doc_id, "map"));
@@ -3680,9 +3713,17 @@ seq: &seq [*valref, bar]
     //
     EXPECT_TRUE(map.has_sibling("map"));
     EXPECT_TRUE(map.has_sibling("seq"));
+    EXPECT_TRUE(map.has_sibling(map.id()));
+    EXPECT_TRUE(map.has_sibling(seq.id()));
+    EXPECT_TRUE(map.has_sibling(map));
+    EXPECT_TRUE(map.has_sibling(seq));
     EXPECT_FALSE(map.has_sibling("..."));
     EXPECT_TRUE(seq.has_sibling("map"));
     EXPECT_TRUE(seq.has_sibling("seq"));
+    EXPECT_TRUE(seq.has_sibling(map.id()));
+    EXPECT_TRUE(seq.has_sibling(seq.id()));
+    EXPECT_TRUE(seq.has_sibling(map));
+    EXPECT_TRUE(seq.has_sibling(seq));
     EXPECT_FALSE(seq.has_sibling("..."));
     //
     EXPECT_EQ(mmap.find_sibling("map").id(), t.find_sibling(map_id, "map"));
@@ -3694,9 +3735,17 @@ seq: &seq [*valref, bar]
     //
     EXPECT_TRUE(mmap.has_sibling("map"));
     EXPECT_TRUE(mmap.has_sibling("seq"));
+    EXPECT_TRUE(mmap.has_sibling(map.id()));
+    EXPECT_TRUE(mmap.has_sibling(seq.id()));
+    EXPECT_TRUE(mmap.has_sibling(map));
+    EXPECT_TRUE(mmap.has_sibling(seq));
     EXPECT_FALSE(mmap.has_sibling("..."));
     EXPECT_TRUE(mseq.has_sibling("map"));
     EXPECT_TRUE(mseq.has_sibling("seq"));
+    EXPECT_TRUE(mseq.has_sibling(map.id()));
+    EXPECT_TRUE(mseq.has_sibling(seq.id()));
+    EXPECT_TRUE(mseq.has_sibling(map));
+    EXPECT_TRUE(mseq.has_sibling(seq));
     EXPECT_FALSE(mseq.has_sibling("..."));
     //
     verify_assertion(t, [&](Tree const&){ return t.docref(0)["none"].find_sibling("foo"); }, visit);
@@ -4200,10 +4249,40 @@ TEST(Tree, lookup_path_or_modify)
         EXPECT_EQ(dst["a"]["b"]["d"][1].val(), "y");
         EXPECT_EQ(dst["a"]["b"]["d"][2].val(), "z");
     }
-
     {
         Tree t;
-        t.rootref() |= MAP;
+        t.rootref().set_map();
+        ExpectError::check_assert_visit(&t, [&]{
+            (void)t.lookup_path_or_modify("x", "newmap.newseq[notnumber].newmap.newseq[0].first");
+        });
+    }
+    {
+        Tree t;
+        t.rootref().set_map();
+        csubstr bigpath = "newmap.newseq[0].newmap.newseq[0].first";
+        id_type id = t.lookup_path_or_modify("x", bigpath);
+        EXPECT_EQ(t.lookup_path(bigpath).target, id);
+        EXPECT_EQ(t.val(id), "x");
+        bigpath = "newmap.newseq[0].newmap[4]";
+        id = t.lookup_path_or_modify("x", bigpath);
+        t.set_key(id, "haha");
+        EXPECT_EQ(t.lookup_path(bigpath).target, id);
+        EXPECT_EQ(t.val(id), "x");
+        EXPECT_EQ(emitrs_yaml<std::string>(t),
+                  "newmap:\n"
+                  "  newseq:\n"
+                  "    - newmap:\n"
+                  "        newseq:\n"
+                  "          - first: x\n"
+                  "        : \n"
+                  "        : \n"
+                  "        : \n"
+                  "        haha: x\n"
+                  "");
+    }
+    {
+        Tree t;
+        t.rootref().set_map();
         csubstr bigpath = "newmap.newseq[0].newmap.newseq[0].first";
         auto result = t.lookup_path(bigpath);
         EXPECT_EQ(result.target, (id_type)NONE);
@@ -4329,7 +4408,7 @@ TEST(set_root_as_stream, empty_tree)
 TEST(set_root_as_stream, already_with_stream)
 {
     Tree t;
-    t.to_stream(t.root_id());
+    t.set_stream(t.root_id());
     NodeRef r = t.rootref();
     EXPECT_EQ(r.is_stream(), true);
     EXPECT_EQ(r.num_children(), 0u);
@@ -5182,8 +5261,12 @@ TEST(Tree, unfiltered)
     EXPECT_FALSE(tree[4].is_val_unfiltered());
     EXPECT_EQ(tree[3].key(), "literal key");
     EXPECT_EQ(tree[3].val(), "literal val");
+    EXPECT_EQ(tree[3].keysc().scalar, "literal key");
+    EXPECT_EQ(tree[3].valsc().scalar, "literal val");
     EXPECT_EQ(tree[4].key(), "folded key");
     EXPECT_EQ(tree[4].val(), "folded val");
+    EXPECT_EQ(tree[4].keysc().scalar, "folded key");
+    EXPECT_EQ(tree[4].valsc().scalar, "folded val");
     EventHandlerTree evt_handler = {};
     Parser parser(&evt_handler, ParserOptions().scalar_filtering(false));
     const Tree tree2 = parse_in_arena(&parser, style_yaml);

--- a/test/test_tree.cpp
+++ b/test/test_tree.cpp
@@ -12,15 +12,12 @@
 #include <gtest/gtest.h>
 #include <unordered_map>
 
-#if defined(_MSC_VER)
-#   pragma warning(push)
-#   pragma warning(disable: 4389) // signed/unsigned mismatch
-#elif defined(__clang__)
-#   pragma clang diagnostic push
-#   pragma clang diagnostic ignored "-Wdollar-in-identifier-extension"
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic push
-#endif
+C4_SUPPRESS_WARNING_PUSH
+C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated")
+C4_SUPPRESS_WARNING_GCC_CLANG("-Wdeprecated-declarations")
+C4_SUPPRESS_WARNING_MSVC(4996) // deprecated
+C4_SUPPRESS_WARNING_MSVC(4389) // signed/unsigned mismatch
+C4_SUPPRESS_WARNING_CLANG("-Wdollar-in-identifier-extension")
 
 RYML_DEFINE_TEST_MAIN()
 
@@ -4539,8 +4536,7 @@ TEST(set_root_as_stream, root_is_docval)
 {
     Tree t;
     NodeRef r = t.rootref();
-    r.set_type(DOCVAL);
-    r.set_val("bar");
+    r.set_val("bar", DOC);
     r.set_val_tag("<!foo>");
     EXPECT_EQ(r.is_stream(), false);
     EXPECT_EQ(r.is_doc(), true);
@@ -5228,10 +5224,4 @@ Case const* get_case(csubstr /*name*/)
 } // namespace yml
 } // namespace c4
 
-#if defined(_MSC_VER)
-#   pragma warning(pop)
-#elif defined(__clang__)
-#   pragma clang diagnostic pop
-#elif defined(__GNUC__)
-#   pragma GCC diagnostic pop
-#endif
+C4_SUPPRESS_WARNING_POP

--- a/test/testsuite/testsuite_events.cpp
+++ b/test/testsuite/testsuite_events.cpp
@@ -230,7 +230,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 id_type node = tree.append_child(top.tree_node);
                 NodeType as_doc = tree.is_stream(top.tree_node) ? DOC : NOTYPE;
                 _nfo_logf("seq[{}]: child={} val='{}' as_doc=", top.tree_node, node, curr.scalar.maybe_get(), as_doc.type_str());
-                tree.to_val(node, curr.filtered_scalar(&tree), as_doc);
+                tree.set_val(node, curr.filtered_scalar(&tree), as_doc);
                 curr.add_val_props(&tree, node);
             }
             else if(tree.is_map(top.tree_node))
@@ -248,7 +248,8 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                     id_type node = tree.append_child(top.tree_node);
                     NodeType as_doc = tree.is_stream(top.tree_node) ? DOC : NOTYPE;
                     _nfo_logf("map[{}]: child={} key='{}' val='{}' as_doc={}", top.tree_node, node, key.scalar.maybe_get(), curr.scalar.maybe_get(), as_doc.type_str());
-                    tree.to_keyval(node, key.filtered_scalar(&tree), curr.filtered_scalar(&tree), as_doc);
+                    tree.set_key(node, key.filtered_scalar(&tree), as_doc);
+                    tree.set_val(node, curr.filtered_scalar(&tree), as_doc);
                     key.add_key_props(&tree, node);
                     curr.add_val_props(&tree, node);
                     _nfo_logf("clear key='{}'", key.scalar.maybe_get());
@@ -258,7 +259,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
             else
             {
                 _nfo_logf("setting tree_node={} to DOCVAL...", top.tree_node);
-                tree.to_val(top.tree_node, curr.filtered_scalar(&tree), tree.type(top.tree_node));
+                tree.set_val(top.tree_node, curr.filtered_scalar(&tree), tree.type(top.tree_node));
                 curr.add_val_props(&tree, top.tree_node);
             }
         }
@@ -272,7 +273,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 _nfo_logf("node[{}] is seq: set {} as val ref", top.tree_node, alias);
                 ASSERT_FALSE(key);
                 id_type node = tree.append_child(top.tree_node);
-                tree.to_val(node, alias);
+                tree.set_val(node, alias);
                 tree.set_val_ref(node, alias);
             }
             else if(tree.is_map(top.tree_node))
@@ -281,7 +282,8 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 {
                     _nfo_logf("node[{}] is map and key '{}' is pending: set {} as val ref", top.tree_node, key.scalar.maybe_get(), alias);
                     id_type node = tree.append_child(top.tree_node);
-                    tree.to_keyval(node, key.filtered_scalar(&tree), alias);
+                    tree.set_key(node, key.filtered_scalar(&tree));
+                    tree.set_val(node, alias);
                     key.add_key_props(&tree, node);
                     tree.set_val_ref(node, alias);
                     _nfo_logf("clear key='{}'", key);
@@ -349,7 +351,8 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 {
                     _nfo_logf("has key, set to keyseq: parent={} child={} key='{}'", parent, node, key);
                     ASSERT_EQ(tree.is_map(parent) || node == parent, true);
-                    tree.to_seq(node, key.filtered_scalar(&tree), more_flags);
+                    tree.set_key(node, key.filtered_scalar(&tree), more_flags);
+                    tree.set_seq(node, more_flags);
                     key.add_key_props(&tree, node);
                     _nfo_logf("clear key='{}'", key.scalar.maybe_get());
                     key = {};
@@ -360,12 +363,13 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                     {
                         _nfo_logf("has null key, set to keyseq: parent={} child={}", parent, node);
                         ASSERT_EQ(tree.is_map(parent) || node == parent, true);
-                        tree.to_seq(node, csubstr{}, more_flags);
+                        tree.set_key(node, csubstr{}, more_flags);
+                        tree.set_seq(node, more_flags);
                     }
                     else
                     {
                         _nfo_logf("no key, set to seq: parent={} child={}", parent, node);
-                        tree.to_seq(node, more_flags);
+                        tree.set_seq(node, more_flags);
                     }
                 }
             }
@@ -424,7 +428,8 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 {
                     _nfo_logf("has key, set to keymap: parent={} child={} key='{}'", parent, node, key);
                     ASSERT_EQ(tree.is_map(parent) || node == parent, true);
-                    tree.to_map(node, key.filtered_scalar(&tree), more_flags);
+                    tree.set_key(node, key.filtered_scalar(&tree), more_flags);
+                    tree.set_map(node, more_flags);
                     key.add_key_props(&tree, node);
                     _nfo_logf("clear key='{}'", key.scalar.maybe_get());
                     key = {};
@@ -435,12 +440,13 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                     {
                         _nfo_logf("has null key, set to keymap: parent={} child={}", parent, node);
                         ASSERT_EQ(tree.is_map(parent) || node == parent, true);
-                        tree.to_map(node, csubstr{}, more_flags);
+                        tree.set_key(node, csubstr{}, more_flags);
+                        tree.set_map(node, more_flags);
                     }
                     else
                     {
                         _nfo_logf("no key, set to map: parent={} child={}", parent, node);
-                        tree.to_map(node, more_flags);
+                        tree.set_map(node, more_flags);
                     }
                 }
             }
@@ -484,7 +490,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 {
                     _nfo_log("there is already a stream, append a DOC");
                     node = tree.append_child(node);
-                    tree.to_doc(node);
+                    tree.set_doc(node);
                     m_stack.push({node});
                 }
                 else if(is_sep)
@@ -495,7 +501,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                         tree._add_flags(node, STREAM);
                         node = tree.append_child(node);
                         _nfo_logf("create STREAM at {} and add DOC child={}", tree.root_id(), node);
-                        tree.to_doc(node);
+                        tree.set_doc(node);
                         m_stack.push({node});
                     }
                     else
@@ -504,7 +510,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                         tree.set_root_as_stream();
                         node = tree.append_child(tree.root_id());
                         _nfo_logf("added doc as STREAM child: {}", node);
-                        tree.to_doc(node);
+                        tree.set_doc(node);
                         m_stack.push({node});
                     }
                 }
@@ -525,7 +531,7 @@ void parse_events_to_tree(csubstr src, Tree *C4_RESTRICT tree_)
                 ASSERT_NE(parent, (id_type)NONE);
                 node = tree.append_child(parent);
                 _nfo_logf("child DOC={}", node);
-                tree.to_doc(node);
+                tree.set_doc(node);
                 m_stack.push({node});
             }
         }


### PR DESCRIPTION
Clean `Tree` and `NodeRef`:
  - Deprecate `NodeInit`
  - `Tree` and `NodeRef`:
    - deprecate `.to_val()` and friends -- add `.set_val()` and friends.
    - deprecate `operator=(csubstr)` and friends -- use `.set_val()` instead.
    - deprecate `operator|=(NodeType)` and `operator=(NodeType)` -- use appropriate overload `.set_*(T, NodeType)`. For example:
      ```c++
      // before
      node |= MAP|BLOCK;
      node["key"] = "val";
      node["key"] |= VAL_SQUO;
      node["seq"] |= SEQ|FLOW;
      node["seq2"] |= SEQ;
      // now:
      node.set_map(BLOCK);
      node["key"].set_val("val", VAL_SQUO);
      node["seq"].set_seq(FLOW);
      node["seq2"].set_seq();
      ```
    - deprecate `NodeInit` and `NodeScalar` methods (use `.set_*()`)
    - deprecate single-arg `NodeRef::{duplicate,move}(ConstNodeRef)`
    - deprecate `NodeRef::visit()` and `NodeRef::visit_stacked()`
    - add `Tree::arena_rem()`
    - add `RYML_DEFAULT_TREE_ARENA_CAPACITY_START` with default value of 256
  - `parse_*()`: internal simplification, no semantic changes
  
