### PR TITLE
Add option to consume c4core from find_package()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ option(RYML_SHORT_ERR_MSG "Use shorter error message from checks/asserts: do not
 option(RYML_BUILD_TOOLS "Build tools" OFF)
 option(RYML_BUILD_API "Enable API generation (python, etc)" OFF)
 option(RYML_DBG "Enable (very verbose) debug prints." OFF)
+option(RYML_SYSTEM_C4CORE "Use system-installed c4core instead of the one provided with ryml" OFF)
 
 option(RYML_INSTALL "Enable install target" ON)
 
@@ -103,7 +104,10 @@ c4_add_library(ryml
         $<INSTALL_INTERFACE:include>
     )
 
-if(NOT RYML_STANDALONE)
+if(RYML_SYSTEM_C4CORE)
+    find_package(c4core REQUIRED)
+    target_link_libraries(ryml PUBLIC c4core::c4core)
+elseif(NOT RYML_STANDALONE)
     target_link_libraries(ryml PUBLIC c4core)
 else()
     include(ext/c4core.cmake)
@@ -203,7 +207,7 @@ endif()
 
 if(RYML_INSTALL)
     c4_install_target(ryml)
-    if(RYML_STANDALONE)
+    if(RYML_STANDALONE OR RYML_SYSTEM_C4CORE)
         c4_install_exports()
     else()
         c4_install_exports(DEPENDENCIES c4core)


### PR DESCRIPTION
Hello! :wave: 

As we are about to update RapidYAML in [Conan](https://conan.io) via PR https://github.com/conan-io/conan-center-index/pull/30470, we actually have an unvendorized version: Both RapidYAML, C4Core, and Fast Float are packaged separately. This modularity allows users to not only know what version what, but pick each package they need and avoid rebuilding dependencies from source.

See:
- https://conan.io/center/recipes?value=c4core (we have a new PR updating to 0.4.0)
- https://conan.io/center/recipes/fast_float?version=8.1.0
- https://conan.io/center/recipes/rapidyaml?version=0.10.0

To make it work for RapidYAML, so far we patched its CMake file to consume a pre-built library of C4Core, packaged in Conan. See: https://github.com/conan-io/conan-center-index/blob/master/recipes/rapidyaml/all/patches/0.10.0-001-remove-internal-c4core.patch

This PR brings this alternative to the project as something more official: Not only package managers like Conan will be able to better track all involved dependencies (version, license, pre-built libraries), but also users who are building RapidYAML but have C4Core installed already, will be able to reuse the same system version.

Regards! 