### PR TITLE
API cleanup: NodeType and int events

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -1,3 +1,14 @@
+- [PR#636](https://github.com/biojppm/rapidyaml/pull/636) **Remove c4core submodule**, and copy c4core files to rapidyaml (and manage sync).
+  - `RYML_STANDALONE` still exists, defaults the same.
+  - Read PR description, and [ext/README.md](https://github.com/biojppm/rapidyaml/tree/master/ext/README.md).
+- [PR#635](https://github.com/biojppm/rapidyaml/pull/635) API cleanup: `NodeType` and `extra::ievt::EventFlags`:
+  - On `Tree` and `NodeRef`, overloads taking `NodeType_e` are now receiving `type_bits`.
+  - This saves operator calls on type queries.
+  - Remove bitwise operators, no longer needed.
+  - Rename `NodeType_e` to `NodeTypeBits` (deprecate `NodeType_e`)
+  - Low impact, no changes should be needed on user code, other than renaming unlikely uses of `NodeType_e`.
+  - Also, for int events:
+    - rename `extra::ievt::EventFlags` to `extra::ievt::EventBits`
 - [PR#620](https://github.com/biojppm/rapidyaml/pull/620) API cleanup: `Tree` and `NodeRef`:
   - Deprecate `NodeInit`
   - `Tree` and `NodeRef`:
@@ -20,8 +31,7 @@
       node["seq2"].set_seq();
       // see the doxygen documentation
       ```
-    - You can disable compiler deprecation warnings from use of these operators: by enabling the cmake variable (or defining the macro) `RYML_WITH_LEGACY
-    _OPERATORS`.
+    - You can disable compiler deprecation warnings from use of these operators: by enabling the cmake variable (or defining the macro) `RYML_WITH_LEGACY_OPERATORS`.
     - deprecate `NodeInit` and `NodeScalar` methods (use `.set_*()`)
     - deprecate single-arg `NodeRef::{duplicate,move}(ConstNodeRef)`
     - deprecate `NodeRef::visit()` and `NodeRef::visit_stacked()`

--- a/doc/doxy_changelog.md
+++ b/doc/doxy_changelog.md
@@ -651,7 +651,7 @@ This handler is meant for use by other programming languages, and it supports co
   - Deserializing an empty quoted string *will not* cause an error.
   - Deserializing an empty string *will* cause an error: the empty string is read in as an empty scalar.
   - Ensure keys are deserialized using all the rules applying to vals.
-  - Added [KEYNIL](@ref c4::yml::NodeType_e::KEYNIL) and [VALNIL](@ref c4::yml::NodeType_e::VALNIL) to [NodeType_e](@ref c4::yml::NodeType_e), used by the parser to mark the key or val as empty. This changed the values of the [NodeType_e](@ref c4::yml::NodeType_e) enumeration.
+  - Added [KEYNIL](@ref c4::yml::NodeTypeBits::KEYNIL) and [VALNIL](@ref c4::yml::NodeTypeBits::VALNIL) to [NodeType_e](@ref c4::yml::NodeTypeBits), used by the parser to mark the key or val as empty. This changed the values of the [NodeType_e](@ref c4::yml::NodeTypeBits) enumeration.
   - Added `.key_is_null()` and `.val_is_null()`:
     - [NodeType](@ref c4::yml::NodeType): [.key_is_null()](@ref c4::yml::NodeType::key_is_null()) and [.val_is_null()](@ref c4::yml::NodeType::val_is_null())
     - [Tree](@ref c4::yml::Tree): [.key_is_null()](@ref c4::yml::Tree::key_is_null()) and [.val_is_null()](@ref c4::yml::Tree::val_is_null())

--- a/src/c4/yml/common.hpp
+++ b/src/c4/yml/common.hpp
@@ -506,6 +506,12 @@ inline csubstr _c4prc(const char &C4_RESTRICT c) // pass by reference!
     }
 }
 
+#if C4_CPP >= 17                                  \
+    || (defined(__GNUC__) && __GNUC__ >= 6)       \
+    || (defined(_MSC_VER) && !defined(__clang__))
+#define RYML_HAS_DEPRECATED_ENUMS__
+#endif
+
 /// @endcond
 
 C4_SUPPRESS_WARNING_GCC_POP

--- a/src/c4/yml/emitter.def.hpp
+++ b/src/c4/yml/emitter.def.hpp
@@ -28,26 +28,19 @@ namespace c4 {
 namespace yml {
 
 namespace detail {
-C4_SUPPRESS_WARNING_GCC_PUSH
-// g++-4.x has problems with the operand types and requires the
-// redundant casting
-#if defined(__GNUC__) && (__GNUC__ < 5) && (!defined(__clang__))
-C4_SUPPRESS_WARNING_GCC("-Wparentheses")
-#endif
 enum : type_bits { // NOLINT
     styles_block_key_ = KEY_LITERAL|KEY_FOLDED,
     styles_block_val_ = VAL_LITERAL|VAL_FOLDED,
-    styles_block_     = ((type_bits)styles_block_key_) | ((type_bits)styles_block_val_), // NOLINT
-    styles_flow_key_  = KEY_STYLE & (~((type_bits)styles_block_key_)), // NOLINT
-    styles_flow_val_  = VAL_STYLE & (~((type_bits)styles_block_val_)), // NOLINT
-    styles_flow_      = ((type_bits)styles_flow_key_) | ((type_bits)styles_flow_val_), // NOLINT
+    styles_block_     = (styles_block_key_ | styles_block_val_),
+    styles_flow_key_  = KEY_STYLE & ~styles_block_key_,
+    styles_flow_val_  = VAL_STYLE & ~styles_block_val_,
+    styles_flow_      = styles_flow_key_ | styles_flow_val_,
     styles_squo_      = KEY_SQUO|VAL_SQUO,
     styles_dquo_      = KEY_DQUO|VAL_DQUO,
     styles_plain_     = KEY_PLAIN|VAL_PLAIN,
     styles_literal_   = KEY_LITERAL|VAL_LITERAL,
     styles_folded_    = KEY_FOLDED|VAL_FOLDED,
 };
-C4_SUPPRESS_WARNING_GCC_POP
 } // namespace detail
 
 
@@ -200,19 +193,20 @@ void Emitter<Writer>::visit_stream_(id_type id)
     ++m_depth;
     for(id_type child = first_child; child != NONE; child = m_tree->next_sibling(child))
     {
+        NodeType ty = m_tree->type(child);
         m_ilevel = 0;
         write_pws_and_pend_(_PWS_NONE);
         top_open_entry_(child);
         visit_doc_(child);
         top_close_entry_(child);
-        if(m_tree->is_val(child))
+        if(ty.is_val())
         {
-            if(m_tree->type(child) & VALNIL)
+            if(ty.m_bits & VALNIL)
                 pend_newl_();
         }
         else if(m_tree->is_container(child))
         {
-            if(m_tree->is_flow(child))
+            if(ty.is_flow())
                 pend_newl_();
         }
         if(m_tree->next_sibling(child) != NONE)
@@ -230,8 +224,8 @@ template<class Writer>
 void Emitter<Writer>::visit_blck_container_(id_type id)
 {
     NodeType ty = m_tree->type(id);
-    if(!(ty & CONTAINER_STYLE))
-        ty |= (m_tree->empty(id) ? FLOW_SL : BLOCK);
+    if(!(ty.m_bits & CONTAINER_STYLE))
+        ty.m_bits |= (m_tree->empty(id) ? FLOW_SL : BLOCK);
     write_pws_and_pend_(_PWS_NONE);
     if(ty.is_flow_sl())
         visit_flow_sl_(id);
@@ -245,8 +239,8 @@ template<class Writer>
 void Emitter<Writer>::visit_flow_container_(id_type id)
 {
     NodeType ty = m_tree->type(id);
-    if(!(ty & CONTAINER_STYLE))
-        ty |= FLOW_SL;
+    if(!(ty.m_bits & CONTAINER_STYLE))
+        ty.m_bits |= FLOW_SL;
     write_pws_and_pend_(_PWS_NONE);
     if(ty.is_flow_mlx())
         visit_flow_ml_(id);
@@ -264,8 +258,8 @@ void Emitter<Writer>::visit_doc_val_(id_type id)
     // appear at 0-indentation
     NodeType ty = m_tree->type(id);
     const csubstr val = m_tree->val(id);
-    type_bits val_style = ty & VAL_STYLE;
-    const bool is_ambiguous = ((ty & VAL_PLAIN) || !val_style)
+    type_bits val_style = ty.m_bits & VAL_STYLE;
+    const bool is_ambiguous = ((ty.m_bits & VAL_PLAIN) || !val_style)
         && (val.begins_with("...") || val.begins_with("---"));
     if(is_ambiguous)
     {
@@ -357,7 +351,8 @@ void Emitter<Writer>::top_open_entry_(id_type node)
 template<class Writer>
 void Emitter<Writer>::top_close_entry_(id_type node)
 {
-    if(m_tree->is_val(node) && !(m_tree->type(node) & VALNIL))
+    NodeType ty = m_tree->type(node);
+    if(ty.is_val() && !(ty.m_bits & VALNIL))
     {
         pend_newl_();
     }
@@ -371,13 +366,13 @@ void Emitter<Writer>::flow_seq_open_entry_(id_type node)
 {
     NodeType ty = m_tree->type(node);
     write_pws_and_pend_(_PWS_NONE);
-    if(ty & VALANCH)
+    if(ty.m_bits & VALANCH)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_('&');
         write_(m_tree->val_anchor(node));
     }
-    if(ty & VALTAG)
+    if(ty.m_bits & VALTAG)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_tag_(m_tree->val_tag(node));
@@ -393,18 +388,18 @@ void Emitter<Writer>::flow_map_open_entry_(id_type node)
     NodeType ty = m_tree->type(node);
     write_pws_and_pend_(_PWS_NONE);
     _RYML_ASSERT_VISIT_(m_tree->callbacks(), ty.has_key(), m_tree, node);
-    if(ty & KEYANCH)
+    if(ty.m_bits & KEYANCH)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_("&");
         write_(m_tree->key_anchor(node));
     }
-    if(ty & KEYTAG)
+    if(ty.m_bits & KEYTAG)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_tag_(m_tree->key_tag(node));
     }
-    if(ty & KEYREF)
+    if(ty.m_bits & KEYREF)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_ref_(m_tree->key(node));
@@ -413,19 +408,19 @@ void Emitter<Writer>::flow_map_open_entry_(id_type node)
     {
         write_pws_and_pend_(_PWS_NONE);
         csubstr key = m_tree->key(node);
-        if(!(ty & (NodeType_e)detail::styles_flow_key_))
-            ty |= scalar_style_choose_flow(key) & (NodeType_e)detail::styles_flow_key_;
-        flow_write_scalar_(key, ty & (NodeType_e)detail::styles_flow_key_);
+        if(!(ty.m_bits & detail::styles_flow_key_))
+            ty.m_bits |= scalar_style_choose_flow(key) & detail::styles_flow_key_;
+        flow_write_scalar_(key, ty.m_bits & detail::styles_flow_key_);
     }
     write_pws_and_pend_(_PWS_SPACE);
     write_(':');
-    if(ty & VALANCH)
+    if(ty.m_bits & VALANCH)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_('&');
         write_(m_tree->val_anchor(node));
     }
-    if(ty & VALTAG)
+    if(ty.m_bits & VALTAG)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_tag_(m_tree->val_tag(node));
@@ -470,8 +465,8 @@ template<class Writer>
 void Emitter<Writer>::flow_pws::start(NodeType ty, size_t max_cols_) noexcept
 {
     max_cols = 0;
-    pend_after_comma = ty & FLOW_SPC ? _PWS_SPACE : _PWS_NONE;
-    if(ty & FLOW_MLN)
+    pend_after_comma = (ty.m_bits & FLOW_SPC) ? _PWS_SPACE : _PWS_NONE;
+    if(ty.m_bits & FLOW_MLN)
     {
         max_cols_ = max_cols_ >= 2 ? max_cols_ : 2;
         // subtract 1 for the comma, and maybe the space from pend_after_comma
@@ -480,7 +475,7 @@ void Emitter<Writer>::flow_pws::start(NodeType ty, size_t max_cols_) noexcept
         static_assert((size_t)_PWS_NONE == 0 && (size_t)_PWS_SPACE == 1, "invalid assumptions");
         active = true;
     }
-    else if(ty & FLOW_ML1)
+    else if(ty.m_bits & FLOW_ML1)
     {
         pend_after_comma = _PWS_NEWL;
     }
@@ -521,14 +516,14 @@ void Emitter<Writer>::blck_seq_open_entry_(id_type node)
     write_pws_and_pend_(_PWS_SPACE); // pend the space after the following dash
     write_('-');
     bool has_tag_or_anchor = false;
-    if(ty & VALANCH)
+    if(ty.m_bits & VALANCH)
     {
         has_tag_or_anchor = true;
         write_pws_and_pend_(_PWS_SPACE);
         write_('&');
         write_(m_tree->val_anchor(node));
     }
-    if(ty & VALTAG)
+    if(ty.m_bits & VALTAG)
     {
         has_tag_or_anchor = true;
         write_pws_and_pend_(_PWS_SPACE);
@@ -536,9 +531,9 @@ void Emitter<Writer>::blck_seq_open_entry_(id_type node)
     }
     if(has_tag_or_anchor && ty.is_container())
     {
-        if(!(ty & CONTAINER_STYLE))
+        if(!(ty.m_bits & CONTAINER_STYLE))
             ty |= BLOCK;
-        if((ty & BLOCK) && m_tree->has_children(node))
+        if((ty.m_bits & BLOCK) && m_tree->has_children(node))
             pend_newl_();
     }
 }
@@ -552,21 +547,21 @@ void Emitter<Writer>::blck_map_open_entry_(id_type node)
     _RYML_ASSERT_VISIT_(m_tree->callbacks(), m_tree->has_key(node), m_tree, node);
     NodeType ty = m_tree->type(node);
     csubstr key = m_tree->key(node);
-    if(!(ty & (KEY_STYLE|KEYREF)))
-        ty |= (scalar_style_choose_block(key) & KEY_STYLE);
+    if(!(ty.m_bits & (KEY_STYLE|KEYREF)))
+        ty.m_bits |= (scalar_style_choose_block(key).m_bits & KEY_STYLE);
     write_pws_and_pend_(_PWS_NONE);
-    if(ty & KEYANCH)
+    if(ty.m_bits & KEYANCH)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_('&');
         write_(m_tree->key_anchor(node));
     }
-    if(ty & KEYTAG)
+    if(ty.m_bits & KEYTAG)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_tag_(m_tree->key_tag(node));
     }
-    if(ty & KEYREF)
+    if(ty.m_bits & KEYREF)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_ref_(key);
@@ -574,34 +569,34 @@ void Emitter<Writer>::blck_map_open_entry_(id_type node)
     else
     {
         write_pws_and_pend_(_PWS_NONE);
-        type_bits use_qmrk = ty & (NodeType_e)detail::styles_block_key_;
+        const type_bits use_qmrk = ty.m_bits & detail::styles_block_key_;
         if(!use_qmrk)
         {
-            blck_write_scalar_(key, ty & KEY_STYLE);
+            blck_write_scalar_(key, ty.m_bits & KEY_STYLE);
         }
         else
         {
             write_("? ");
-            blck_write_scalar_(key, ty & KEY_STYLE);
+            blck_write_scalar_(key, ty.m_bits & KEY_STYLE);
             pend_newl_();
         }
     }
     write_pws_and_pend_(_PWS_SPACE); // pend the space after the colon
     write_(':');
-    if(ty & VALANCH)
+    if(ty.m_bits & VALANCH)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_('&');
         write_(m_tree->val_anchor(node));
     }
-    if(ty & VALTAG)
+    if(ty.m_bits & VALTAG)
     {
         write_pws_and_pend_(_PWS_SPACE);
         write_tag_(m_tree->val_tag(node));
     }
     if(ty.is_container() && m_tree->has_children(node))
     {
-        if(!(ty & CONTAINER_STYLE))
+        if(!(ty.m_bits & CONTAINER_STYLE))
             ty |= BLOCK;
         if(ty.is_block())
             pend_newl_();
@@ -638,9 +633,9 @@ void Emitter<Writer>::visit_blck_seq_(id_type node)
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & VAL_STYLE))
-                    ty |= (scalar_style_choose_block(val) & VAL_STYLE);
-                blck_write_scalar_(val, ty & VAL_STYLE);
+                if(!(ty.m_bits & VAL_STYLE))
+                    ty.m_bits |= (scalar_style_choose_block(val).m_bits & VAL_STYLE);
+                blck_write_scalar_(val, ty.m_bits & VAL_STYLE);
             }
             else
             {
@@ -684,9 +679,9 @@ void Emitter<Writer>::visit_blck_map_(id_type node)
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & VAL_STYLE))
-                    ty |= (scalar_style_choose_block(val) & VAL_STYLE);
-                blck_write_scalar_(val, ty & VAL_STYLE);
+                if(!(ty.m_bits & VAL_STYLE))
+                    ty |= (scalar_style_choose_block(val).m_bits & VAL_STYLE);
+                blck_write_scalar_(val, ty.m_bits & VAL_STYLE);
             }
             else
             {
@@ -724,22 +719,22 @@ void Emitter<Writer>::visit_flow_sl_seq_(id_type node)
         NodeType ty = m_tree->type(child);
         _RYML_ASSERT_VISIT_(m_tree->callbacks(), (ty & (VAL|SEQ|MAP)) || ty == NOTYPE, m_tree, node);
         flow_seq_open_entry_(child);
-        if(ty & VAL)
+        if(ty.m_bits & VAL)
         {
             write_pws_and_pend_(_PWS_NONE);
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & (NodeType_e)detail::styles_flow_val_))
-                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)detail::styles_flow_val_);
-                flow_write_scalar_(val, ty & (NodeType_e)detail::styles_flow_val_);
+                if(!(ty.m_bits & detail::styles_flow_val_))
+                    ty.m_bits |= (scalar_style_choose_flow(val).m_bits & detail::styles_flow_val_);
+                flow_write_scalar_(val, ty.m_bits & detail::styles_flow_val_);
             }
             else
             {
                 write_ref_(val);
             }
         }
-        else if(ty & (SEQ|MAP))
+        else if(ty.m_bits & (SEQ|MAP))
         {
             ++m_depth;
             visit_flow_container_(child);
@@ -772,9 +767,9 @@ void Emitter<Writer>::visit_flow_ml_seq_(id_type node)
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & (NodeType_e)detail::styles_flow_val_))
-                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)detail::styles_flow_val_);
-                flow_write_scalar_(val, ty & (NodeType_e)detail::styles_flow_val_);
+                if(!(ty.m_bits & detail::styles_flow_val_))
+                    ty.m_bits |= (scalar_style_choose_flow(val).m_bits & detail::styles_flow_val_);
+                flow_write_scalar_(val, ty.m_bits & detail::styles_flow_val_);
             }
             else
             {
@@ -816,9 +811,9 @@ void Emitter<Writer>::visit_flow_sl_map_(id_type node)
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & (NodeType_e)detail::styles_flow_val_))
-                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)detail::styles_flow_val_);
-                flow_write_scalar_(val, ty & (NodeType_e)detail::styles_flow_val_);
+                if(!(ty.m_bits & detail::styles_flow_val_))
+                    ty.m_bits |= (scalar_style_choose_flow(val).m_bits & detail::styles_flow_val_);
+                flow_write_scalar_(val, ty.m_bits & detail::styles_flow_val_);
             }
             else
             {
@@ -859,9 +854,9 @@ void Emitter<Writer>::visit_flow_ml_map_(id_type node)
             csubstr val = m_tree->val(child);
             if(!ty.is_val_ref())
             {
-                if(!(ty & (NodeType_e)detail::styles_flow_val_))
-                    ty |= (scalar_style_choose_flow(val) & (NodeType_e)detail::styles_flow_val_);
-                flow_write_scalar_(val, ty & (NodeType_e)detail::styles_flow_val_);
+                if(!(ty.m_bits & detail::styles_flow_val_))
+                    ty.m_bits |= (scalar_style_choose_flow(val).m_bits & detail::styles_flow_val_);
+                flow_write_scalar_(val, ty.m_bits & detail::styles_flow_val_);
             }
             else
             {
@@ -918,7 +913,7 @@ void Emitter<Writer>::visit_flow_sl_(id_type node)
     if(C4_UNLIKELY(m_depth > m_opts.max_depth()))
         _RYML_ERR_VISIT_(m_tree->callbacks(), m_tree, node, "max depth exceeded");
     const NodeType ty = m_tree->type(node);
-    if(ty & SEQ)
+    if(ty.m_bits & SEQ)
     {
         visit_flow_sl_seq_(node);
     }
@@ -941,7 +936,7 @@ void Emitter<Writer>::visit_flow_ml_(id_type node)
     if(C4_UNLIKELY(m_depth > m_opts.max_depth()))
         _RYML_ERR_VISIT_(m_tree->callbacks(), m_tree, node, "max depth exceeded");
     const NodeType ty = m_tree->type(node);
-    if(ty & SEQ)
+    if(ty.m_bits & SEQ)
     {
         visit_flow_ml_seq_(node);
     }
@@ -1470,12 +1465,12 @@ void Emitter<Writer>::json_visit_ml_(id_type id, NodeType ty, id_type depth)
                 {
                     write_(',');
                     const size_t maxcols = m_opts.max_cols();
-                    if((ty & FLOW_MLN) && (m_col+1 < maxcols))
+                    if((ty.m_bits & FLOW_MLN) && (m_col+1 < maxcols))
                     {
-                        if((ty & FLOW_SPC) || m_opts.force_flow_spc())
+                        if((ty.m_bits & FLOW_SPC) || m_opts.force_flow_spc())
                             write_(' ');
                     }
-                    else if((ty & FLOW_ML1) || (m_col+1 >= maxcols))
+                    else if((ty.m_bits & FLOW_ML1) || (m_col+1 >= maxcols))
                     {
                         newl_();
                         indent_(m_ilevel);
@@ -1590,8 +1585,8 @@ void Emitter<Writer>::json_writev_(id_type id, NodeType ty)
     if(val.len)
     {
         // use double quoted style if the style is marked quoted
-        bool dquoted = ((ty & VALQUO)
-                        || (scalar_style_choose_json(val) & SCALAR_DQUO)); // choose the style
+        bool dquoted = ((ty.m_bits & VALQUO)
+                        || (scalar_style_choose_json(val).m_bits & SCALAR_DQUO)); // choose the style
         if(dquoted)
             json_write_scalar_dquo_(val);
         else if(json_maybe_write_naninf_(val))
@@ -1603,7 +1598,7 @@ void Emitter<Writer>::json_writev_(id_type id, NodeType ty)
     }
     else
     {
-        if(val.str || (ty & (VALQUO|VALTAG)))
+        if(val.str || (ty.m_bits & (VALQUO|VALTAG)))
             write_("\"\"");
         else
             write_("null");

--- a/src/c4/yml/error.hpp
+++ b/src/c4/yml/error.hpp
@@ -45,40 +45,34 @@ struct _SubstrWriter
 {
     substr buf;
     size_t pos;
-    _SubstrWriter(substr buf_, size_t pos_=0) : buf(buf_), pos(pos_) { C4_ASSERT(buf.str); }
-    void append(csubstr s)
+    _SubstrWriter(substr buf_, size_t pos_=0) noexcept : buf(buf_), pos(pos_) { C4_ASSERT(buf.str || !buf.len); }
+    void append(csubstr s) RYML_NOEXCEPT
     {
         C4_ASSERT(!s.overlaps(buf));
-        C4_ASSERT(s.str || !s.len);
         if(s.len && pos + s.len <= buf.len)
-        {
-            C4_ASSERT(s.str);
             memcpy(buf.str + pos, s.str, s.len);
-        }
         pos += s.len;
     }
-    void append(char c)
+    void append(char c) noexcept
     {
-        C4_ASSERT(buf.str);
         if(pos < buf.len)
             buf.str[pos] = c;
         ++pos;
     }
-    void append_n(char c, size_t numtimes)
+    void append_n(char c, size_t numtimes) noexcept
     {
-        C4_ASSERT(buf.str);
         if(numtimes && pos + numtimes < buf.len)
             memset(buf.str + pos, c, numtimes);
         pos += numtimes;
     }
-    size_t slack() const { return pos <= buf.len ? buf.len - pos : 0; }
-    size_t excess() const { return pos > buf.len ? pos - buf.len : 0; }
+    size_t slack() const noexcept { return pos <= buf.len ? buf.len - pos : 0; }
+    size_t excess() const noexcept { return pos > buf.len ? pos - buf.len : 0; }
     //! get the part written so far
-    csubstr curr() const { return pos <= buf.len ? buf.first(pos) : buf; }
+    csubstr curr() const noexcept { return pos <= buf.len ? buf.first(pos) : buf; }
     //! get the part that is still free to write to (the remainder)
-    substr rem() const { return pos < buf.len ? buf.sub(pos) : buf.last(0); }
+    substr rem() const noexcept { return pos < buf.len ? buf.sub(pos) : buf.last(0); }
 
-    size_t advance(size_t more) { pos += more; return pos; }
+    size_t advance(size_t more) noexcept { pos += more; return pos; }
 };
 
 

--- a/src/c4/yml/event_handler_tree.hpp
+++ b/src/c4/yml/event_handler_tree.hpp
@@ -279,7 +279,7 @@ public:
         _pop();
     }
 
-    void end_map_flow(bool multiline, NodeType_e multiline_style=FLOW_ML1)
+    void end_map_flow(bool multiline, type_bits multiline_style=FLOW_ML1)
     {
         _c4dbgpf("node[{}]: end_map. multiline={} startline={} endline={}", m_parent->node_id, multiline, m_parent->pos.line, m_curr->pos.line);
         _pop();
@@ -329,7 +329,7 @@ public:
         _pop();
     }
 
-    void end_seq_flow(bool multiline, NodeType_e multiline_style=FLOW_ML1)
+    void end_seq_flow(bool multiline, type_bits multiline_style=FLOW_ML1)
     {
         _c4dbgpf("node[{}]: end_seq. multiline={} startline={} endline={}", m_parent->node_id, multiline, m_parent->pos.line, m_curr->pos.line);
         _pop();

--- a/src/c4/yml/event_handler_tree.hpp
+++ b/src/c4/yml/event_handler_tree.hpp
@@ -684,15 +684,15 @@ public:
 
     C4_ALWAYS_INLINE void _enable__(type_bits bits) noexcept
     {
-        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits | bits);
+        m_curr->tr_data->m_type.m_bits |= bits;
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE void _enable__() noexcept
     {
-        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits | bits);
+        m_curr->tr_data->m_type.m_bits |= bits;
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE void _disable__() noexcept
     {
-        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits & (~bits));
+        m_curr->tr_data->m_type.m_bits &= ~bits;
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE bool _has_any__() const noexcept
     {

--- a/src/c4/yml/event_handler_tree.hpp
+++ b/src/c4/yml/event_handler_tree.hpp
@@ -684,19 +684,19 @@ public:
 
     C4_ALWAYS_INLINE void _enable__(type_bits bits) noexcept
     {
-        m_curr->tr_data->m_type.type = static_cast<NodeType_e>(m_curr->tr_data->m_type.type | bits);
+        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits | bits);
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE void _enable__() noexcept
     {
-        m_curr->tr_data->m_type.type = static_cast<NodeType_e>(m_curr->tr_data->m_type.type | bits);
+        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits | bits);
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE void _disable__() noexcept
     {
-        m_curr->tr_data->m_type.type = static_cast<NodeType_e>(m_curr->tr_data->m_type.type & (~bits));
+        m_curr->tr_data->m_type.m_bits = static_cast<NodeType_e>(m_curr->tr_data->m_type.m_bits & (~bits));
     }
     template<type_bits bits> C4_HOT C4_ALWAYS_INLINE bool _has_any__() const noexcept
     {
-        return (m_curr->tr_data->m_type.type & bits) != 0;
+        return (m_curr->tr_data->m_type.m_bits & bits) != 0;
     }
 
 public:
@@ -733,11 +733,11 @@ public:
         r.m_type = d.m_type;
         static_assert((_VALMASK >> 1u) == _KEYMASK, "required for this function to work");
         static_assert((VAL_STYLE >> 1u) == KEY_STYLE, "required for this function to work");
-        r.m_type.type = ((d.m_type.type & (_VALMASK|VAL_STYLE)) >> 1u);
-        r.m_type.type = (r.m_type.type & ~(_VALMASK|VAL_STYLE));
-        r.m_type.type = (r.m_type.type | KEY);
-        if(d.m_type.type & VALNIL)
-            r.m_type.type = (r.m_type.type | KEYNIL);
+        r.m_type.m_bits = ((d.m_type.m_bits & (_VALMASK|VAL_STYLE)) >> 1u);
+        r.m_type.m_bits = (r.m_type.m_bits & ~(_VALMASK|VAL_STYLE));
+        r.m_type.m_bits = (r.m_type.m_bits | KEY);
+        if(d.m_type.m_bits & VALNIL)
+            r.m_type.m_bits = (r.m_type.m_bits | KEYNIL);
         return r;
     }
 

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -231,9 +231,9 @@ public:
     // vertically aligned to highlight differences.
     // documentation to the right -->
 
-    C4_ALWAYS_INLINE bool type_has_any(NodeType_e bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_any(id_, bits); }  /**< Forward to @ref Tree::type_has_any(). Node must be readable. */
-    C4_ALWAYS_INLINE bool type_has_all(NodeType_e bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_all(id_, bits); }  /**< Forward to @ref Tree::type_has_all(). Node must be readable. */
-    C4_ALWAYS_INLINE bool type_has_none(NodeType_e bits) const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_none(id_, bits); } /**< Forward to @ref Tree::type_has_none(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_any(type_bits bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_any(id_, bits); }  /**< Forward to @ref Tree::type_has_any(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_all(type_bits bits)  const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_all(id_, bits); }  /**< Forward to @ref Tree::type_has_all(). Node must be readable. */
+    C4_ALWAYS_INLINE bool type_has_none(type_bits bits) const RYML_NOEXCEPT { assert_readable__(); return tree_->type_has_none(id_, bits); } /**< Forward to @ref Tree::type_has_none(). Node must be readable. */
 
     C4_ALWAYS_INLINE NodeType key_style()       const RYML_NOEXCEPT { assert_readable__(); return tree_->key_style(id_); } /**< Forward to @ref Tree::key_style(). Node must be readable. */
     C4_ALWAYS_INLINE NodeType val_style()       const RYML_NOEXCEPT { assert_readable__(); return tree_->val_style(id_); } /**< Forward to @ref Tree::val_style(). Node must be readable. */
@@ -1174,9 +1174,9 @@ public:
     void set_key_ref(csubstr key_ref) { create(); m_tree->set_key_ref(m_id, key_ref); }
     void set_val_ref(csubstr val_ref) { create(); m_tree->set_val_ref(m_id, val_ref); }
 
-    void set_container_style(NodeType_e style) { create(); m_tree->set_container_style(m_id, style); }
-    void set_key_style(NodeType_e style) { create(); m_tree->set_key_style(m_id, style); }
-    void set_val_style(NodeType_e style) { create(); m_tree->set_val_style(m_id, style); }
+    void set_container_style(type_bits style) { create(); m_tree->set_container_style(m_id, style); }
+    void set_key_style(type_bits style) { create(); m_tree->set_key_style(m_id, style); }
+    void set_val_style(type_bits style) { create(); m_tree->set_val_style(m_id, style); }
 
     /** @} */
 
@@ -1754,10 +1754,10 @@ public:
     /** @{ */
 
     RYML_LEGACY_OPERATOR(".use the appropriate .set_*() overload")
-    void operator= (NodeType_e t) { create(); m_tree->_p(m_id)->m_type = t; }
+    void operator= (type_bits t) { create(); m_tree->_p(m_id)->m_type = t; }
 
     RYML_LEGACY_OPERATOR(".use the appropriate .set_*() overload")
-    void operator|= (NodeType_e t) { create(); m_tree->_add_flags(m_id, t); }
+    void operator|= (type_bits t) { create(); m_tree->_add_flags(m_id, t); }
 
     RYML_LEGACY_OPERATOR("use .set_val()")
     NodeRef& operator= (csubstr v) { set_val(v); return *this; }

--- a/src/c4/yml/node_type.cpp
+++ b/src/c4/yml/node_type.cpp
@@ -66,71 +66,63 @@ const char* NodeType::type_str(type_bits ty) noexcept
     }
 }
 
+namespace {
+struct type_and_name { const char* str; type_bits bits; };
+constexpr const type_and_name type_names[] = {
+    {"STREAM", STREAM},
+    {"DOC", DOC},
+    // key properties
+    {"KEY", KEY},
+    {"KNIL", KEYNIL},
+    {"KTAG", KEYTAG},
+    {"KANCH", KEYANCH},
+    {"KREF", KEYREF},
+    {"KLITERAL", KEY_LITERAL},
+    {"KFOLDED", KEY_FOLDED},
+    {"KSQUO", KEY_SQUO},
+    {"KDQUO", KEY_DQUO},
+    {"KPLAIN", KEY_PLAIN},
+    {"KUNFILT", KEY_UNFILT},
+    // val properties
+    {"VAL", VAL},
+    {"VNIL", VALNIL},
+    {"VTAG", VALTAG},
+    {"VANCH", VALANCH},
+    {"VREF", VALREF},
+    {"VLITERAL", VAL_LITERAL},
+    {"VFOLDED", VAL_FOLDED},
+    {"VSQUO", VAL_SQUO},
+    {"VDQUO", VAL_DQUO},
+    {"VPLAIN", VAL_PLAIN},
+    {"VUNFILT", VAL_UNFILT},
+    // container properties
+    {"MAP", MAP},
+    {"SEQ", SEQ},
+    {"FLOWSL", FLOW_SL},
+    {"FLOWML1", FLOW_ML1},
+    {"FLOWMLN", FLOW_MLN},
+    {"FLOWSPC", FLOW_SPC},
+    {"BLCK", BLOCK},
+};
+} // namespace
 size_t NodeType::type_str(substr buf, type_bits flags) noexcept
 {
-    size_t pos = 0;
-    bool gotone = false;
-
-    #define _prflag(fl, txt)                                    \
-    do {                                                        \
-        if((flags & (fl)) == (fl))                              \
-        {                                                       \
-            if(gotone)                                          \
-            {                                                   \
-                if(pos + 1 < buf.len)                           \
-                    buf[pos] = '|';                             \
-                ++pos;                                          \
-            }                                                   \
-            csubstr fltxt = txt;                                \
-            if(pos + fltxt.len <= buf.len)                      \
-                memcpy(buf.str + pos, fltxt.str, fltxt.len);    \
-            pos += fltxt.len;                                   \
-            gotone = true;                                      \
-            flags = (flags & ~(fl)); /*remove the flag*/        \
-        }                                                       \
-    } while(0)
-
-    _prflag(STREAM, "STREAM");
-    _prflag(DOC, "DOC");
-    // key properties
-    _prflag(KEY, "KEY");
-    _prflag(KEYNIL, "KNIL");
-    _prflag(KEYTAG, "KTAG");
-    _prflag(KEYANCH, "KANCH");
-    _prflag(KEYREF, "KREF");
-    _prflag(KEY_LITERAL, "KLITERAL");
-    _prflag(KEY_FOLDED, "KFOLDED");
-    _prflag(KEY_SQUO, "KSQUO");
-    _prflag(KEY_DQUO, "KDQUO");
-    _prflag(KEY_PLAIN, "KPLAIN");
-    _prflag(KEY_UNFILT, "KUNFILT");
-    // val properties
-    _prflag(VAL, "VAL");
-    _prflag(VALNIL, "VNIL");
-    _prflag(VALTAG, "VTAG");
-    _prflag(VALANCH, "VANCH");
-    _prflag(VALREF, "VREF");
-    _prflag(VAL_UNFILT, "VUNFILT");
-    _prflag(VAL_LITERAL, "VLITERAL");
-    _prflag(VAL_FOLDED, "VFOLDED");
-    _prflag(VAL_SQUO, "VSQUO");
-    _prflag(VAL_DQUO, "VDQUO");
-    _prflag(VAL_PLAIN, "VPLAIN");
-    _prflag(VAL_UNFILT, "VUNFILT");
-    // container properties
-    _prflag(MAP, "MAP");
-    _prflag(SEQ, "SEQ");
-    _prflag(FLOW_SL, "FLOWSL");
-    _prflag(FLOW_ML1, "FLOWML1");
-    _prflag(FLOW_MLN, "FLOWMLN");
-    _prflag(FLOW_SPC, "FLOWSPC");
-    _prflag(BLOCK, "BLCK");
-    if(pos == 0)
-        _prflag(NOTYPE, "NOTYPE");
-
-    #undef _prflag
-
-    return pos;
+    detail::_SubstrWriter writer(buf);
+    for(type_and_name const tn : type_names)
+    {
+        if((flags & tn.bits) == tn.bits)
+        {
+            if(writer.pos)
+                writer.append('|');
+            writer.append(tn.str);
+            flags = flags & ~tn.bits; // remove the flag
+        }
+    }
+    if(!writer.pos)
+        writer.append("NOTYPE");
+    if(writer.pos < buf.len)
+        buf[writer.pos] = '\0';
+    return writer.pos;
 }
 
 } // namespace yml

--- a/src/c4/yml/node_type.cpp
+++ b/src/c4/yml/node_type.cpp
@@ -9,7 +9,7 @@
 namespace c4 {
 namespace yml {
 
-const char* NodeType::type_str(NodeType_e ty) noexcept
+const char* NodeType::type_str(type_bits ty) noexcept
 {
     switch(ty & _TYMASK)
     {
@@ -66,7 +66,7 @@ const char* NodeType::type_str(NodeType_e ty) noexcept
     }
 }
 
-size_t NodeType::type_str(substr buf, NodeType_e flags) noexcept
+size_t NodeType::type_str(substr buf, type_bits flags) noexcept
 {
     size_t pos = 0;
     bool gotone = false;

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -181,36 +181,26 @@ typedef enum : type_bits { // NOLINT
     CONTAINER_STYLE_BLOCK = BLOCK, ///< alias to @ref BLOCK
     CONTAINER_STYLE       = CONTAINER_STYLE_FLOW|CONTAINER_STYLE_BLOCK, ///< mask of @ref CONTAINER_STYLE_FLOW|@ref CONTAINER_STYLE_BLOCK : all container style flags
     STYLE          = SCALAR_STYLE | CONTAINER_STYLE, ///< mask of @ref SCALAR_STYLE | @ref CONTAINER_STYLE : all style flags
-    /** @cond dev */
     //
     // mixed masks
+    /** @cond dev */
     _KEYMASK = KEY | KEYQUO | KEYANCH | KEYREF | KEYTAG,
     _VALMASK = VAL | VALQUO | VALANCH | VALREF | VALTAG,
     #undef __
-    #if C4_CPP >= 17                                  \
-        || (defined(__GNUC__) && __GNUC__ >= 6)       \
-        || (defined(_MSC_VER) && !defined(__clang__))
-    #define RYML_HAS_DEPRECATED_ENUMS__
+    #ifdef RYML_HAS_DEPRECATED_ENUMS__
     FLOW_ML RYML_DEPRECATED("use one of FLOW_ML{1,N,X}") = FLOW_ML1,
     #endif
     /** @endcond */
 } NodeType_e;
+
 /** @cond dev */
-#if !defined(RYML_HAS_DEPRECATED_ENUMS__)
+#ifndef RYML_HAS_DEPRECATED_ENUMS__
 // defined here because the current c++ standard / compiler cannot
 // handle deprecated enums
 RYML_DEPRECATED("use one of FLOW_ML{1,N,X}")
-constexpr const NodeType_e FLOW_ML = FLOW_ML1;
+constexpr const type_bits FLOW_ML = FLOW_ML1;
 #endif
 /** @endcond */
-
-constexpr C4_ALWAYS_INLINE C4_CONST NodeType_e operator|  (NodeType_e lhs, NodeType_e rhs) noexcept { return (NodeType_e)(((type_bits)lhs) | ((type_bits)rhs)); }
-constexpr C4_ALWAYS_INLINE C4_CONST NodeType_e operator&  (NodeType_e lhs, NodeType_e rhs) noexcept { return (NodeType_e)(((type_bits)lhs) & ((type_bits)rhs)); }
-constexpr C4_ALWAYS_INLINE C4_CONST NodeType_e operator>> (NodeType_e bits, uint32_t n) noexcept { return (NodeType_e)(((type_bits)bits) >> n); }
-constexpr C4_ALWAYS_INLINE C4_CONST NodeType_e operator<< (NodeType_e bits, uint32_t n) noexcept { return (NodeType_e)(((type_bits)bits) << n); }
-constexpr C4_ALWAYS_INLINE C4_CONST NodeType_e operator~  (NodeType_e bits) noexcept { return (NodeType_e)(~(type_bits)bits); }
-C4_ALWAYS_INLINE NodeType_e& operator&= (NodeType_e &subject, NodeType_e bits) noexcept { subject = (NodeType_e)((type_bits)subject & (type_bits)bits); return subject; }
-C4_ALWAYS_INLINE NodeType_e& operator|= (NodeType_e &subject, NodeType_e bits) noexcept { subject = (NodeType_e)((type_bits)subject | (type_bits)bits); return subject; }
 
 
 //-----------------------------------------------------------------------------
@@ -222,29 +212,28 @@ struct RYML_EXPORT NodeType
 {
 public:
 
-    NodeType_e type;
+    type_bits type; // TODO rename to bits
 
 public:
 
     C4_ALWAYS_INLINE NodeType() noexcept : type(NOTYPE) {}
-    C4_ALWAYS_INLINE NodeType(NodeType_e t) noexcept : type(t) {}
-    C4_ALWAYS_INLINE NodeType(type_bits t) noexcept : type((NodeType_e)t) {}
+    C4_ALWAYS_INLINE NodeType(type_bits t) noexcept : type(t) {}
 
-    C4_ALWAYS_INLINE bool has_any(NodeType_e t) const noexcept { return (type & t) != 0u; }
-    C4_ALWAYS_INLINE bool has_all(NodeType_e t) const noexcept { return (type & t) == t; }
-    C4_ALWAYS_INLINE bool has_none(NodeType_e t) const noexcept { return (type & t) == 0; }
+    C4_ALWAYS_INLINE bool has_any(type_bits t) const noexcept { return (type & t) != 0u; }
+    C4_ALWAYS_INLINE bool has_all(type_bits t) const noexcept { return (type & t) == t; }
+    C4_ALWAYS_INLINE bool has_none(type_bits t) const noexcept { return (type & t) == 0; }
 
-    C4_ALWAYS_INLINE void set(NodeType_e t) noexcept { type = t; }
-    C4_ALWAYS_INLINE void add(NodeType_e t) noexcept { type = (type|t); }
-    C4_ALWAYS_INLINE void rem(NodeType_e t) noexcept { type = (type & ~t); }
-    C4_ALWAYS_INLINE void addrem(NodeType_e bits_to_add, NodeType_e bits_to_remove) noexcept { type |= bits_to_add; type &= ~bits_to_remove; }
+    C4_ALWAYS_INLINE void set(type_bits t) noexcept { type = t; }
+    C4_ALWAYS_INLINE void add(type_bits t) noexcept { type = (type|t); }
+    C4_ALWAYS_INLINE void rem(type_bits t) noexcept { type = (type & ~t); }
+    C4_ALWAYS_INLINE void addrem(type_bits bits_to_add, type_bits bits_to_remove) noexcept { type |= bits_to_add; type &= ~bits_to_remove; }
 
     C4_ALWAYS_INLINE void clear() noexcept { type = NOTYPE; }
 
 public:
 
-    C4_ALWAYS_INLINE operator NodeType_e      & C4_RESTRICT ()       noexcept { return type; }
-    C4_ALWAYS_INLINE operator NodeType_e const& C4_RESTRICT () const noexcept { return type; }
+    C4_ALWAYS_INLINE operator type_bits      & C4_RESTRICT ()       noexcept { return type; }
+    C4_ALWAYS_INLINE operator type_bits const& C4_RESTRICT () const noexcept { return type; }
 
 public:
 
@@ -254,17 +243,17 @@ public:
     /** return a preset string based on the node type */
     C4_ALWAYS_INLINE const char *type_str() const noexcept { return type_str(type); }
     /** return a preset string based on the node type */
-    static const char* type_str(NodeType_e t) noexcept;
+    static const char* type_str(type_bits t) noexcept;
 
     /** fill a string with the node type flags. */
     C4_ALWAYS_INLINE size_t type_str(substr buf) const noexcept { return type_str(buf, type); }
     /** fill a string with the node type flags. */
-    static size_t type_str(substr buf, NodeType_e t) noexcept;
+    static size_t type_str(substr buf, type_bits t) noexcept;
 
     /** fill a string with the node type flags. If the string is small, returns {null, len} */
     C4_ALWAYS_INLINE csubstr type_str_sub(substr buf) const noexcept { return type_str_sub(buf, type); }
     /** fill a string with the node type flags. If the string is small, returns {null, len}  */
-    static csubstr type_str_sub(substr buf, NodeType_e t) noexcept
+    static csubstr type_str_sub(substr buf, type_bits t) noexcept
     {
         csubstr ret;
         ret.len = type_str(buf, t);
@@ -338,9 +327,9 @@ public:
     C4_ALWAYS_INLINE NodeType key_style() const noexcept { return (type & (KEY_STYLE)); }
     C4_ALWAYS_INLINE NodeType val_style() const noexcept { return (type & (VAL_STYLE)); }
 
-    C4_ALWAYS_INLINE void set_container_style(NodeType_e style) noexcept { type = ((style & CONTAINER_STYLE) | (type & ~CONTAINER_STYLE)); }
-    C4_ALWAYS_INLINE void set_key_style(NodeType_e style) noexcept { type = ((style & KEY_STYLE) | (type & ~KEY_STYLE)); }
-    C4_ALWAYS_INLINE void set_val_style(NodeType_e style) noexcept { type = ((style & VAL_STYLE) | (type & ~VAL_STYLE)); }
+    C4_ALWAYS_INLINE void set_container_style(type_bits style) noexcept { type = ((style & CONTAINER_STYLE) | (type & ~CONTAINER_STYLE)); }
+    C4_ALWAYS_INLINE void set_key_style(type_bits style) noexcept { type = ((style & KEY_STYLE) | (type & ~KEY_STYLE)); }
+    C4_ALWAYS_INLINE void set_val_style(type_bits style) noexcept { type = ((style & VAL_STYLE) | (type & ~VAL_STYLE)); }
     C4_ALWAYS_INLINE void clear_style() noexcept { type &= ~STYLE; }
 
     /** @} */
@@ -352,9 +341,7 @@ public: // deprecated methods
     RYML_DEPRECATED("use has_val_anchor()")    bool is_val_anchor() const noexcept { return has_val_anchor(); }
     RYML_DEPRECATED("use has_anchor()")        bool is_anchor() const noexcept { return has_anchor(); }
     RYML_DEPRECATED("use has_anchor() || is_ref()") bool is_anchor_or_ref() const noexcept { return has_anchor() || is_ref(); }
-
-    RYML_DEPRECATED("use one of .is_flow_ml{1,n,x}()")
-    bool is_flow_ml() const noexcept { return (type & (FLOW_ML1)) != 0; }
+    RYML_DEPRECATED("use one of .is_flow_ml{1,n,x}()") bool is_flow_ml() const noexcept { return (type & (FLOW_ML1)) != 0; }
     /** @endcond */ // LCOV_EXCL_STOP
 };
 

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -212,28 +212,45 @@ struct RYML_EXPORT NodeType
 {
 public:
 
-    type_bits type; // TODO rename to bits
+    type_bits m_bits;
 
 public:
 
-    C4_ALWAYS_INLINE NodeType() noexcept : type(NOTYPE) {}
-    C4_ALWAYS_INLINE NodeType(type_bits t) noexcept : type(t) {}
+    /** @name auto convert to type_bits
+     * @{ */
 
-    C4_ALWAYS_INLINE bool has_any(type_bits t) const noexcept { return (type & t) != 0u; }
-    C4_ALWAYS_INLINE bool has_all(type_bits t) const noexcept { return (type & t) == t; }
-    C4_ALWAYS_INLINE bool has_none(type_bits t) const noexcept { return (type & t) == 0; }
+    C4_ALWAYS_INLINE operator type_bits      & ()       noexcept { return m_bits; }
+    C4_ALWAYS_INLINE operator type_bits const& () const noexcept { return m_bits; }
 
-    C4_ALWAYS_INLINE void set(type_bits t) noexcept { type = t; }
-    C4_ALWAYS_INLINE void add(type_bits t) noexcept { type = (type|t); }
-    C4_ALWAYS_INLINE void rem(type_bits t) noexcept { type = (type & ~t); }
-    C4_ALWAYS_INLINE void addrem(type_bits bits_to_add, type_bits bits_to_remove) noexcept { type |= bits_to_add; type &= ~bits_to_remove; }
-
-    C4_ALWAYS_INLINE void clear() noexcept { type = NOTYPE; }
+    /** @} */
 
 public:
 
-    C4_ALWAYS_INLINE operator type_bits      & C4_RESTRICT ()       noexcept { return type; }
-    C4_ALWAYS_INLINE operator type_bits const& C4_RESTRICT () const noexcept { return type; }
+    /** @name ctor
+     * @{ */
+
+    C4_ALWAYS_INLINE NodeType() noexcept : m_bits(NOTYPE) {}
+    C4_ALWAYS_INLINE NodeType(type_bits t) noexcept : m_bits(t) {}
+
+    /** @} */
+
+public:
+
+    /** @name query / set
+     * @{ */
+
+    C4_ALWAYS_INLINE bool has_any(type_bits t) const noexcept { return (m_bits & t) != 0u; }
+    C4_ALWAYS_INLINE bool has_all(type_bits t) const noexcept { return (m_bits & t) == t; }
+    C4_ALWAYS_INLINE bool has_none(type_bits t) const noexcept { return (m_bits & t) == 0; }
+
+    C4_ALWAYS_INLINE void set(type_bits t) noexcept { m_bits = t; }
+    C4_ALWAYS_INLINE void add(type_bits t) noexcept { m_bits |= t; }
+    C4_ALWAYS_INLINE void rem(type_bits t) noexcept { m_bits &= ~t; }
+    C4_ALWAYS_INLINE void addrem(type_bits bits_to_add, type_bits bits_to_remove) noexcept { m_bits |= bits_to_add; m_bits &= ~bits_to_remove; }
+
+    C4_ALWAYS_INLINE void clear() noexcept { m_bits = NOTYPE; }
+
+    /** @} */
 
 public:
 
@@ -241,17 +258,17 @@ public:
      * @{ */
 
     /** return a preset string based on the node type */
-    C4_ALWAYS_INLINE const char *type_str() const noexcept { return type_str(type); }
+    C4_ALWAYS_INLINE const char *type_str() const noexcept { return type_str(m_bits); }
     /** return a preset string based on the node type */
     static const char* type_str(type_bits t) noexcept;
 
     /** fill a string with the node type flags. */
-    C4_ALWAYS_INLINE size_t type_str(substr buf) const noexcept { return type_str(buf, type); }
+    C4_ALWAYS_INLINE size_t type_str(substr buf) const noexcept { return type_str(buf, m_bits); }
     /** fill a string with the node type flags. */
     static size_t type_str(substr buf, type_bits t) noexcept;
 
     /** fill a string with the node type flags. If the string is small, returns {null, len} */
-    C4_ALWAYS_INLINE csubstr type_str_sub(substr buf) const noexcept { return type_str_sub(buf, type); }
+    C4_ALWAYS_INLINE csubstr type_str_sub(substr buf) const noexcept { return type_str_sub(buf, m_bits); }
     /** fill a string with the node type flags. If the string is small, returns {null, len}  */
     static csubstr type_str_sub(substr buf, type_bits t) noexcept
     {
@@ -265,72 +282,72 @@ public:
 
 public:
 
-    /** @name node type queries
+    /** @name node type predicates
      * @{ */
 
-    C4_ALWAYS_INLINE bool is_notype()         const noexcept { return type == NOTYPE; }
-    C4_ALWAYS_INLINE bool is_stream()         const noexcept { return ((type & STREAM) == STREAM) != 0; }
-    C4_ALWAYS_INLINE bool is_doc()            const noexcept { return (type & DOC) != 0; }
-    C4_ALWAYS_INLINE bool is_container()      const noexcept { return (type & (MAP|SEQ|STREAM)) != 0; }
-    C4_ALWAYS_INLINE bool is_map()            const noexcept { return (type & MAP) != 0; }
-    C4_ALWAYS_INLINE bool is_seq()            const noexcept { return (type & SEQ) != 0; }
-    C4_ALWAYS_INLINE bool has_key()           const noexcept { return (type & KEY) != 0; }
-    C4_ALWAYS_INLINE bool has_val()           const noexcept { return (type & VAL) != 0; }
-    C4_ALWAYS_INLINE bool is_val()            const noexcept { return (type & KEYVAL) == VAL; }
-    C4_ALWAYS_INLINE bool is_keyval()         const noexcept { return (type & KEYVAL) == KEYVAL; }
-    C4_ALWAYS_INLINE bool key_is_null()       const noexcept { return (type & KEYNIL) != 0; }
-    C4_ALWAYS_INLINE bool val_is_null()       const noexcept { return (type & VALNIL) != 0; }
-    C4_ALWAYS_INLINE bool has_key_tag()       const noexcept { return (type & KEYTAG) != 0; }
-    C4_ALWAYS_INLINE bool has_val_tag()       const noexcept { return (type & VALTAG) != 0; }
-    C4_ALWAYS_INLINE bool has_key_anchor()    const noexcept { return (type & KEYANCH) != 0; }
-    C4_ALWAYS_INLINE bool has_val_anchor()    const noexcept { return (type & VALANCH) != 0; }
-    C4_ALWAYS_INLINE bool has_anchor()        const noexcept { return (type & (KEYANCH|VALANCH)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_ref()        const noexcept { return (type & KEYREF) != 0; }
-    C4_ALWAYS_INLINE bool is_val_ref()        const noexcept { return (type & VALREF) != 0; }
-    C4_ALWAYS_INLINE bool is_ref()            const noexcept { return (type & (KEYREF|VALREF)) != 0; }
+    C4_ALWAYS_INLINE bool is_notype()         const noexcept { return m_bits == NOTYPE; }
+    C4_ALWAYS_INLINE bool is_stream()         const noexcept { return ((m_bits & STREAM) == STREAM) != 0; }
+    C4_ALWAYS_INLINE bool is_doc()            const noexcept { return (m_bits & DOC) != 0; }
+    C4_ALWAYS_INLINE bool is_container()      const noexcept { return (m_bits & (MAP|SEQ|STREAM)) != 0; }
+    C4_ALWAYS_INLINE bool is_map()            const noexcept { return (m_bits & MAP) != 0; }
+    C4_ALWAYS_INLINE bool is_seq()            const noexcept { return (m_bits & SEQ) != 0; }
+    C4_ALWAYS_INLINE bool has_key()           const noexcept { return (m_bits & KEY) != 0; }
+    C4_ALWAYS_INLINE bool has_val()           const noexcept { return (m_bits & VAL) != 0; }
+    C4_ALWAYS_INLINE bool is_val()            const noexcept { return (m_bits & KEYVAL) == VAL; }
+    C4_ALWAYS_INLINE bool is_keyval()         const noexcept { return (m_bits & KEYVAL) == KEYVAL; }
+    C4_ALWAYS_INLINE bool key_is_null()       const noexcept { return (m_bits & KEYNIL) != 0; }
+    C4_ALWAYS_INLINE bool val_is_null()       const noexcept { return (m_bits & VALNIL) != 0; }
+    C4_ALWAYS_INLINE bool has_key_tag()       const noexcept { return (m_bits & KEYTAG) != 0; }
+    C4_ALWAYS_INLINE bool has_val_tag()       const noexcept { return (m_bits & VALTAG) != 0; }
+    C4_ALWAYS_INLINE bool has_key_anchor()    const noexcept { return (m_bits & KEYANCH) != 0; }
+    C4_ALWAYS_INLINE bool has_val_anchor()    const noexcept { return (m_bits & VALANCH) != 0; }
+    C4_ALWAYS_INLINE bool has_anchor()        const noexcept { return (m_bits & (KEYANCH|VALANCH)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_ref()        const noexcept { return (m_bits & KEYREF) != 0; }
+    C4_ALWAYS_INLINE bool is_val_ref()        const noexcept { return (m_bits & VALREF) != 0; }
+    C4_ALWAYS_INLINE bool is_ref()            const noexcept { return (m_bits & (KEYREF|VALREF)) != 0; }
 
-    C4_ALWAYS_INLINE bool is_key_unfiltered() const noexcept { return (type & (KEY_UNFILT)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_unfiltered() const noexcept { return (type & (VAL_UNFILT)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_unfiltered() const noexcept { return (m_bits & (KEY_UNFILT)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_unfiltered() const noexcept { return (m_bits & (VAL_UNFILT)) != 0; }
 
     /** @} */
 
 public:
 
-    /** @name style functions
+    /** @name node style predicates
      * @{ */
 
-    C4_ALWAYS_INLINE bool is_container_styled() const noexcept { return (type & (CONTAINER_STYLE)) != 0; }
-    C4_ALWAYS_INLINE bool is_block() const noexcept { return (type & (BLOCK)) != 0; }
-    C4_ALWAYS_INLINE bool is_flow_sl() const noexcept { return (type & (FLOW_SL)) != 0; }
-    C4_ALWAYS_INLINE bool is_flow_ml1() const noexcept { return (type & (FLOW_ML1)) != 0; }
-    C4_ALWAYS_INLINE bool is_flow_mln() const noexcept { return (type & (FLOW_MLN)) != 0; }
-    C4_ALWAYS_INLINE bool is_flow_mlx() const noexcept { return (type & (FLOW_ML1|FLOW_MLN)) != 0; }
-    C4_ALWAYS_INLINE bool is_flow() const noexcept { return (type & (FLOW_ML1|FLOW_MLN|FLOW_SL)) != 0; }
-    C4_ALWAYS_INLINE bool has_flow_space() const noexcept { return (type & (FLOW_SPC)) != 0; }
+    C4_ALWAYS_INLINE bool is_container_styled() const noexcept { return (m_bits & (CONTAINER_STYLE)) != 0; }
+    C4_ALWAYS_INLINE bool is_block() const noexcept { return (m_bits & (BLOCK)) != 0; }
+    C4_ALWAYS_INLINE bool is_flow_sl() const noexcept { return (m_bits & (FLOW_SL)) != 0; }
+    C4_ALWAYS_INLINE bool is_flow_ml1() const noexcept { return (m_bits & (FLOW_ML1)) != 0; }
+    C4_ALWAYS_INLINE bool is_flow_mln() const noexcept { return (m_bits & (FLOW_MLN)) != 0; }
+    C4_ALWAYS_INLINE bool is_flow_mlx() const noexcept { return (m_bits & (FLOW_ML1|FLOW_MLN)) != 0; }
+    C4_ALWAYS_INLINE bool is_flow() const noexcept { return (m_bits & (FLOW_ML1|FLOW_MLN|FLOW_SL)) != 0; }
+    C4_ALWAYS_INLINE bool has_flow_space() const noexcept { return (m_bits & (FLOW_SPC)) != 0; }
 
-    C4_ALWAYS_INLINE bool is_key_styled() const noexcept { return (type & (KEY_STYLE)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_styled() const noexcept { return (type & (VAL_STYLE)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_literal() const noexcept { return (type & (KEY_LITERAL)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_literal() const noexcept { return (type & (VAL_LITERAL)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_folded() const noexcept { return (type & (KEY_FOLDED)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_folded() const noexcept { return (type & (VAL_FOLDED)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_squo() const noexcept { return (type & (KEY_SQUO)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_squo() const noexcept { return (type & (VAL_SQUO)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_dquo() const noexcept { return (type & (KEY_DQUO)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_dquo() const noexcept { return (type & (VAL_DQUO)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_plain() const noexcept { return (type & (KEY_PLAIN)) != 0; }
-    C4_ALWAYS_INLINE bool is_val_plain() const noexcept { return (type & (VAL_PLAIN)) != 0; }
-    C4_ALWAYS_INLINE bool is_key_quoted() const noexcept { return (type & KEYQUO) != 0; }
-    C4_ALWAYS_INLINE bool is_val_quoted() const noexcept { return (type & VALQUO) != 0; }
-    C4_ALWAYS_INLINE bool is_quoted() const noexcept { return (type & (KEYQUO|VALQUO)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_styled() const noexcept { return (m_bits & (KEY_STYLE)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_styled() const noexcept { return (m_bits & (VAL_STYLE)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_literal() const noexcept { return (m_bits & (KEY_LITERAL)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_literal() const noexcept { return (m_bits & (VAL_LITERAL)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_folded() const noexcept { return (m_bits & (KEY_FOLDED)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_folded() const noexcept { return (m_bits & (VAL_FOLDED)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_squo() const noexcept { return (m_bits & (KEY_SQUO)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_squo() const noexcept { return (m_bits & (VAL_SQUO)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_dquo() const noexcept { return (m_bits & (KEY_DQUO)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_dquo() const noexcept { return (m_bits & (VAL_DQUO)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_plain() const noexcept { return (m_bits & (KEY_PLAIN)) != 0; }
+    C4_ALWAYS_INLINE bool is_val_plain() const noexcept { return (m_bits & (VAL_PLAIN)) != 0; }
+    C4_ALWAYS_INLINE bool is_key_quoted() const noexcept { return (m_bits & KEYQUO) != 0; }
+    C4_ALWAYS_INLINE bool is_val_quoted() const noexcept { return (m_bits & VALQUO) != 0; }
+    C4_ALWAYS_INLINE bool is_quoted() const noexcept { return (m_bits & (KEYQUO|VALQUO)) != 0; }
 
-    C4_ALWAYS_INLINE NodeType key_style() const noexcept { return (type & (KEY_STYLE)); }
-    C4_ALWAYS_INLINE NodeType val_style() const noexcept { return (type & (VAL_STYLE)); }
+    C4_ALWAYS_INLINE NodeType key_style() const noexcept { return (m_bits & (KEY_STYLE)); }
+    C4_ALWAYS_INLINE NodeType val_style() const noexcept { return (m_bits & (VAL_STYLE)); }
 
-    C4_ALWAYS_INLINE void set_container_style(type_bits style) noexcept { type = ((style & CONTAINER_STYLE) | (type & ~CONTAINER_STYLE)); }
-    C4_ALWAYS_INLINE void set_key_style(type_bits style) noexcept { type = ((style & KEY_STYLE) | (type & ~KEY_STYLE)); }
-    C4_ALWAYS_INLINE void set_val_style(type_bits style) noexcept { type = ((style & VAL_STYLE) | (type & ~VAL_STYLE)); }
-    C4_ALWAYS_INLINE void clear_style() noexcept { type &= ~STYLE; }
+    C4_ALWAYS_INLINE void set_container_style(type_bits style) noexcept { m_bits = ((style & CONTAINER_STYLE) | (m_bits & ~CONTAINER_STYLE)); }
+    C4_ALWAYS_INLINE void set_key_style(type_bits style) noexcept { m_bits = ((style & KEY_STYLE) | (m_bits & ~KEY_STYLE)); }
+    C4_ALWAYS_INLINE void set_val_style(type_bits style) noexcept { m_bits = ((style & VAL_STYLE) | (m_bits & ~VAL_STYLE)); }
+    C4_ALWAYS_INLINE void clear_style() noexcept { m_bits &= ~STYLE; }
 
     /** @} */
 
@@ -341,7 +358,7 @@ public: // deprecated methods
     RYML_DEPRECATED("use has_val_anchor()")    bool is_val_anchor() const noexcept { return has_val_anchor(); }
     RYML_DEPRECATED("use has_anchor()")        bool is_anchor() const noexcept { return has_anchor(); }
     RYML_DEPRECATED("use has_anchor() || is_ref()") bool is_anchor_or_ref() const noexcept { return has_anchor() || is_ref(); }
-    RYML_DEPRECATED("use one of .is_flow_ml{1,n,x}()") bool is_flow_ml() const noexcept { return (type & (FLOW_ML1)) != 0; }
+    RYML_DEPRECATED("use one of .is_flow_ml{1,n,x}()") bool is_flow_ml() const noexcept { return (m_bits & (FLOW_ML1)) != 0; }
     /** @endcond */ // LCOV_EXCL_STOP
 };
 

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -191,9 +191,10 @@ typedef enum : type_bits { // NOLINT
     FLOW_ML RYML_DEPRECATED("use one of FLOW_ML{1,N,X}") = FLOW_ML1,
     #endif
     /** @endcond */
-} NodeType_e;
+} NodeTypeBits;
 
 /** @cond dev */
+using NodeType_e RYML_DEPRECATED("use NodeTypeBits") = NodeTypeBits;
 #ifndef RYML_HAS_DEPRECATED_ENUMS__
 // defined here because the current c++ standard / compiler cannot
 // handle deprecated enums
@@ -207,8 +208,8 @@ constexpr const type_bits FLOW_ML = FLOW_ML1;
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** wraps a @ref type_bits mask of @ref NodeType_e flags with some
- * syntactic sugar and predicates */
+/** Wraps a @ref type_bits mask of @ref NodeTypeBits flags with some
+ * syntactic sugar and predicates. */
 struct RYML_EXPORT NodeType
 {
 public:

--- a/src/c4/yml/node_type.hpp
+++ b/src/c4/yml/node_type.hpp
@@ -207,7 +207,8 @@ constexpr const type_bits FLOW_ML = FLOW_ML1;
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
-/** wraps a NodeType_e element with some syntactic sugar and predicates */
+/** wraps a @ref type_bits mask of @ref NodeType_e flags with some
+ * syntactic sugar and predicates */
 struct RYML_EXPORT NodeType
 {
 public:

--- a/src/c4/yml/parse_engine.def.hpp
+++ b/src/c4/yml/parse_engine.def.hpp
@@ -1756,7 +1756,7 @@ void ParseEngine<EventHandler>::_end_map_flow()
     bool multiline = m_evt_handler->m_parent->pos.line < m_evt_handler->m_curr->pos.line;
     size_t orig_indent = m_evt_handler->m_curr->indref;
     _c4dbgpf("mapflow: end, multiline={}", multiline);
-    m_evt_handler->end_map_flow(multiline && m_options.detect_flow_ml(), m_options.flow_ml_style().type);
+    m_evt_handler->end_map_flow(multiline && m_options.detect_flow_ml(), m_options.flow_ml_style().m_bits);
     _end_flow_container(orig_indent, multiline);
 }
 
@@ -1766,7 +1766,7 @@ void ParseEngine<EventHandler>::_end_seq_flow()
     bool multiline = m_evt_handler->m_parent->pos.line < m_evt_handler->m_curr->pos.line;
     size_t orig_indent = m_evt_handler->m_curr->indref;
     _c4dbgpf("seqflow: end, multiline={}", multiline);
-    m_evt_handler->end_seq_flow(multiline && m_options.detect_flow_ml(), m_options.flow_ml_style().type);
+    m_evt_handler->end_seq_flow(multiline && m_options.detect_flow_ml(), m_options.flow_ml_style().m_bits);
     _end_flow_container(orig_indent, multiline);
 }
 

--- a/src/c4/yml/parse_options.hpp
+++ b/src/c4/yml/parse_options.hpp
@@ -32,7 +32,7 @@ private:
     } Flags_e;
 
     uint32_t m_flags = DEFAULTS;
-    NodeType_e m_flow_ml_style = FLOW_ML1;
+    type_bits m_flow_ml_style = FLOW_ML1;
 
     ParserOptions& set_flags_(bool enabled, Flags_e f)
     {

--- a/src/c4/yml/reference_resolver.cpp
+++ b/src/c4/yml/reference_resolver.cpp
@@ -238,7 +238,7 @@ void ReferenceResolver::resolve_()
                     _c4dbgpf("instance[{}:node{}] target.anchor==val.anchor=={}", i, refdata.node, m_tree->val_anchor(refdata.target));
                     _RYML_CHECK_VISIT_(m_tree->m_callbacks, !m_tree->is_container(refdata.target), m_tree, refdata.target);
                     _RYML_CHECK_VISIT_(m_tree->m_callbacks, m_tree->has_val(refdata.target), m_tree, refdata.target);
-                    const type_bits existing_style_flags = VAL_STYLE & m_tree->_p(refdata.target)->m_type.type;
+                    const type_bits existing_style_flags = VAL_STYLE & m_tree->_p(refdata.target)->m_type.m_bits;
                     static_assert((VAL_STYLE >> 1u) == (KEY_STYLE), "bad flags");
                     m_tree->_p(refdata.node)->m_key.scalar = m_tree->val(refdata.target);
                     m_tree->_add_flags(refdata.node, KEY | (existing_style_flags >> 1u));
@@ -249,7 +249,7 @@ void ReferenceResolver::resolve_()
                     _RYML_CHECK_BASIC_(m_tree->m_callbacks, m_tree->key_anchor(refdata.target) == m_tree->key_ref(refdata.node));
                     m_tree->_p(refdata.node)->m_key.scalar = m_tree->key(refdata.target);
                     // keys cannot be containers, so don't inherit container flags
-                    const type_bits existing_style_flags = KEY_STYLE & m_tree->_p(refdata.target)->m_type.type;
+                    const type_bits existing_style_flags = KEY_STYLE & m_tree->_p(refdata.target)->m_type.m_bits;
                     m_tree->_add_flags(refdata.node, KEY | existing_style_flags);
                 }
             }
@@ -263,7 +263,7 @@ void ReferenceResolver::resolve_()
                     _RYML_CHECK_BASIC_(m_tree->m_callbacks, !m_tree->is_container(refdata.target));
                     _RYML_CHECK_BASIC_(m_tree->m_callbacks, m_tree->has_val(refdata.target));
                     // keys cannot be containers, so don't inherit container flags
-                    const type_bits existing_style_flags = (KEY_STYLE) & m_tree->_p(refdata.target)->m_type.type;
+                    const type_bits existing_style_flags = (KEY_STYLE) & m_tree->_p(refdata.target)->m_type.m_bits;
                     static_assert((KEY_STYLE << 1u) == (VAL_STYLE), "bad flags");
                     m_tree->_p(refdata.node)->m_val.scalar = m_tree->key(refdata.target);
                     m_tree->_add_flags(refdata.node, VAL | (existing_style_flags << 1u));

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -857,7 +857,7 @@ void Tree::set_root_as_stream()
     id_type root = root_id();
     if(is_stream(root))
         return;
-    _c4dbgpf("set_root_as_stream. rootty={}", type(root).type);
+    _c4dbgpf("set_root_as_stream. rootty={}", type(root).m_bits);
     bool empty_root = ((type(root) & (SEQ|MAP|VAL)) == 0);
     for(TagDirective &C4_RESTRICT td : m_tag_directives)
     {

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -229,17 +229,17 @@ public:
     /// initialize as an empty node
     NodeInit() : type(NOTYPE), key(), val() {}
     /// initialize as a typed node
-    NodeInit(NodeType_e t) : type(t), key(), val() {}
+    NodeInit(type_bits t) : type(t), key(), val() {}
     /// initialize as a sequence member
     NodeInit(NodeScalar const& v) : type(VAL), key(), val(v) { _add_flags(); }
     /// initialize as a sequence member with explicit type
-    NodeInit(NodeScalar const& v, NodeType_e t) : type(t|VAL), key(), val(v) { _add_flags(); }
+    NodeInit(NodeScalar const& v, type_bits t) : type(t|VAL), key(), val(v) { _add_flags(); }
     /// initialize as a mapping member
     NodeInit(              NodeScalar const& k, NodeScalar const& v) : type(KEYVAL), key(k), val(v) { _add_flags(); }
     /// initialize as a mapping member with explicit type
-    NodeInit(NodeType_e t, NodeScalar const& k, NodeScalar const& v) : type(t), key(k), val(v) { _add_flags(); }
+    NodeInit(type_bits t, NodeScalar const& k, NodeScalar const& v) : type(t), key(k), val(v) { _add_flags(); }
     /// initialize as a mapping member with explicit type (eg for SEQ or MAP)
-    NodeInit(NodeType_e t, NodeScalar const& k                     ) : type(t), key(k), val( ) { _add_flags(KEY); }
+    NodeInit(type_bits t, NodeScalar const& k                     ) : type(t), key(k), val( ) { _add_flags(KEY); }
 
 public:
 
@@ -470,9 +470,9 @@ public:
     /** @name node type predicates */
     /** @{ */
 
-    C4_ALWAYS_INLINE bool type_has_any(id_type node, NodeType_e bits) const { return _p(node)->m_type.has_any(bits); }
-    C4_ALWAYS_INLINE bool type_has_all(id_type node, NodeType_e bits) const { return _p(node)->m_type.has_all(bits); }
-    C4_ALWAYS_INLINE bool type_has_none(id_type node, NodeType_e bits) const { return _p(node)->m_type.has_none(bits); }
+    C4_ALWAYS_INLINE bool type_has_any(id_type node, type_bits bits) const { return _p(node)->m_type.has_any(bits); }
+    C4_ALWAYS_INLINE bool type_has_all(id_type node, type_bits bits) const { return _p(node)->m_type.has_all(bits); }
+    C4_ALWAYS_INLINE bool type_has_none(id_type node, type_bits bits) const { return _p(node)->m_type.has_none(bits); }
 
     C4_ALWAYS_INLINE bool is_stream(id_type node) const { return _p(node)->m_type.is_stream(); }
     C4_ALWAYS_INLINE bool is_doc(id_type node) const { return _p(node)->m_type.is_doc(); }
@@ -647,9 +647,9 @@ public:
     C4_ALWAYS_INLINE NodeType key_style(id_type node) const { _RYML_ASSERT_VISIT_(m_callbacks, has_key(node), this, node); return _p(node)->m_type.key_style(); }
     C4_ALWAYS_INLINE NodeType val_style(id_type node) const { _RYML_ASSERT_VISIT_(m_callbacks, has_val(node) || is_root(node), this, node); return _p(node)->m_type.val_style(); }
 
-    C4_ALWAYS_INLINE void set_container_style(id_type node, NodeType_e style) { _RYML_ASSERT_VISIT_(m_callbacks, is_container(node), this, node); _p(node)->m_type.set_container_style(style); }
-    C4_ALWAYS_INLINE void set_key_style(id_type node, NodeType_e style) { _RYML_ASSERT_VISIT_(m_callbacks, has_key(node), this, node); _p(node)->m_type.set_key_style(style); }
-    C4_ALWAYS_INLINE void set_val_style(id_type node, NodeType_e style) { _RYML_ASSERT_VISIT_(m_callbacks, has_val(node), this, node); _p(node)->m_type.set_val_style(style); }
+    C4_ALWAYS_INLINE void set_container_style(id_type node, type_bits style) { _RYML_ASSERT_VISIT_(m_callbacks, is_container(node), this, node); _p(node)->m_type.set_container_style(style); }
+    C4_ALWAYS_INLINE void set_key_style(id_type node, type_bits style) { _RYML_ASSERT_VISIT_(m_callbacks, has_key(node), this, node); _p(node)->m_type.set_key_style(style); }
+    C4_ALWAYS_INLINE void set_val_style(id_type node, type_bits style) { _RYML_ASSERT_VISIT_(m_callbacks, has_val(node), this, node); _p(node)->m_type.set_val_style(style); }
 
     void clear_style(id_type node, bool recurse=false);
     void set_style_conditionally(id_type node,
@@ -1444,10 +1444,8 @@ public:
     }
     #endif
 
-    void _add_flags(id_type node, NodeType_e f) { NodeData *d = _p(node); type_bits fb = f |  d->m_type; _check_next_flags(node, fb); d->m_type = (NodeType_e) fb; }
-    void _add_flags(id_type node, type_bits  f) { NodeData *d = _p(node); f |= d->m_type; _check_next_flags(node,  f); d->m_type = f; }
-    void _rem_flags(id_type node, NodeType_e f) { NodeData *d = _p(node); type_bits fb = d->m_type & ~f; _check_next_flags(node, fb); d->m_type = (NodeType_e) fb; }
-    void _rem_flags(id_type node, type_bits  f) { NodeData *d = _p(node); f = d->m_type & ~f; _check_next_flags(node,  f); d->m_type = f; }
+    void _add_flags(id_type node, type_bits f) { NodeData *d = _p(node); type_bits fb = f |  d->m_type; _check_next_flags(node, fb); d->m_type = fb; }
+    void _rem_flags(id_type node, type_bits f) { NodeData *d = _p(node); type_bits fb = d->m_type & ~f; _check_next_flags(node, fb); d->m_type = fb; }
 
     id_type _do_reorder(id_type *node, id_type count);
 

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -252,15 +252,15 @@ public:
 
     void _add_flags(type_bits more_flags=0)
     {
-        type = (type|more_flags);
+        type = (type.m_bits|more_flags);
         if( ! key.tag.empty())
-            type = (type|KEYTAG);
+            type = (type.m_bits|KEYTAG);
         if( ! val.tag.empty())
-            type = (type|VALTAG);
+            type = (type.m_bits|VALTAG);
         if( ! key.anchor.empty())
-            type = (type|KEYANCH);
+            type = (type.m_bits|KEYANCH);
         if( ! val.anchor.empty())
-            type = (type|VALANCH);
+            type = (type.m_bits|VALANCH);
     }
 
     bool _check() const

--- a/src_extra/c4/yml/extra/event_handler_ints.hpp
+++ b/src_extra/c4/yml/extra/event_handler_ints.hpp
@@ -35,13 +35,14 @@ namespace extra {
 
 namespace ievt {
 
-/** data type for integer events. This is set to a 32 bit signed
- * integer to allow compatibility with a wide range of processing
- * languages. */
-using DataType = int32_t;
+
+/** data type for integer events bits. This is set to an int32_t integer
+ * to allow compatibility with a wide range of processing languages. */
+using evt_bits = int32_t;
+
 
 /** enumeration of integer event bits. */
-typedef enum : DataType { // NOLINT
+typedef enum : evt_bits { // NOLINT
 
     //-------------------------------------------------------------------------
     // YAML flags
@@ -212,7 +213,7 @@ struct EventHandlerIntsState : public c4::yml::ParserState
  *
  * ```c++
  * using namespace c4::yml::extra::ievt;
- * const DataType arr[] = {       // result of parsing: [a, bb, ccc]
+ * const evt_bits arr[] = {       // result of parsing: [a, bb, ccc]
  *   BSTR,                        // begin stream
  *   BDOC,                        // begin doc
  *   VAL_|BSEQ|FLOW,              // begin seq as val, flow
@@ -295,7 +296,7 @@ i      :        12   |        13       14
  *
  * Here's another example with the result of parsing `a: bb`
  * ```c++
- * const DataType arr[] = {       // result of parsing: `a: bb`
+ * const evt_bits arr[] = {       // result of parsing: `a: bb`
  *   BSTR,                        // begin stream
  *   BDOC,                        // begin doc
  *   VAL_|BMAP|BLCK,              // begin map as val, block
@@ -451,7 +452,7 @@ struct EventHandlerInts : public c4::yml::EventHandlerStack<EventHandlerInts, Ev
     /** @name types
      * @{ */
 
-    using value_type = ievt::DataType;
+    using value_type = ievt::evt_bits;
     using state = EventHandlerIntsState; // our internal state must inherit from parser state
     enum { requires_strings_on_buffers = true }; // NOLINT
 
@@ -460,7 +461,7 @@ struct EventHandlerInts : public c4::yml::EventHandlerStack<EventHandlerInts, Ev
 public:
 
     /** @cond dev */
-    ievt::DataType * m_evt;
+    ievt::evt_bits * m_evt;
     int32_t m_evt_pos;
     int32_t m_evt_prev;
     int32_t m_evt_size;
@@ -491,7 +492,7 @@ public:
     {
     }
 
-    void reset(substr str, substr arena, ievt::DataType *dst, int32_t dst_size)
+    void reset(substr str, substr arena, ievt::evt_bits *dst, int32_t dst_size)
     {
         _stack_reset_root();
         m_curr->flags |= c4::yml::RUNK|c4::yml::RTOP;
@@ -872,15 +873,15 @@ private:
     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, ((i) + 3) < m_evt_size);   \
     if(C4_LIKELY((scalar).is_sub(m_src)))                               \
     {                                                                   \
-        m_evt[(i) + 1] = (ievt::DataType)((scalar).str - m_src.str);    \
+        m_evt[(i) + 1] = (ievt::evt_bits)((scalar).str - m_src.str);    \
     }                                                                   \
     else                                                                \
     {                                                                   \
         m_evt[i] |= ievt::AREN;                                         \
-        m_evt[(i) + 1] = (ievt::DataType)((scalar).str - m_arena.str);  \
+        m_evt[(i) + 1] = (ievt::evt_bits)((scalar).str - m_arena.str);  \
         _c4dbgpf("{}/{}: arena! ->{}", i, m_evt_size, m_evt[(i)+1]);    \
     }                                                                   \
-    m_evt[(i) + 2] = (ievt::DataType)(scalar).len;                      \
+    m_evt[(i) + 2] = (ievt::evt_bits)(scalar).len;                      \
     m_evt[(i) + 3] = ievt::PSTR
     /** @endcond */
 
@@ -1018,7 +1019,7 @@ public:
                     }
                     int32_t num_move = m_evt_pos + 1 - pos;
                     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, num_move > 0);
-                    memmove(m_evt + pos + 1, m_evt + pos, (size_t)num_move * sizeof(ievt::DataType));
+                    memmove(m_evt + pos + 1, m_evt + pos, (size_t)num_move * sizeof(ievt::evt_bits));
                 }
                 m_evt[pos] = ievt::BMAP|ievt::FLOW|ievt::VAL_;
                 // move PSTR to prev
@@ -1054,7 +1055,7 @@ public:
                 {
                     int32_t num_move = m_evt_pos + 1 - pos;
                     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, num_move > 0);
-                    memmove(m_evt + posp1, m_evt + pos, (size_t)num_move * sizeof(ievt::DataType));
+                    memmove(m_evt + posp1, m_evt + pos, (size_t)num_move * sizeof(ievt::evt_bits));
                 }
                 _RYML_ASSERT_BASIC_(m_stack.m_callbacks, posp1 < m_evt_pos);
                 // start the map
@@ -1103,7 +1104,7 @@ public:
                     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, ((m_evt[pos] & ievt::BSEQ) == ievt::BSEQ) || ((m_evt[pos] & ievt::BMAP) == ievt::BMAP));
                     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, num_move > 0);
                     _RYML_ASSERT_BASIC_(m_stack.m_callbacks, 0 == (m_evt[posp1] & ievt::PSTR));
-                    memmove(m_evt + posp1, m_evt + pos, (size_t)num_move * sizeof(ievt::DataType));
+                    memmove(m_evt + posp1, m_evt + pos, (size_t)num_move * sizeof(ievt::evt_bits));
                     m_evt[pos] = ievt::VAL_|ievt::BMAP|ievt::BLCK;
                     m_evt[posp1] &= ~ievt::VAL_;
                     m_evt[posp1] |= ievt::KEY_;
@@ -1194,7 +1195,7 @@ public:
         return (!str.str || str.is_sub(m_src) || str.is_sub(m_arena));
     }
 
-    C4_ALWAYS_INLINE void _send_flag_only_(ievt::DataType flags)
+    C4_ALWAYS_INLINE void _send_flag_only_(ievt::evt_bits flags)
     {
         _c4dbgpf("{}/{}: flag only", m_evt_pos, m_evt_size);
         if(m_evt_pos < m_evt_size)
@@ -1206,7 +1207,7 @@ public:
             m_evt[m_evt_pos] = {};
     }
 
-    C4_ALWAYS_INLINE void _send_str_(csubstr scalar, ievt::DataType flags)
+    C4_ALWAYS_INLINE void _send_str_(csubstr scalar, ievt::evt_bits flags)
     {
         _c4dbgpf("{}/{}: send str", m_evt_pos, m_evt_size);
         if(m_evt_pos + 3 < m_evt_size)
@@ -1238,7 +1239,7 @@ public:
         _RYML_ASSERT_BASIC_(m_stack.m_callbacks, pos < m_evt_size); // it's safe to read from the array
         while(pos >= 0)
         {
-            ievt::DataType e = m_evt[pos];
+            ievt::evt_bits e = m_evt[pos];
             if((e & ievt::BDOC) == ievt::BDOC)
                 return pos;
             pos -= (e & ievt::PSTR) ? 3 : 1;
@@ -1246,7 +1247,7 @@ public:
         return -1; // LCOV_EXCL_LINE
     }
 
-    int32_t _find_matching_open(ievt::DataType open, ievt::DataType close, int32_t pos) const
+    int32_t _find_matching_open(ievt::evt_bits open, ievt::evt_bits close, int32_t pos) const
     {
         _c4dbgpf("find_matching: start at {}", pos);
         _RYML_ASSERT_BASIC_(m_stack.m_callbacks, pos < m_evt_size);
@@ -1256,7 +1257,7 @@ public:
         uint32_t count = 0;
         while(pos >= 0)
         {
-            ievt::DataType e = m_evt[pos];
+            ievt::evt_bits e = m_evt[pos];
             _c4dbgpf("find_matching: pos={} count={} e={}", pos, count, m_evt[pos]);
             if((e & close) == close)
             {

--- a/src_extra/c4/yml/extra/event_handler_ints.hpp
+++ b/src_extra/c4/yml/extra/event_handler_ints.hpp
@@ -129,6 +129,11 @@ typedef enum : evt_bits { // NOLINT
 
 } EventBits;
 
+/** @cond dev */
+using DataType RYML_DEPRECATED("use evt_bits") = evt_bits;
+using EventFlags RYML_DEPRECATED("use EventBits") = EventBits;
+/** @endcond */
+
 } // namespace ievt
 
 /** @} */
@@ -684,7 +689,7 @@ public:
         _send_flag_only_(ievt::EMAP);
     }
 
-    void end_map_flow(bool /*multiline*/, NodeType_e /*multiline_style*/=FLOW_ML1)
+    void end_map_flow(bool /*multiline*/, type_bits /*multiline_style*/=FLOW_ML1)
     {
         _pop();
         _send_flag_only_(ievt::EMAP);
@@ -737,7 +742,7 @@ public:
         _send_flag_only_(ievt::ESEQ);
     }
 
-    void end_seq_flow(bool /*multiline*/, NodeType_e /*multiline_style*/=FLOW_ML1)
+    void end_seq_flow(bool /*multiline*/, type_bits /*multiline_style*/=FLOW_ML1)
     {
         _pop();
         _send_flag_only_(ievt::ESEQ);

--- a/src_extra/c4/yml/extra/event_handler_ints.hpp
+++ b/src_extra/c4/yml/extra/event_handler_ints.hpp
@@ -5,7 +5,7 @@
  * integer buffer with a very compact representation of the YAML tree
  * in a source buffer. This is not part of the main rapidyaml library.
  *
- * @see c4::yml::extra::ievt::EventFlags
+ * @see c4::yml::extra::ievt::EventBits
  * @see c4::yml::extra::EventHandlerInts
  * */
 
@@ -127,7 +127,7 @@ typedef enum : evt_bits { // NOLINT
     /// a mask of all bits in this enumeration
     MASK = (LAST << 1) - 1,
 
-} EventFlags;
+} EventBits;
 
 } // namespace ievt
 
@@ -195,7 +195,7 @@ struct EventHandlerIntsState : public c4::yml::ParserState
 
 /** A parser event handler that creates a compact representation of
  * the YAML tree in a contiguous buffer of integers. The integers are
- * @ref ievt::EventFlags containing masks (to represent events),
+ * @ref ievt::EventBits containing masks (to represent events),
  * interleaved with offset+length (to represent strings in the source
  * buffer).
  *
@@ -204,7 +204,7 @@ struct EventHandlerIntsState : public c4::yml::ParserState
  * tree parser, because the resulting data structure is much simpler.
  *
  * The resulting integer buffer is a linear array of integers containing
- * events (as a mask of @ref ievt::EventFlags), which in some cases (see
+ * events (as a mask of @ref ievt::EventBits), which in some cases (see
  * @ref ievt::WSTR) are followed by an encoded string (encoded as an
  * offset and length to the parsed source buffer).
  *

--- a/src_extra/c4/yml/extra/ints_to_testsuite.cpp
+++ b/src_extra/c4/yml/extra/ints_to_testsuite.cpp
@@ -32,11 +32,11 @@ namespace extra {
 C4_NODISCARD RYML_EXPORT
 size_t events_ints_to_testsuite(csubstr parsed_yaml, // NOLINT(*-use-internal-linkage)
                                 csubstr arena,
-                                ievt::DataType const* evts_ints,
-                                ievt::DataType evts_ints_sz,
+                                ievt::evt_bits const* evts_ints,
+                                ievt::evt_bits evts_ints_sz,
                                 substr evts_test_suite)
 {
-    auto getstr = [&](ievt::DataType i){
+    auto getstr = [&](ievt::evt_bits i){
         bool in_arena = evts_ints[i] & ievt::AREN;
         csubstr region = !in_arena ? parsed_yaml : arena;
         return region.sub((size_t)evts_ints[i+1], (size_t)evts_ints[i+2]);
@@ -102,8 +102,8 @@ size_t events_ints_to_testsuite(csubstr parsed_yaml, // NOLINT(*-use-internal-li
         append(evt);
         append_esc(val);
     };
-    ievt::DataType evt = 0;
-    for(ievt::DataType i = 0; i < evts_ints_sz; i += (evt & ievt::WSTR) ? 3 : 1)
+    ievt::evt_bits evt = 0;
+    for(ievt::evt_bits i = 0; i < evts_ints_sz; i += (evt & ievt::WSTR) ? 3 : 1)
     {
         evt = evts_ints[i];
         if(evt & ievt::SCLR)

--- a/src_extra/c4/yml/extra/ints_to_testsuite.hpp
+++ b/src_extra/c4/yml/extra/ints_to_testsuite.hpp
@@ -28,8 +28,8 @@ namespace extra {
 C4_NODISCARD RYML_EXPORT
 size_t events_ints_to_testsuite(csubstr parsed_yaml,
                                 csubstr arena,
-                                ievt::DataType const* evts_ints,
-                                ievt::DataType evts_ints_sz,
+                                ievt::evt_bits const* evts_ints,
+                                ievt::evt_bits evts_ints_sz,
                                 substr evts_testsuite);
 
 
@@ -38,8 +38,8 @@ size_t events_ints_to_testsuite(csubstr parsed_yaml,
 template<class Container>
 void events_ints_to_testsuite(csubstr parsed_yaml,
                               csubstr arena,
-                              ievt::DataType const* evts_ints,
-                              ievt::DataType evts_ints_sz,
+                              ievt::evt_bits const* evts_ints,
+                              ievt::evt_bits evts_ints_sz,
                               Container *evts_testsuite)
 {
     size_t len = events_ints_to_testsuite(parsed_yaml, arena, evts_ints, evts_ints_sz, to_substr(*evts_testsuite));
@@ -57,8 +57,8 @@ void events_ints_to_testsuite(csubstr parsed_yaml,
 template<class Container>
 Container events_ints_to_testsuite(csubstr parsed_yaml,
                                    csubstr arena,
-                                   ievt::DataType const* evts_ints,
-                                   ievt::DataType evts_ints_sz)
+                                   ievt::evt_bits const* evts_ints,
+                                   ievt::evt_bits evts_ints_sz)
 {
     Container ret;
     events_ints_to_testsuite(parsed_yaml, arena, evts_ints, evts_ints_sz, &ret);

--- a/src_extra/c4/yml/extra/ints_utils.cpp
+++ b/src_extra/c4/yml/extra/ints_utils.cpp
@@ -57,7 +57,7 @@ const FlagSym flag_syms_[] = {
 };
 } // namespace
 
-size_t to_str(substr buf, ievt::DataType flags) noexcept
+size_t to_str(substr buf, ievt::evt_bits flags) noexcept
 {
     detail::_SubstrWriter writer(buf);
     for(const FlagSym sym : flag_syms_)
@@ -77,7 +77,7 @@ size_t to_str(substr buf, ievt::DataType flags) noexcept
     return writer.pos;
 }
 
-csubstr to_str_sub(substr buf, ievt::DataType flags)
+csubstr to_str_sub(substr buf, ievt::evt_bits flags)
 {
     size_t reqsize = ievt::to_str(buf, flags);
     _RYML_CHECK_BASIC(reqsize > 0u);
@@ -100,15 +100,15 @@ namespace c4 {
 namespace yml {
 namespace extra {
 
-void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::DataType const* evts, ievt::DataType evts_sz)
+void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::evt_bits const* evts, ievt::evt_bits evts_sz)
 {
     char buf[200];
-    for(ievt::DataType evtpos = 0, evtnumber = 0;
+    for(ievt::evt_bits evtpos = 0, evtnumber = 0;
         evtpos < evts_sz;
         ++evtnumber,
             evtpos += ((evts[evtpos] & ievt::WSTR) ? 3 : 1))
     {
-        ievt::DataType evt = evts[evtpos];
+        ievt::evt_bits evt = evts[evtpos];
         csubstr flags = ievt::to_str_sub(buf, evt);
         printf("[%d][%d] %.*s(0x%x)", evtnumber, evtpos, (int)flags.len, flags.str, evt);
         if (evt & ievt::WSTR)
@@ -117,10 +117,10 @@ void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::DataType const*
             csubstr region = !in_arena ? parsed_yaml : arena;
             bool safe = (evts[evtpos + 1] >= 0)
                 && (evts[evtpos + 2] >= 0)
-                && (evts[evtpos + 1] <= (ievt::DataType)region.len) // NOLINT
-                && (evts[evtpos + 2] <= ((ievt::DataType)region.len - evts[evtpos + 1]));
+                && (evts[evtpos + 1] <= (ievt::evt_bits)region.len) // NOLINT
+                && (evts[evtpos + 2] <= ((ievt::evt_bits)region.len - evts[evtpos + 1]));
             const char *str = safe ? (region.str + evts[evtpos + 1]) : "ERR!!!";
-            ievt::DataType len = safe ? evts[evtpos + 2] : 6;
+            ievt::evt_bits len = safe ? evts[evtpos + 2] : 6;
             printf(": %d [%d]~~~%.*s~~~", evts[evtpos+1], evts[evtpos+2], len, str);
             if(in_arena)
                 printf(" (arenasz=%zu)", arena.len);

--- a/src_extra/c4/yml/extra/ints_utils.cpp
+++ b/src_extra/c4/yml/extra/ints_utils.cpp
@@ -24,7 +24,7 @@ namespace extra {
 namespace ievt {
 
 namespace {
-struct FlagSym { const char *str; EventFlags flags; };
+struct FlagSym { const char *str; EventBits flags; };
 const FlagSym flag_syms_[] = {
     {"KEY_", KEY_},
     {"VAL_", VAL_},

--- a/src_extra/c4/yml/extra/ints_utils.hpp
+++ b/src_extra/c4/yml/extra/ints_utils.hpp
@@ -19,14 +19,14 @@ namespace extra {
 
 namespace ievt {
 /** Convert bit mask of @ref ievt::EventFlags to text. */
-RYML_EXPORT size_t to_str(substr buf, yml::extra::ievt::DataType flags) noexcept;
+RYML_EXPORT size_t to_str(substr buf, yml::extra::ievt::evt_bits flags) noexcept;
 /** Convert bit mask of @ref ievt::EventFlags to text. */
-RYML_EXPORT csubstr to_str_sub(substr buf, yml::extra::ievt::DataType flags);
+RYML_EXPORT csubstr to_str_sub(substr buf, yml::extra::ievt::evt_bits flags);
 } // namespace ievt
 
 
 /** Print integer events to stdout */
-RYML_EXPORT void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::DataType const* evts_ints, ievt::DataType evts_ints_sz);
+RYML_EXPORT void events_ints_print(csubstr parsed_yaml, csubstr arena, ievt::evt_bits const* evts_ints, ievt::evt_bits evts_ints_sz);
 
 
 /** @} */

--- a/src_extra/c4/yml/extra/ints_utils.hpp
+++ b/src_extra/c4/yml/extra/ints_utils.hpp
@@ -18,9 +18,9 @@ namespace extra {
 
 
 namespace ievt {
-/** Convert bit mask of @ref ievt::EventFlags to text. */
+/** Convert bit mask of @ref ievt::EventBits to text. */
 RYML_EXPORT size_t to_str(substr buf, yml::extra::ievt::evt_bits flags) noexcept;
-/** Convert bit mask of @ref ievt::EventFlags to text. */
+/** Convert bit mask of @ref ievt::EventBits to text. */
 RYML_EXPORT csubstr to_str_sub(substr buf, yml::extra::ievt::evt_bits flags);
 } // namespace ievt
 

--- a/test/test_anchor.cpp
+++ b/test/test_anchor.cpp
@@ -404,7 +404,7 @@ tpl: &anchor
 
 //-----------------------------------------------------------------------------
 
-Tree github566_make_map(NodeType_e root_style)
+Tree github566_make_map(NodeType root_style)
 {
     Tree tree;
     NodeRef root = tree.rootref();
@@ -417,7 +417,7 @@ Tree github566_make_map(NodeType_e root_style)
     return tree;
 }
 
-Tree github566_make_seq(NodeType_e root_style)
+Tree github566_make_seq(NodeType root_style)
 {
     Tree tree;
     NodeRef root = tree.rootref();

--- a/test/test_extra_ints.cpp
+++ b/test/test_extra_ints.cpp
@@ -22,7 +22,7 @@ TEST(flags, to_chars)
     char buf_[200]; substr buf = buf_;
 #define _(flags, str)                                       \
     {                                                       \
-        ievt::DataType flags_{flags};                       \
+        ievt::evt_bits flags_{flags};                       \
         csubstr actual(str);                                \
         EXPECT_EQ(ievt::to_str(buf1, flags_), actual.len);  \
         size_t ret = ievt::to_str(buf, flags_);             \
@@ -48,13 +48,13 @@ struct IntEventsCase
     csubstr yaml;
     const std::vector<IntEventWithScalar> evt;
 
-    void testeq(csubstr parsed_source, csubstr arena, ievt::DataType const* actual, size_t actual_size) const
+    void testeq(csubstr parsed_source, csubstr arena, ievt::evt_bits const* actual, size_t actual_size) const
     {
         RYML_TRACE_FMT("defined in:\n{}:{}: (here)\n", file, line);
         #ifdef RYML_DBG
-        events_ints_print(parsed_source, arena, actual, (extra::ievt::DataType)actual_size);
+        events_ints_print(parsed_source, arena, actual, (extra::ievt::evt_bits)actual_size);
         #endif
-        test_events_ints_invariants(parsed_source, arena, actual, (ievt::DataType)actual_size);
+        test_events_ints_invariants(parsed_source, arena, actual, (ievt::evt_bits)actual_size);
         test_events_ints(evt.data(), evt.size(), actual, actual_size, yaml, parsed_source, arena);
     }
 };
@@ -610,7 +610,7 @@ struct IntEventsTestHelper
     extra::EventHandlerInts handler;
     ParseEngine<extra::EventHandlerInts> parser;
     std::string src_copy;
-    std::vector<DataType> actual;
+    std::vector<evt_bits> actual;
     std::string arena;
     IntEventsTestHelper(IntEventsCase const& ec_)
         : ec(ec_)

--- a/test/test_json.cpp
+++ b/test/test_json.cpp
@@ -213,9 +213,9 @@ TEST(emit_json, issue121)
 {
     csubstr json = R"({"string_value": "string","number_value": "9001","broken_value": "0.30.2"})";
     const Tree t = parse_json_in_arena(json);
-    EXPECT_TRUE(t["string_value"].get()->m_type.type & VAL_DQUO);
-    EXPECT_TRUE(t["number_value"].get()->m_type.type & VAL_DQUO);
-    EXPECT_TRUE(t["broken_value"].get()->m_type.type & VAL_DQUO);
+    EXPECT_TRUE(t["string_value"].get()->m_type.m_bits & VAL_DQUO);
+    EXPECT_TRUE(t["number_value"].get()->m_type.m_bits & VAL_DQUO);
+    EXPECT_TRUE(t["broken_value"].get()->m_type.m_bits & VAL_DQUO);
     std::string out;
     emitrs_json(t, &out);
     EXPECT_EQ(out, json);

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -60,8 +60,8 @@
         {                                                               \
             char ltypebuf[256];                                         \
             char rtypebuf[256];                                         \
-            csubstr ltype = NodeType::type_str_sub(ltypebuf, (NodeType_e)lhs); \
-            csubstr rtype = NodeType::type_str_sub(rtypebuf, (NodeType_e)rhs); \
+            csubstr ltype = NodeType::type_str_sub(ltypebuf, (type_bits)lhs); \
+            csubstr rtype = NodeType::type_str_sub(rtypebuf, (type_bits)rhs); \
             EXPECT_##testop(lhs, rhs);                                  \
             std::cout << __FILE__  << ":" << __LINE__ << ": ...\n";     \
             if(ltype.str && rtype.str)                                  \

--- a/test/test_lib/test_case.hpp
+++ b/test/test_lib/test_case.hpp
@@ -95,7 +95,7 @@ inline void PrintTo(NodeType ty, ::std::ostream* os)
 {
     *os << ty.type_str();
 }
-inline void PrintTo(NodeType_e ty, ::std::ostream* os)
+inline void PrintTo(NodeTypeBits ty, ::std::ostream* os)
 {
     *os << NodeType::type_str(ty);
 }

--- a/test/test_lib/test_case_node.cpp
+++ b/test/test_lib/test_case_node.cpp
@@ -53,7 +53,7 @@ type_bits TestCaseNode::_guess() const
     }
     else
     {
-        NodeType_e has_key = key.empty() ? NOTYPE : KEY;
+        type_bits has_key = key.empty() ? NOTYPE : KEY;
         auto const& ch = children.front();
         if(ch.key.empty())
         {

--- a/test/test_lib/test_case_node.cpp
+++ b/test/test_lib/test_case_node.cpp
@@ -35,7 +35,7 @@ TEST(CaseNode, setting_up)
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
-NodeType_e TestCaseNode::_guess() const
+type_bits TestCaseNode::_guess() const
 {
     NodeType t;
     C4_ASSERT(!val.empty() != !children.empty() || (val.empty() && children.empty()));

--- a/test/test_lib/test_case_node.hpp
+++ b/test/test_lib/test_case_node.hpp
@@ -72,7 +72,7 @@ public:
     // brace yourself: what you are about to see is ... crazy.
 
     TestCaseNode() : TestCaseNode(NOTYPE) {}
-    TestCaseNode(NodeType_e t) : type(t), key(), key_tag(), key_anchor(), val(), val_tag(), val_anchor(), children(), parent(nullptr) { _set_parent(); }
+    TestCaseNode(type_bits t) : type(t), key(), key_tag(), key_anchor(), val(), val_tag(), val_anchor(), children(), parent(nullptr) { _set_parent(); }
 
     // val
     template<size_t N> explicit TestCaseNode(const char (&v)[N]   ) : type((VAL       )), key(), key_tag(), key_anchor(), val(v       ), val_tag(     ), val_anchor(), children(), parent(nullptr) { _set_parent(); }
@@ -240,7 +240,7 @@ public:
         C4_SUPPRESS_WARNING_GCC_POP
     }
 
-    NodeType_e _guess() const;
+    type_bits _guess() const;
 
     bool is_root() const { return parent; }
     bool is_doc() const { return type & DOC; }

--- a/test/test_lib/test_case_node.hpp
+++ b/test/test_lib/test_case_node.hpp
@@ -25,11 +25,11 @@ struct TaggedScalar
 
 struct AnchorRef
 {
-    NodeType_e type;
+    type_bits type;
     csubstr str;
     AnchorRef() : type(NOTYPE), str() {}
-    AnchorRef(NodeType_e t) : type(t), str() {}
-    AnchorRef(NodeType_e t, csubstr v) : type(t), str(v) {}
+    AnchorRef(type_bits t) : type(t), str() {}
+    AnchorRef(type_bits t, csubstr v) : type(t), str(v) {}
 };
 
 

--- a/test/test_lib/test_engine.cpp
+++ b/test/test_lib/test_engine.cpp
@@ -42,7 +42,7 @@ public:
 
     void prepare_yaml(extra::EventHandlerInts &handler,
                       EngineEvtTestCase const& test_case, std::string const& parsed_yaml,
-                      extra::ievt::DataType ints_size=-1, size_t arena_size=npos)
+                      extra::ievt::evt_bits ints_size=-1, size_t arena_size=npos)
     {
         if(ints_size == -1)
             ints_size = extra::estimate_events_ints_size(to_csubstr(parsed_yaml));
@@ -73,7 +73,7 @@ public:
 
     void prepare_events(EventHandlerIntsTr &handler_tr,
                         EngineEvtTestCase const& test_case, std::string const& parsed_yaml,
-                        extra::ievt::DataType ints_size=-1, size_t arena_size=npos)
+                        extra::ievt::evt_bits ints_size=-1, size_t arena_size=npos)
     {
         prepare_yaml(handler_tr.handler, test_case, parsed_yaml, ints_size, arena_size);
         handler_tr.transformer.src = to_csubstr(src);

--- a/test/test_lib/test_events_ints_helpers.cpp
+++ b/test/test_lib/test_events_ints_helpers.cpp
@@ -17,7 +17,7 @@ size_t num_ints(IntEventWithScalar const *evt, size_t evt_size)
 
 
 void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
-                      ievt::DataType const* actual, size_t actual_sz,
+                      ievt::evt_bits const* actual, size_t actual_sz,
                       csubstr yaml,
                       csubstr parsed_source,
                       csubstr arena)
@@ -100,21 +100,21 @@ void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
 
 void test_events_ints_invariants(csubstr parsed_yaml,
                                  csubstr arena,
-                                 ievt::DataType const* evts,
-                                 ievt::DataType evts_sz)
+                                 ievt::evt_bits const* evts,
+                                 ievt::evt_bits evts_sz)
 {
     char bufpos[200];
     char bufprev[200];
     EXPECT_GT(evts_sz, 0);
-    for(ievt::DataType evtpos = 0, evtnumber = 0;
+    for(ievt::evt_bits evtpos = 0, evtnumber = 0;
         evtpos < evts_sz;
         ++evtnumber,
             evtpos += ((evts[evtpos] & ievt::WSTR) ? 3 : 1))
     {
-        ievt::DataType evt = evts[evtpos];
-        ievt::DataType prev = {};
-        ievt::DataType nextpos = evtpos + ((evt & ievt::WSTR) ? 3 : 1);
-        ievt::DataType next = {};
+        ievt::evt_bits evt = evts[evtpos];
+        ievt::evt_bits prev = {};
+        ievt::evt_bits nextpos = evtpos + ((evt & ievt::WSTR) ? 3 : 1);
+        ievt::evt_bits next = {};
         SCOPED_TRACE(evtpos); // position in the array
         SCOPED_TRACE(evtnumber); // event number
         SCOPED_TRACE(ievt::to_str_sub(bufpos, evt));
@@ -149,9 +149,9 @@ void test_events_ints_invariants(csubstr parsed_yaml,
             SCOPED_TRACE(ievt::to_str_sub(bufprev, prev));
             EXPECT_NE(prev & ievt::WSTR, 0);
         }
-        constexpr const ievt::DataType style = ievt::PLAI|ievt::SQUO|ievt::DQUO|ievt::LITL|ievt::FOLD;
-        constexpr const ievt::DataType scope = ievt::MAP_|ievt::SEQ_|ievt::DOC_|ievt::STRM;
-        constexpr const ievt::DataType directives = ievt::YAML|ievt::TAGH|ievt::TAGP;
+        constexpr const ievt::evt_bits style = ievt::PLAI|ievt::SQUO|ievt::DQUO|ievt::LITL|ievt::FOLD;
+        constexpr const ievt::evt_bits scope = ievt::MAP_|ievt::SEQ_|ievt::DOC_|ievt::STRM;
+        constexpr const ievt::evt_bits directives = ievt::YAML|ievt::TAGH|ievt::TAGP;
         if(evt & (ievt::BEG_|ievt::END_))
         {
             EXPECT_NE(evt & scope, 0);
@@ -404,7 +404,7 @@ void test_events_ints_invariants(csubstr parsed_yaml,
             EXPECT_EQ(evt & (ievt::BMAP|ievt::EMAP), 0);
             EXPECT_EQ(evt & (ievt::FLOW|ievt::BLCK), 0);
             EXPECT_EQ(next & ievt::PSTR, ievt::PSTR);
-            ievt::DataType estyle = evt & style;
+            ievt::evt_bits estyle = evt & style;
             EXPECT_NE(estyle, 0);
             EXPECT_EQ((estyle & (estyle << 1)), 0);
             _test_str_in_buffer(evtpos);

--- a/test/test_lib/test_events_ints_helpers.hpp
+++ b/test/test_lib/test_events_ints_helpers.hpp
@@ -16,10 +16,10 @@ namespace extra {
 // specifying events in tests
 struct IntEventWithScalar
 {
-    ievt::DataType flags, str_start, str_len;
+    ievt::evt_bits flags, str_start, str_len;
     csubstr scalar;
     bool needs_filter;
-    IntEventWithScalar(ievt::DataType t, ievt::DataType start=0, ievt::DataType len=0, csubstr sclr={}, bool needs_filter_=false)
+    IntEventWithScalar(ievt::evt_bits t, ievt::evt_bits start=0, ievt::evt_bits len=0, csubstr sclr={}, bool needs_filter_=false)
         : flags(t)
         , str_start(start)
         , str_len(len)
@@ -35,7 +35,7 @@ size_t num_ints(IntEventWithScalar const *evt, size_t evt_size);
 
 
 void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
-                      ievt::DataType const* actual, size_t actual_sz,
+                      ievt::evt_bits const* actual, size_t actual_sz,
                       csubstr yaml,
                       csubstr parsed_source,
                       csubstr arena);
@@ -43,8 +43,8 @@ void test_events_ints(IntEventWithScalar const* expected, size_t expected_sz,
 void test_events_ints_invariants(
     csubstr parsed_yaml,
     csubstr arena,
-    ievt::DataType const* evts_ints,
-    ievt::DataType evts_ints_sz);
+    ievt::evt_bits const* evts_ints,
+    ievt::evt_bits evts_ints_sz);
 
 } // namespace extra
 } // namespace yml

--- a/test/test_lib/test_group.cpp
+++ b/test/test_lib/test_group.cpp
@@ -112,7 +112,7 @@ void YmlTestCase::_test_parse_using_ryml(CaseDataLineEndings *cd)
 static void _parse_events_ints(csubstr name, substr src, std::vector<int> *ints, std::vector<char> *arena)
 {
     SCOPED_TRACE("parse_ints");
-    using I = extra::ievt::DataType;
+    using I = extra::ievt::evt_bits;
     using Handler = extra::EventHandlerInts;
     int estimated_size = extra::estimate_events_ints_size(src);
     ints->resize((size_t)estimated_size);

--- a/test/test_lib/test_group.hpp
+++ b/test/test_lib/test_group.hpp
@@ -150,27 +150,27 @@ C4_SUPPRESS_WARNING_GCC_PUSH
 C4_SUPPRESS_WARNING_GCC("-Wunused-const-variable")
 #endif
 
-constexpr const NodeType_e KP = (KEY|KEY_PLAIN);   ///< key, plain scalar
-constexpr const NodeType_e KN = (KEY|KEY_PLAIN|KEYNIL); ///< key, plain scalar, nil
-constexpr const NodeType_e KS = (KEY|KEY_SQUO);    ///< key, single-quoted scalar
-constexpr const NodeType_e KD = (KEY|KEY_DQUO);    ///< key, double-quoted scalar
-constexpr const NodeType_e KL = (KEY|KEY_LITERAL); ///< key, block-literal scalar
-constexpr const NodeType_e KF = (KEY|KEY_FOLDED);  ///< key, block-folded scalar
+constexpr const type_bits KP = (KEY|KEY_PLAIN);   ///< key, plain scalar
+constexpr const type_bits KN = (KEY|KEY_PLAIN|KEYNIL); ///< key, plain scalar, nil
+constexpr const type_bits KS = (KEY|KEY_SQUO);    ///< key, single-quoted scalar
+constexpr const type_bits KD = (KEY|KEY_DQUO);    ///< key, double-quoted scalar
+constexpr const type_bits KL = (KEY|KEY_LITERAL); ///< key, block-literal scalar
+constexpr const type_bits KF = (KEY|KEY_FOLDED);  ///< key, block-folded scalar
 
-constexpr const NodeType_e VP = (VAL|VAL_PLAIN);   ///< val, plain scalar
-constexpr const NodeType_e VN = (VAL|VAL_PLAIN|VALNIL); ///< val, plain scalar, nil
-constexpr const NodeType_e VS = (VAL|VAL_SQUO);    ///< val, single-quoted scalar
-constexpr const NodeType_e VD = (VAL|VAL_DQUO);    ///< val, double-quoted scalar
-constexpr const NodeType_e VL = (VAL|VAL_LITERAL); ///< val, block-literal scalar
-constexpr const NodeType_e VF = (VAL|VAL_FOLDED);  ///< val, block-folded scalar
+constexpr const type_bits VP = (VAL|VAL_PLAIN);   ///< val, plain scalar
+constexpr const type_bits VN = (VAL|VAL_PLAIN|VALNIL); ///< val, plain scalar, nil
+constexpr const type_bits VS = (VAL|VAL_SQUO);    ///< val, single-quoted scalar
+constexpr const type_bits VD = (VAL|VAL_DQUO);    ///< val, double-quoted scalar
+constexpr const type_bits VL = (VAL|VAL_LITERAL); ///< val, block-literal scalar
+constexpr const type_bits VF = (VAL|VAL_FOLDED);  ///< val, block-folded scalar
 
-constexpr const NodeType_e SB = (SEQ|BLOCK);       ///< sequence, block-style
-constexpr const NodeType_e SFS = (SEQ|FLOW_SL);    ///< sequence, flow-style, single-line
-constexpr const NodeType_e SFM = (SEQ|FLOW_ML1);   ///< sequence, flow-style, multi-line
+constexpr const type_bits SB = (SEQ|BLOCK);       ///< sequence, block-style
+constexpr const type_bits SFS = (SEQ|FLOW_SL);    ///< sequence, flow-style, single-line
+constexpr const type_bits SFM = (SEQ|FLOW_ML1);   ///< sequence, flow-style, multi-line
 
-constexpr const NodeType_e MB = (MAP|BLOCK);       ///< map, flow-style
-constexpr const NodeType_e MFS = (MAP|FLOW_SL);    ///< map, flow-style, single-line
-constexpr const NodeType_e MFM = (MAP|FLOW_ML1);   ///< map, flow-style, multi-line
+constexpr const type_bits MB = (MAP|BLOCK);       ///< map, flow-style
+constexpr const type_bits MFS = (MAP|FLOW_SL);    ///< map, flow-style, single-line
+constexpr const type_bits MFM = (MAP|FLOW_ML1);   ///< map, flow-style, multi-line
 
 C4_SUPPRESS_WARNING_GCC_POP
 

--- a/test/test_node_type.cpp
+++ b/test/test_node_type.cpp
@@ -692,7 +692,7 @@ size_t to_chars(substr buf, showtype_ s)
 {
     size_t pos = s.ty.type_str(buf);
     buf = buf.sub(pos < buf.len ? pos : buf.len);
-    pos += format(buf, "({})", s.ty.type);
+    pos += format(buf, "({})", s.ty.m_bits);
     return pos;
 }
 
@@ -773,7 +773,7 @@ void test_plain_valid(scalar_style_spec const& p, bool flow, cspan<csubstr> case
 {
     if(p.style_flow != P || !p.scalar.len || p.scalar.first_not_of(" \n\t\r") == npos)
         return;
-    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.type));
+    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.m_bits));
     std::string buf;
     size_t i = 0;
     for(csubstr c : cases)
@@ -981,7 +981,7 @@ bool block = false;
 TEST_P(TestScalarStyle, query_plain_flow)
 {
     scalar_style_spec const& p = GetParam();
-    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.type));
+    SHOWPARAM(p, "expected_flow={}", showtype(p.style_flow.m_bits));
     EXPECT_EQ(scalar_style_query_plain_flow(p.scalar), p.style_flow == P);
     EXPECT_EQ(scalar_style_query_plain_flow(p.scalar),
               scalar_style_query_plain(p.scalar, flow));
@@ -1018,7 +1018,7 @@ TEST_P(TestScalarStyle, query_plain_flow_invalid_at_end)
 TEST_P(TestScalarStyle, query_plain_block)
 {
     scalar_style_spec const& p = GetParam();
-    SHOWPARAM(p, "expected_block={}", showtype(p.style_block.type));
+    SHOWPARAM(p, "expected_block={}", showtype(p.style_block.m_bits));
     EXPECT_EQ(scalar_style_query_plain_block(p.scalar), p.style_block == P);
     EXPECT_EQ(scalar_style_query_plain_block(p.scalar),
               scalar_style_query_plain(p.scalar, block));
@@ -1056,7 +1056,7 @@ TEST_P(TestScalarStyle, choose_flow)
 {
     scalar_style_spec const& p = GetParam();
     NodeType actual = scalar_style_choose_flow(p.scalar);
-    NodeType expected = p.style_flow.type;
+    NodeType expected = p.style_flow.m_bits;
     SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
     RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
 }
@@ -1065,7 +1065,7 @@ TEST_P(TestScalarStyle, choose_block)
 {
     scalar_style_spec const& p = GetParam();
     NodeType actual = scalar_style_choose_block(p.scalar);
-    NodeType expected = p.style_block.type;
+    NodeType expected = p.style_block.m_bits;
     SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
     RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
 }
@@ -1074,7 +1074,7 @@ TEST_P(TestScalarStyle, choose_json)
 {
     scalar_style_spec const& p = GetParam();
     NodeType actual = scalar_style_json_choose(p.scalar);
-    NodeType expected = p.style_json.type;
+    NodeType expected = p.style_json.m_bits;
     SHOWPARAM(p, "\n  actual  ={}\n  expected={}", showtype(actual), showtype(expected));
     RYML_COMPARE_NODE_TYPE(actual, expected, ==, EQ);
 }

--- a/test/testsuite.cpp
+++ b/test/testsuite.cpp
@@ -312,7 +312,7 @@ struct TestSequenceLevel
 
     void parse_yaml_to_events_ints()
     {
-        using I = extra::ievt::DataType;
+        using I = extra::ievt::evt_bits;
         if(events_ints_were_generated)
             return;
         if(prev)

--- a/tools/parse_emit.cpp
+++ b/tools/parse_emit.cpp
@@ -335,7 +335,7 @@ void process_file_tree(Args const& args, c4::substr contents)
 void process_file_ints(Args const& args, c4::csubstr contents)
 {
     TS(process_file_ints);
-    using evt_type = yml::extra::ievt::DataType;
+    using evt_type = yml::extra::ievt::evt_bits;
     using Handler = yml::extra::EventHandlerInts;
     using Parser = yml::ParseEngine<Handler>;
     Handler handler;

--- a/tools/yaml_events.cpp
+++ b/tools/yaml_events.cpp
@@ -122,7 +122,7 @@ EXAMPLES:
 
 //-----------------------------------------------------------------------------
 
-using IntEvents = std::vector<extra::ievt::DataType>;
+using IntEvents = std::vector<extra::ievt::evt_bits>;
 
 std::string load_file(csubstr filename);
 std::string emit_testsuite_events_from_tree(csubstr filename, substr filecontents);
@@ -265,7 +265,7 @@ std::string emit_testsuite_events_from_tree(csubstr filename, substr filecontent
 
 csubstr parse_events_ints(csubstr filename, substr filecontents, std::string &parsed, std::string &arena, IntEvents &evts, bool fail_size)
 {
-    using I = extra::ievt::DataType;
+    using I = extra::ievt::evt_bits;
     using Handler = extra::EventHandlerInts;
     Handler handler(create_custom_callbacks());
     ParseEngine<Handler> parser(&handler, parse_opts);
@@ -314,7 +314,7 @@ csubstr parse_events_ints(csubstr filename, substr filecontents, std::string &pa
 
 std::string emit_testsuite_events_from_ints(csubstr filename, substr filecontents, IntEvents &evts, bool fail_size)
 {
-    using I = extra::ievt::DataType;
+    using I = extra::ievt::evt_bits;
     std::string buf;
     std::string arena;
     csubstr parsed;
@@ -333,7 +333,7 @@ std::string emit_testsuite_events_from_ints(csubstr filename, substr filecontent
 
 void emit_ints_events(csubstr filename, substr filecontents, IntEvents &evts, bool fail_size)
 {
-    using I = extra::ievt::DataType;
+    using I = extra::ievt::evt_bits;
     std::string buf;
     std::string arena;
     csubstr parsed;


### PR DESCRIPTION
API cleanup: `NodeType` and `extra::ievt::EventFlags`:
  - On `Tree` and `NodeRef`, overloads taking `NodeType_e` are now receiving `type_bits`.
  - This saves operator calls on type queries.
  - Remove bitwise operators, no longer needed.
  - Rename `NodeType_e` to `NodeTypeBits` (deprecate `NodeType_e`)
  - Low impact, no changes should be needed on user code, other than renaming unlikely uses of `NodeType_e`.
  - Also, for int events:
    - rename `extra::ievt::EventFlags` to `extra::ievt::EventBits`