### PR TITLE
Refactor uses of C4_LIKELY() / C4_UNLIKELY(). No logic changes.

### DIFF
--- a/changelog/current.md
+++ b/changelog/current.md
@@ -272,6 +272,7 @@ Here's the list of new `ReadResult`-returning methods that may be of use in simi
 <a>v0.16changelogsection</a>
 ## Full changelog
 
+- [PR#641](https://github.com/biojppm/rapidyaml/pull/641): change uses of `C4_LIKELY()` / `C4_UNLIKELY()` to turn into `[[likely]]` / `[[unlikely]]`. No logic changes.
 - [PR#640](https://github.com/biojppm/rapidyaml/pull/640): add `.deserialize_child()` methods to simplify read() implementations
 - [PR#639](https://github.com/biojppm/rapidyaml/pull/639): fix names using leading/double underscore (renames only, no logic changes).
 - [PR#638](https://github.com/biojppm/rapidyaml/pull/638): improve quickstart-ints.

--- a/ext/c4core.dev/c4/alloc.cpp
+++ b/ext/c4core.dev/c4/alloc.cpp
@@ -39,7 +39,7 @@ void* aalloc_impl(size_t size, size_t alignment) // NOLINT(misc-use-internal-lin
     // alignment must be nonzero and a power of 2
     C4_CHECK(alignment > 0 && (alignment & (alignment - 1u)) == 0);
     // NOTE: alignment needs to be sized in multiples of sizeof(void*)
-    if(C4_UNLIKELY(alignment < sizeof(void*)))
+    if C4_UNLIKELY(alignment < sizeof(void*))
         alignment = sizeof(void*);
     static_assert((sizeof(void*) & (sizeof(void*)-1u)) == 0, "sizeof(void*) must be a power of 2");
     C4_CHECK(((alignment & (sizeof(void*) - 1u))) == 0u);
@@ -49,7 +49,7 @@ void* aalloc_impl(size_t size, size_t alignment) // NOLINT(misc-use-internal-lin
     C4_CHECK(mem != nullptr || size == 0);
 #elif defined(C4_POSIX) || defined(C4_IOS) || defined(C4_MACOS)
     int ret = ::posix_memalign(&mem, alignment, size);
-    if(C4_UNLIKELY(ret))
+    if C4_UNLIKELY(ret)
     {
         C4_ASSERT(ret != EINVAL); // this was already handled above
         if(ret == ENOMEM)

--- a/ext/c4core.mk
+++ b/ext/c4core.mk
@@ -3,4 +3,4 @@
 C4CORE_REPO := https://github.com/biojppm/c4core
 # must be either tag or a FULL commit hash; cannot
 # be a branch name or short commit hash!
-C4CORE_TAG := ee72737e3182052eec7d86db090bcb60949c98e1
+C4CORE_TAG := b66bebf7bf1ff4db02e1e65949d1687a6671844b

--- a/ext/c4core.src/c4/base64.cpp
+++ b/ext/c4core.src/c4/base64.cpp
@@ -165,8 +165,8 @@ C4_HOT C4_ALWAYS_INLINE bool is_valid_encoded_group16_(const char *C4_RESTRICT c
     C4_ASSERT(!(num & 15)); // must be multiple of 16
     size_t rem = num;
     for( ; rem >= 16; rem -= 16, c += 16)
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(c)
-                    || !is_valid_encoded_group8_(c + 8)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(c)
+                    || !is_valid_encoded_group8_(c + 8))
             return false;
     return true;
 }
@@ -449,21 +449,21 @@ bool base64_decode(char const* encoded_, size_t encoded_sz,
 #if (C4_WORDSIZE >= 8)
     for( ; rem >= 15; rem -= 12)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group16_(encoded, 16)))
+        if C4_UNLIKELY(!is_valid_encoded_group16_(encoded, 16))
             return false;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
     }
     for( ; rem >= 9; rem -= 6)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(encoded))
             return false;
         base64_decode_block64_(encoded, data); encoded += 8; data += 6;
     }
 #else
     for( ; rem >= 9; rem -= 6)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group8_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group8_(encoded))
             return false;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
@@ -471,7 +471,7 @@ bool base64_decode(char const* encoded_, size_t encoded_sz,
 #endif
     for( ; rem >= 3; rem -= 3)
     {
-        if(C4_UNLIKELY(!is_valid_encoded_group4_(encoded)))
+        if C4_UNLIKELY(!is_valid_encoded_group4_(encoded))
             return false;
         base64_decode_block32_(encoded, data); encoded += 4; data += 3;
     }

--- a/ext/c4core.src/c4/charconv.hpp
+++ b/ext/c4core.src/c4/charconv.hpp
@@ -405,7 +405,7 @@ template<> struct charconv_digits_<8u, false> // uint64_t
 } // namespace detail
 
 // Helper macros, undefined below
-#define c4append_(c) { if(C4_LIKELY(pos < buf.len)) { buf.str[pos++] = static_cast<char>(c); } else { ++pos; } }
+#define c4append_(c) { if C4_LIKELY(pos < buf.len) { buf.str[pos++] = static_cast<char>(c); } else { ++pos; } }
 
 /** @endcond */
 
@@ -716,7 +716,7 @@ C4_ALWAYS_INLINE size_t write_dec(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_dec(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_dec_unchecked(buf, v, digits);
     return digits;
 }
@@ -735,7 +735,7 @@ C4_ALWAYS_INLINE size_t write_hex(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_hex(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_hex_unchecked(buf, v, digits);
     return digits;
 }
@@ -754,7 +754,7 @@ C4_ALWAYS_INLINE size_t write_oct(substr buf, T v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_ASSERT(v >= 0);
     unsigned digits = digits_oct(v);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_oct_unchecked(buf, v, digits);
     return digits;
 }
@@ -774,7 +774,7 @@ C4_ALWAYS_INLINE size_t write_bin(substr buf, T v) noexcept
     C4_ASSERT(v >= 0);
     unsigned digits = digits_bin(v);
     C4_ASSERT(digits > 0);
-    if(C4_LIKELY(buf.len >= digits))
+    if C4_LIKELY(buf.len >= digits)
         write_bin_unchecked(buf, v, digits);
     return digits;
 }
@@ -878,7 +878,7 @@ C4_ALWAYS_INLINE bool read_dec(csubstr s, I *C4_RESTRICT v) noexcept
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '9'))
+        if C4_UNLIKELY(c < '0' || c > '9')
             return false;
         *v = ((*v) * I(10)) + (I(c) - I('0'));
     }
@@ -971,7 +971,7 @@ C4_ALWAYS_INLINE bool read_oct(csubstr s, I *C4_RESTRICT v) noexcept
     *v = 0;
     for(char c : s)
     {
-        if(C4_UNLIKELY(c < '0' || c > '7'))
+        if C4_UNLIKELY(c < '0' || c > '7')
             return false;
         *v = ((*v) * I(8)) + (I(c) - I('0'));
     }
@@ -1011,7 +1011,7 @@ template<class I>
 C4_NO_INLINE size_t _itoadec2buf(substr buf) noexcept
 {
     using digits_type = detail::charconv_digits<I>;
-    if(C4_UNLIKELY(buf.len < digits_type::maxdigits_dec))
+    if C4_UNLIKELY(buf.len < digits_type::maxdigits_dec)
         return digits_type::maxdigits_dec;
     buf.str[0] = '-';
     return detail::_itoa2buf(buf, 1, digits_type::min_value_dec());
@@ -1021,31 +1021,31 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix) noexcept
 {
     using digits_type = detail::charconv_digits<I>;
     size_t pos = 0;
-    if(C4_LIKELY(buf.len > 0))
+    if C4_LIKELY(buf.len > 0)
         buf.str[pos++] = '-';
     switch(radix) // NOLINT(hicpp-multiway-paths-covered)
     {
     case I(10):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_dec))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_dec)
             return digits_type::maxdigits_dec;
         pos =_itoa2buf(buf, pos, digits_type::min_value_dec());
         break;
     case I(16):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_hex))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_hex)
             return digits_type::maxdigits_hex;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'x';
         pos = _itoa2buf(buf, pos, digits_type::min_value_hex());
         break;
     case I( 2):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_bin))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_bin)
             return digits_type::maxdigits_bin;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'b';
         pos = _itoa2buf(buf, pos, digits_type::min_value_bin());
         break;
     case I( 8):
-        if(C4_UNLIKELY(buf.len < digits_type::maxdigits_oct))
+        if C4_UNLIKELY(buf.len < digits_type::maxdigits_oct)
             return digits_type::maxdigits_oct;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'o';
@@ -1060,21 +1060,21 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     using digits_type = detail::charconv_digits<I>;
     size_t pos = 0;
     size_t needed_digits = 0;
-    if(C4_LIKELY(buf.len > 0))
+    if C4_LIKELY(buf.len > 0)
         buf.str[pos++] = '-';
     switch(radix) // NOLINT(hicpp-multiway-paths-covered)
     {
     case I(10):
         // add 1 to account for -
         needed_digits = num_digits+1 > digits_type::maxdigits_dec ? num_digits+1 : digits_type::maxdigits_dec;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         pos = _itoa2bufwithdigits(buf, pos, num_digits, digits_type::min_value_dec());
         break;
     case I(16):
         // add 3 to account for -0x
         needed_digits = num_digits+3 > digits_type::maxdigits_hex ? num_digits+3 : digits_type::maxdigits_hex;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         buf.str[pos++] = '0';
         buf.str[pos++] = 'x';
@@ -1083,7 +1083,7 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     case I(2):
         // add 3 to account for -0b
         needed_digits = num_digits+3 > digits_type::maxdigits_bin ? num_digits+3 : digits_type::maxdigits_bin;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         C4_ASSERT(buf.len >= digits_type::maxdigits_bin);
         buf.str[pos++] = '0';
@@ -1093,7 +1093,7 @@ C4_NO_INLINE size_t _itoa2buf(substr buf, I radix, size_t num_digits) noexcept
     case I(8):
         // add 3 to account for -0o
         needed_digits = num_digits+3 > digits_type::maxdigits_oct ? num_digits+3 : digits_type::maxdigits_oct;
-        if(C4_UNLIKELY(buf.len < needed_digits))
+        if C4_UNLIKELY(buf.len < needed_digits)
             return needed_digits;
         C4_ASSERT(buf.len >= digits_type::maxdigits_oct);
         buf.str[pos++] = '0';
@@ -1127,11 +1127,11 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v) noexcept
     }
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         v = (T)-v;
         unsigned digits = digits_dec(v);
-        if(C4_LIKELY(buf.len >= digits + 1u))
+        if C4_LIKELY(buf.len >= digits + 1u)
         {
             buf.str[0] = '-';
             write_dec_unchecked(buf.sub(1), v, digits);
@@ -1159,13 +1159,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
     #endif
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         unsigned pos = 0;
         if(v < 0)
         {
             v = (T)-v;
-            if(C4_LIKELY(buf.len > 0))
+            if C4_LIKELY(buf.len > 0)
                 buf.str[pos] = '-';
             ++pos;
         }
@@ -1174,12 +1174,12 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
         {
         case T(10):
             digits = digits_dec(v);
-            if(C4_LIKELY(buf.len >= pos + digits))
+            if C4_LIKELY(buf.len >= pos + digits)
                 write_dec_unchecked(buf.sub(pos), v, digits);
             break;
         case T(16):
             digits = digits_hex(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'x';
@@ -1189,7 +1189,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
             break;
         case T(2):
             digits = digits_bin(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'b';
@@ -1199,7 +1199,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix) noexcept
             break;
         case T(8):
             digits = digits_oct(v);
-            if(C4_LIKELY(buf.len >= pos + 2u + digits))
+            if C4_LIKELY(buf.len >= pos + 2u + digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'o';
@@ -1236,13 +1236,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
     #endif
     // when T is the min value (eg i8: -128), negating it
     // will overflow, so treat the min as a special case
-    if(C4_LIKELY(v != std::numeric_limits<T>::min()))
+    if C4_LIKELY(v != std::numeric_limits<T>::min())
     {
         unsigned pos = 0;
         if(v < 0)
         {
             v = (T)-v;
-            if(C4_LIKELY(buf.len > 0))
+            if C4_LIKELY(buf.len > 0)
                 buf.str[pos] = '-';
             ++pos;
         }
@@ -1252,13 +1252,13 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(10):
             total_digits = digits_dec(v);
             total_digits = pos + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
                 write_dec(buf.sub(pos), v, num_digits);
             break;
         case T(16):
             total_digits = digits_hex(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'x';
@@ -1268,7 +1268,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(2):
             total_digits = digits_bin(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'b';
@@ -1278,7 +1278,7 @@ C4_ALWAYS_INLINE size_t itoa(substr buf, T v, T radix, size_t num_digits) noexce
         case T(8):
             total_digits = digits_oct(v);
             total_digits = pos + 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-            if(C4_LIKELY(buf.len >= total_digits))
+            if C4_LIKELY(buf.len >= total_digits)
             {
                 buf.str[pos + 0] = '0';
                 buf.str[pos + 1] = 'o';
@@ -1336,12 +1336,12 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
     {
     case T(10):
         digits = digits_dec(v);
-        if(C4_LIKELY(buf.len >= digits))
+        if C4_LIKELY(buf.len >= digits)
             write_dec_unchecked(buf, v, digits);
         break;
     case T(16):
         digits = digits_hex(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'x';
@@ -1351,7 +1351,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
         break;
     case T(2):
         digits = digits_bin(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'b';
@@ -1361,7 +1361,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix) noexcept
         break;
     case T(8):
         digits = digits_oct(v);
-        if(C4_LIKELY(buf.len >= digits+2u))
+        if C4_LIKELY(buf.len >= digits+2u)
         {
             buf.str[0] = '0';
             buf.str[1] = 'o';
@@ -1392,13 +1392,13 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(10):
         total_digits = digits_dec(v);
         total_digits = (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
             write_dec(buf, v, num_digits);
         break;
     case T(16):
         total_digits = digits_hex(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'x';
@@ -1408,7 +1408,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(2):
         total_digits = digits_bin(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'b';
@@ -1418,7 +1418,7 @@ C4_ALWAYS_INLINE size_t utoa(substr buf, T v, T radix, size_t num_digits) noexce
     case T(8):
         total_digits = digits_oct(v);
         total_digits = 2u + (unsigned)(num_digits > total_digits ? num_digits : total_digits);
-        if(C4_LIKELY(buf.len >= total_digits))
+        if C4_LIKELY(buf.len >= total_digits)
         {
             buf.str[0] = '0';
             buf.str[1] = 'o';
@@ -1468,7 +1468,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     C4_STATIC_ASSERT(std::is_integral<T>::value);
     C4_STATIC_ASSERT(std::is_signed<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
         return false;
     // no need for the assertion, but we leave it here to document
     // the expectation:
@@ -1478,7 +1478,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     size_t start = 0;
     if(str.str[0] == '-')
     {
-        if(C4_UNLIKELY(str.len == ++start))
+        if C4_UNLIKELY(str.len == ++start)
             return false;
         sign = -1;
     }
@@ -1505,7 +1505,7 @@ C4_ALWAYS_INLINE bool atoi(csubstr str, T * C4_RESTRICT v) noexcept
     {
         parsed_ok = read_dec(str.sub(start), v);
     }
-    if(C4_LIKELY(parsed_ok))
+    if C4_LIKELY(parsed_ok)
         *v *= sign;
     return parsed_ok;
 }
@@ -1559,7 +1559,7 @@ bool atou(csubstr str, T * C4_RESTRICT v) noexcept
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0 || str.front() == '-'))
+    if C4_UNLIKELY(str.len == 0 || str.front() == '-')
         return false;
 
     bool parsed_ok = true;
@@ -1656,7 +1656,7 @@ auto overflows(csubstr str) noexcept
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
 
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
     {
         return false;
     }
@@ -1699,7 +1699,7 @@ auto overflows(csubstr str) noexcept
             }
         }
     }
-    else if(C4_UNLIKELY(str.str[0] == '-'))
+    else if C4_UNLIKELY(str.str[0] == '-')
     {
         return true;
     }
@@ -1722,7 +1722,7 @@ auto overflows(csubstr str) noexcept
     -> typename std::enable_if<std::is_signed<T>::value, bool>::type
 {
     C4_STATIC_ASSERT(std::is_integral<T>::value);
-    if(C4_UNLIKELY(str.len == 0))
+    if C4_UNLIKELY(str.len == 0)
         return false;
     if(str.str[0] == '-')
     {
@@ -2031,14 +2031,14 @@ C4_ALWAYS_INLINE bool scan_rhex(csubstr s, T *C4_RESTRICT val) noexcept
     }
     return true;
 power:
-    if(C4_LIKELY(pos < s.len))
+    if C4_LIKELY(pos < s.len)
     {
         if(s.str[pos] == '+') // atoi() cannot handle a leading '+'
             ++pos;
-        if(C4_LIKELY(pos < s.len))
+        if C4_LIKELY(pos < s.len)
         {
             int16_t powval = {};
-            if(C4_LIKELY(atoi(s.sub(pos), &powval)))
+            if C4_LIKELY(atoi(s.sub(pos), &powval))
             {
                 *val *= ipow<T, int16_t, 16>(powval);
                 return true;
@@ -2499,7 +2499,7 @@ inline bool from_chars(csubstr buf, bool * C4_RESTRICT v) noexcept
     // fallback to c-style int bools
     int val = 0;
     bool ret = from_chars(buf, &val);
-    if(C4_LIKELY(ret))
+    if C4_LIKELY(ret)
     {
         *v = (val != 0);
     }
@@ -2638,7 +2638,7 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
 {
     csubstr trimmed = buf.first_non_empty_span();
     C4_ASSERT(!trimmed.overlaps(*v));
-    if(C4_UNLIKELY(trimmed.len == 0))
+    if C4_UNLIKELY(trimmed.len == 0)
         return csubstr::npos;
     size_t len = trimmed.len > v->len ? v->len : trimmed.len;
     // calling memcpy with zero len is undefined behavior
@@ -2650,7 +2650,7 @@ inline size_t from_chars_first(csubstr buf, substr * C4_RESTRICT v) noexcept
         C4_ASSERT(v->str != nullptr);
         memcpy(v->str, trimmed.str, len);
     }
-    if(C4_UNLIKELY(trimmed.len > v->len))
+    if C4_UNLIKELY(trimmed.len > v->len)
         return csubstr::npos;
     return static_cast<size_t>(trimmed.end() - buf.begin());
 }

--- a/ext/c4core.src/c4/dump.hpp
+++ b/ext/c4core.src/c4/dump.hpp
@@ -117,7 +117,7 @@ size_t dump(substr buf, Arg const& a)
         // serialize to the buffer
         const size_t sz = to_chars(buf, a);
         // dump the buffer to the sink
-        if(C4_LIKELY(sz <= buf.len))
+        if C4_LIKELY(sz <= buf.len)
         {
             // NOTE: don't do this:
             //sinkfn(buf.first(sz));
@@ -171,7 +171,7 @@ size_t dump(SinkFn &&sinkfn, substr buf, Arg const& a)
         // serialize to the buffer
         const size_t sz = to_chars(buf, a);
         // dump the buffer to the sink
-        if(C4_LIKELY(sz <= buf.len))
+        if C4_LIKELY(sz <= buf.len)
         {
             // NOTE: don't do this:
             //std::forward<SinkFn>(sinkfn)(buf.first(sz));
@@ -218,7 +218,7 @@ inline auto dump(substr buf, Arg const& a)
     // serialize to the buffer
     const size_t sz = to_chars(buf, a);
     // dump the buffer to the sink
-    if(C4_LIKELY(sz <= buf.len))
+    if C4_LIKELY(sz <= buf.len)
     {
         // NOTE: don't do this:
         //sinkfn(buf.first(sz));
@@ -237,7 +237,7 @@ inline auto dump(SinkFn &&sinkfn, substr buf, Arg const& a)
     // serialize to the buffer
     const size_t sz = to_chars(buf, a);
     // dump the buffer to the sink
-    if(C4_LIKELY(sz <= buf.len))
+    if C4_LIKELY(sz <= buf.len)
     {
         // NOTE: don't do this:
         //std::forward<SinkFn>(sinkfn)(buf.first(sz));
@@ -322,7 +322,7 @@ template<class SinkFn, class Arg, class... Args>
 size_t cat_dump(SinkFn &&sinkfn, substr buf, Arg const& a, Args const& ...more)
 {
     const size_t size_for_a = dump(std::forward<SinkFn>(sinkfn), buf, a);
-    if(C4_UNLIKELY(size_for_a > buf.len))
+    if C4_UNLIKELY(size_for_a > buf.len)
         buf.len = 0; // ensure no more calls to the sink
     const size_t size_for_more = cat_dump(std::forward<SinkFn>(sinkfn), buf, more...);
     return size_for_more > size_for_a ? size_for_more : size_for_a;
@@ -348,7 +348,7 @@ template<SinkPfn sinkfn, class Arg, class... Args>
 size_t cat_dump(substr buf, Arg const& a, Args const& ...more)
 {
     const size_t size_for_a = dump<sinkfn>(buf, a);
-    if(C4_UNLIKELY(size_for_a > buf.len))
+    if C4_UNLIKELY(size_for_a > buf.len)
         buf.len = 0; // ensure no more calls to the sink
     const size_t size_for_more = cat_dump<sinkfn>(buf, more...);
     return size_for_more > size_for_a ? size_for_more : size_for_a;
@@ -379,7 +379,7 @@ C4_ALWAYS_INLINE DumpResults cat_dump_resume(size_t, SinkFn &&, DumpResults resu
 template<SinkPfn sinkfn, class Arg, class... Args>
 DumpResults cat_dump_resume(size_t currarg, DumpResults results, substr buf, Arg const& C4_RESTRICT a, Args const& ...more)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         size_t sz = dump<sinkfn>(buf, a);  // yield to the specialized function
         if(currarg == results.lastok + 1 && sz <= buf.len)
@@ -392,7 +392,7 @@ DumpResults cat_dump_resume(size_t currarg, DumpResults results, substr buf, Arg
 template<class SinkFn, class Arg, class... Args>
 DumpResults cat_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults results, substr buf, Arg const& C4_RESTRICT a, Args const& ...more)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         size_t sz = dump(std::forward<SinkFn>(sinkfn), buf, a);  // yield to the specialized function
         if(currarg == results.lastok + 1 && sz <= buf.len)
@@ -462,12 +462,12 @@ template<class SinkFn, class Sep, class Arg, class... Args>
 size_t catsep_dump(SinkFn &&sinkfn, substr buf, Sep const& sep, Arg const& a, Args const& ...more)
 {
     size_t sz = dump(std::forward<SinkFn>(sinkfn), buf, a);
-    if(C4_UNLIKELY(sz > buf.len))
+    if C4_UNLIKELY(sz > buf.len)
         buf.len = 0; // ensure no more calls
     if C4_IF_CONSTEXPR (sizeof...(more) > 0)
     {
         size_t szsep = dump(std::forward<SinkFn>(sinkfn), buf, sep);
-        if(C4_UNLIKELY(szsep > buf.len))
+        if C4_UNLIKELY(szsep > buf.len)
             buf.len = 0; // ensure no more calls
         sz = sz > szsep ? sz : szsep;
     }
@@ -480,12 +480,12 @@ template<SinkPfn sinkfn, class Sep, class Arg, class... Args>
 size_t catsep_dump(substr buf, Sep const& sep, Arg const& a, Args const& ...more)
 {
     size_t sz = dump<sinkfn>(buf, a);
-    if(C4_UNLIKELY(sz > buf.len))
+    if C4_UNLIKELY(sz > buf.len)
         buf.len = 0; // ensure no more calls
     if C4_IF_CONSTEXPR (sizeof...(more) > 0)
     {
         size_t szsep = dump<sinkfn>(buf, sep);
-        if(C4_UNLIKELY(szsep > buf.len))
+        if C4_UNLIKELY(szsep > buf.len)
             buf.len = 0; // ensure no more calls
         sz = sz > szsep ? sz : szsep;
     }
@@ -503,11 +503,11 @@ namespace detail {
 template<SinkPfn sinkfn, class Arg>
 void catsep_dump_resume_(size_t currarg, DumpResults *C4_RESTRICT results, substr *buf, Arg const& a)
 {
-    if(C4_LIKELY(results->write_arg(currarg)))
+    if C4_LIKELY(results->write_arg(currarg))
     {
         size_t sz = dump<sinkfn>(*buf, a);
         results->bufsize = sz > results->bufsize ? sz : results->bufsize;
-        if(C4_LIKELY(sz <= buf->len))
+        if C4_LIKELY(sz <= buf->len)
             results->lastok = currarg;
         else
             buf->len = 0;
@@ -517,11 +517,11 @@ void catsep_dump_resume_(size_t currarg, DumpResults *C4_RESTRICT results, subst
 template<class SinkFn, class Arg>
 void catsep_dump_resume_(size_t currarg, SinkFn &&sinkfn, DumpResults *C4_RESTRICT results, substr *C4_RESTRICT buf, Arg const& C4_RESTRICT a)
 {
-    if(C4_LIKELY(results->write_arg(currarg)))
+    if C4_LIKELY(results->write_arg(currarg))
     {
         size_t sz = dump(std::forward<SinkFn>(sinkfn), *buf, a);
         results->bufsize = sz > results->bufsize ? sz : results->bufsize;
-        if(C4_LIKELY(sz <= buf->len))
+        if C4_LIKELY(sz <= buf->len)
             results->lastok = currarg;
         else
             buf->len = 0;
@@ -650,7 +650,7 @@ C4_NO_INLINE size_t format_dump(SinkFn &&sinkfn, substr buf, csubstr fmt, Arg co
     // we can dump without using buf
     // but we'll only dump if the buffer is ok
     size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
     {
         std::forward<SinkFn>(sinkfn)(fmt);
         return 0u;
@@ -660,7 +660,7 @@ C4_NO_INLINE size_t format_dump(SinkFn &&sinkfn, substr buf, csubstr fmt, Arg co
     pos = dump(std::forward<SinkFn>(sinkfn), buf, a); // reuse pos to get needed_size
     // dump no more if the buffer was exhausted
     size_t size_for_more;
-    if(C4_LIKELY(pos <= buf.len))
+    if C4_LIKELY(pos <= buf.len)
         size_for_more = format_dump(std::forward<SinkFn>(sinkfn), buf, fmt, more...);
     else
         size_for_more = detail::_format_dump_compute_size(more...);
@@ -674,7 +674,7 @@ C4_NO_INLINE size_t format_dump(substr buf, csubstr fmt, Arg const& C4_RESTRICT 
     // we can dump without using buf
     // but we'll only dump if the buffer is ok
     size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
     {
         sinkfn(fmt);
         return 0u;
@@ -684,7 +684,7 @@ C4_NO_INLINE size_t format_dump(substr buf, csubstr fmt, Arg const& C4_RESTRICT 
     pos = dump<sinkfn>(buf, a); // reuse pos to get needed_size
     // dump no more if the buffer was exhausted
     size_t size_for_more;
-    if(C4_LIKELY(pos <= buf.len))
+    if C4_LIKELY(pos <= buf.len)
         size_for_more = format_dump<sinkfn>(buf, fmt, more...);
     else
         size_for_more = detail::_format_dump_compute_size(more...);
@@ -702,7 +702,7 @@ namespace detail {
 template<SinkPfn sinkfn>
 DumpResults format_dump_resume(size_t currarg, DumpResults results, substr, csubstr fmt)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         // we can dump without using buf
         sinkfn(fmt);
@@ -715,7 +715,7 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr, csub
 template<class SinkFn>
 DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults results, substr, csubstr fmt)
 {
-    if(C4_LIKELY(results.write_arg(currarg)))
+    if C4_LIKELY(results.write_arg(currarg))
     {
         // we can dump without using buf
         std::forward<SinkFn>(sinkfn)(fmt);
@@ -730,18 +730,18 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr buf, 
     // we need to process the format even if we're not
     // going to print the first arguments because we're resuming
     const size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_LIKELY(pos != csubstr::npos))
+    if C4_LIKELY(pos != csubstr::npos)
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             sinkfn(fmt.first(pos));
             results.lastok = currarg;
         }
-        if(C4_LIKELY(results.write_arg(currarg + 1u)))
+        if C4_LIKELY(results.write_arg(currarg + 1u))
         {
             const size_t len = dump<sinkfn>(buf, a);
             results.bufsize = len > results.bufsize ? len : results.bufsize;
-            if(C4_LIKELY(len <= buf.len))
+            if C4_LIKELY(len <= buf.len)
             {
                 results.lastok = currarg + 1u;
             }
@@ -755,7 +755,7 @@ DumpResults format_dump_resume(size_t currarg, DumpResults results, substr buf, 
     }
     else
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             sinkfn(fmt);
             results.lastok = currarg;
@@ -775,18 +775,18 @@ DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults resu
     // we need to process the format even if we're not
     // going to print the first arguments because we're resuming
     const size_t pos = fmt.find("{}"); // @todo use _find_fmt()
-    if(C4_LIKELY(pos != csubstr::npos))
+    if C4_LIKELY(pos != csubstr::npos)
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             std::forward<SinkFn>(sinkfn)(fmt.first(pos));
             results.lastok = currarg;
         }
-        if(C4_LIKELY(results.write_arg(currarg + 1u)))
+        if C4_LIKELY(results.write_arg(currarg + 1u))
         {
             const size_t len = dump(std::forward<SinkFn>(sinkfn), buf, a);
             results.bufsize = len > results.bufsize ? len : results.bufsize;
-            if(C4_LIKELY(len <= buf.len))
+            if C4_LIKELY(len <= buf.len)
             {
                 results.lastok = currarg + 1u;
             }
@@ -800,7 +800,7 @@ DumpResults format_dump_resume(size_t currarg, SinkFn &&sinkfn, DumpResults resu
     }
     else
     {
-        if(C4_LIKELY(results.write_arg(currarg)))
+        if C4_LIKELY(results.write_arg(currarg))
         {
             std::forward<SinkFn>(sinkfn)(fmt);
             results.lastok = currarg;

--- a/ext/c4core.src/c4/error.hpp
+++ b/ext/c4core.src/c4/error.hpp
@@ -333,7 +333,7 @@ C4CORE_EXPORT void handle_warning(srcloc s, const char *fmt, ...);
  */
 #define C4_CHECK(cond)                              \
     do {                                            \
-        if(C4_UNLIKELY(!(cond)))                    \
+        if C4_UNLIKELY(!(cond))                     \
         {                                           \
             C4_ERROR("check failed: %s", #cond);    \
         }                                           \
@@ -345,7 +345,7 @@ C4CORE_EXPORT void handle_warning(srcloc s, const char *fmt, ...);
  * @ingroup error_checking */
 #define C4_CHECK_MSG(cond, fmt, ...)                                    \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             C4_ERROR("check failed: " #cond "\n" fmt, ## __VA_ARGS__);  \
         }                                                               \

--- a/ext/c4core.src/c4/format.hpp
+++ b/ext/c4core.src/c4/format.hpp
@@ -321,7 +321,7 @@ C4_ALWAYS_INLINE auto to_chars(substr buf, fmt::integral_padded_<T> fmt)
 template<class T>
 C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> wrapper)
 {
-    if(C4_LIKELY(!overflows<T>(s)))
+    if C4_LIKELY(!overflows<T>(s))
         return atox(s, wrapper.val);
     return false;
 }
@@ -330,7 +330,7 @@ C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> wrapper)
 template<class T>
 C4_ALWAYS_INLINE bool from_chars(csubstr s, fmt::overflow_checked_<T> *wrapper)
 {
-    if(C4_LIKELY(!overflows<T>(s)))
+    if C4_LIKELY(!overflows<T>(s))
         return atox(s, wrapper->val);
     return false;
 }
@@ -690,11 +690,11 @@ template<class Arg, class... Args>
 size_t uncat(csubstr buf, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
     size_t out = from_chars_first(buf, &a);
-    if(C4_UNLIKELY(out == csubstr::npos))
+    if C4_UNLIKELY(out == csubstr::npos)
         return csubstr::npos;
     buf  = buf.len >= out ? buf.sub(out) : substr{};
     size_t num = uncat(buf, more...);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     return out + num;
 }
@@ -818,16 +818,16 @@ inline size_t uncatsep(csubstr buf, csubstr /*sep*/, Arg &C4_RESTRICT a)
 template<class Arg, class... Args>
 size_t uncatsep(csubstr buf, csubstr sep, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
-    if(C4_LIKELY(sep.len > 0))
+    if C4_LIKELY(sep.len > 0)
     {
         size_t pos = buf.find(sep);
-        if(C4_LIKELY(pos != csubstr::npos))
+        if C4_LIKELY(pos != csubstr::npos)
         {
-            if(C4_LIKELY(from_chars(buf.first(pos), &a)))
+            if C4_LIKELY(from_chars(buf.first(pos), &a))
             {
                 pos += sep.len;
                 size_t num = uncatsep(buf.sub(pos), sep, more...);
-                if(C4_LIKELY(num != csubstr::npos))
+                if C4_LIKELY(num != csubstr::npos)
                     return pos + num;
             }
         }
@@ -936,7 +936,7 @@ template<class Arg, class... Args>
 size_t format(substr buf, csubstr fmt, Arg const& C4_RESTRICT a, Args const& C4_RESTRICT ...more)
 {
     size_t pos = fmt.find("{}");
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
         return to_chars(buf, fmt);
     size_t num = to_chars(buf, fmt.first(pos));
     size_t out = num;
@@ -987,18 +987,18 @@ template<class Arg, class... Args>
 size_t unformat(csubstr buf, csubstr fmt, Arg & C4_RESTRICT a, Args & C4_RESTRICT ...more)
 {
     const size_t pos = fmt.find("{}");
-    if(C4_UNLIKELY(pos == csubstr::npos))
+    if C4_UNLIKELY(pos == csubstr::npos)
         return unformat(buf, fmt);
     size_t num = pos;
     size_t out = num;
     buf  = buf.len >= num ? buf.sub(num) : substr{};
     num  = from_chars_first(buf, &a);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     out += num;
     buf  = buf.len >= num ? buf.sub(num) : substr{};
     num  = unformat(buf, fmt.sub(pos + 2), more...);
-    if(C4_UNLIKELY(num == csubstr::npos))
+    if C4_UNLIKELY(num == csubstr::npos)
         return csubstr::npos;
     out += num;
     return out;

--- a/ext/c4core.src/c4/language.hpp
+++ b/ext/c4core.src/c4/language.hpp
@@ -18,45 +18,39 @@
 #           if (!defined(_MSVC_LANG))
 #               error _MSVC not defined
 #           endif
-#           if _MSVC_LANG >= 201705L
+#           if _MSVC_LANG >= 202302L
+#               define C4_CPP 23
+#           elif _MSVC_LANG >= 202002L
 #               define C4_CPP 20
-#               define C4_CPP20
 #           elif _MSVC_LANG == 201703L
 #               define C4_CPP 17
-#               define C4_CPP17
 #           elif _MSVC_LANG >= 201402L
 #               define C4_CPP 14
-#               define C4_CPP14
 #           elif _MSVC_LANG >= 201103L
 #               define C4_CPP 11
-#               define C4_CPP11
 #           else
 #               error C++ lesser than C++11 not supported
 #           endif
 #       else
 #           if _MSC_VER == 1900
 #               define C4_CPP 14  // VS2015 is c++14 https://devblogs.microsoft.com/cppblog/c111417-features-in-vs-2015-rtm/
-#               define C4_CPP14
 #           elif _MSC_VER == 1800 // VS2013
 #               define C4_CPP 11
-#               define C4_CPP11
 #           else
 #               error C++ lesser than C++11 not supported
 #           endif
 #       endif
-#   elif defined(__INTEL_COMPILER) // https://software.intel.com/en-us/node/524490
-#       ifdef __INTEL_CXX20_MODE__ // not sure about this
+#   elif defined(__INTEL_COMPILER) // not sure about this https://software.intel.com/en-us/node/524490
+#       ifdef __INTEL_CXX23_MODE__
+#           define C4_CPP 23
+#       elif defined __INTEL_CXX20_MODE__
 #           define C4_CPP 20
-#           define C4_CPP20
-#       elif defined __INTEL_CXX17_MODE__ // not sure about this
+#       elif defined __INTEL_CXX17_MODE__
 #           define C4_CPP 17
-#           define C4_CPP17
-#       elif defined __INTEL_CXX14_MODE__ // not sure about this
+#       elif defined __INTEL_CXX14_MODE__
 #           define C4_CPP 14
-#           define C4_CPP14
 #       elif defined __INTEL_CXX11_MODE__
 #           define C4_CPP 11
-#           define C4_CPP11
 #       else
 #           error C++ lesser than C++11 not supported
 #       endif
@@ -66,49 +60,37 @@
 #       endif
 #       if __cplusplus == 1
 #           error cannot handle __cplusplus==1
-#       elif __cplusplus >= 201709L
+#       elif __cplusplus >= 202302L
+#           define C4_CPP 23
+#       elif __cplusplus >= 202002L
 #           define C4_CPP 20
-#           define C4_CPP20
 #       elif __cplusplus >= 201703L
 #           define C4_CPP 17
-#           define C4_CPP17
 #       elif __cplusplus >= 201402L
 #           define C4_CPP 14
-#           define C4_CPP14
 #       elif __cplusplus >= 201103L
 #           define C4_CPP 11
-#           define C4_CPP11
 #       elif __cplusplus >= 199711L
 #           error C++ lesser than C++11 not supported
 #       endif
 #   endif
-#else
-#   ifdef C4_CPP == 20
-#       define C4_CPP20
-#   elif C4_CPP == 17
-#       define C4_CPP17
-#   elif C4_CPP == 14
-#       define C4_CPP14
-#   elif C4_CPP == 11
-#       define C4_CPP11
-#   elif C4_CPP == 98
-#       define C4_CPP98
-#       error C++ lesser than C++11 not supported
-#   else
-#       error C4_CPP must be one of 20, 17, 14, 11, 98
-#   endif
+#endif
+#if C4_CPP >= 23
+#   define C4_CPP23
+#endif
+#if C4_CPP >= 20
+#   define C4_CPP20
+#endif
+#if C4_CPP >= 17
+#   define C4_CPP17
+#endif
+#if C4_CPP >= 14
+#   define C4_CPP14
+#endif
+#if C4_CPP >= 11
+#   define C4_CPP11
 #endif
 
-#ifdef C4_CPP20
-#   define C4_CPP17
-#   define C4_CPP14
-#   define C4_CPP11
-#elif defined(C4_CPP17)
-#   define C4_CPP14
-#   define C4_CPP11
-#elif defined(C4_CPP14)
-#   define C4_CPP11
-#endif
 
 /** lifted from this answer: http://stackoverflow.com/a/20170989/5875572 */
 #if defined(_MSC_VER) && !defined(__clang__)
@@ -195,6 +177,7 @@
 #define C4_BEGIN_HIDDEN_NAMESPACE namespace /*hidden*/ {
 #define C4_END_HIDDEN_NAMESPACE } /* namespace hidden */
 
+
 //------------------------------------------------------------
 
 #ifndef C4_API
@@ -224,8 +207,6 @@
 #   define C4_COLD        /** @todo */
 #   define C4_ASSUME(...) __assume(__VA_ARGS__)
 #   define C4_EXPECT(x, y) x /** @todo */
-#   define C4_LIKELY(x)   x
-#   define C4_UNLIKELY(x) x
 #   define C4_UNREACHABLE() _c4_msvc_unreachable()
 #   define C4_ATTR_FORMAT(...) /** */
 #   define C4_NORETURN [[noreturn]]
@@ -263,8 +244,6 @@
  * @see http://stackoverflow.com/questions/15028990/semantics-of-gcc-hot-attribute */
 #   define C4_COLD __attribute__((cold))
 #   define C4_EXPECT(x, y) __builtin_expect(x, y) ///< @see https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
-#   define C4_LIKELY(x)   __builtin_expect(x, 1)
-#   define C4_UNLIKELY(x) __builtin_expect(x, 0)
 #   define C4_UNREACHABLE() __builtin_unreachable()
 #   define C4_ATTR_FORMAT(...) //__attribute__((format (__VA_ARGS__))) ///< @see https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#Common-Function-Attributes
 #   define C4_NORETURN __attribute__((noreturn))
@@ -305,6 +284,30 @@
 #   ifndef C4_ASSUME
 #       define C4_ASSUME(...)
 #   endif
+#endif
+
+
+#ifdef __has_cpp_attribute
+#   if (__has_cpp_attribute(unlikely) >= 201803L) && (C4_CPP >= 20)
+#       define C4_UNLIKELY_IS_ATTR_
+#   endif
+#endif
+
+#ifdef C4_UNLIKELY_IS_ATTR_
+#   define C4_LIKELY(x)   (x) [[likely]]
+#   define C4_UNLIKELY(x) (x) [[unlikely]]
+#   define C4_LIKELY20   [[likely]]
+#   define C4_UNLIKELY20 [[unlikely]]
+#elif defined(__clang__) || defined(__GNUC__)
+#   define C4_LIKELY(x)   (__builtin_expect(x, 1))
+#   define C4_UNLIKELY(x) (__builtin_expect(x, 0))
+#   define C4_LIKELY20
+#   define C4_UNLIKELY20
+#elif defined(_MSC_VER)
+#   define C4_LIKELY(x)   (x)
+#   define C4_UNLIKELY(x) (x)
+#   define C4_LIKELY20
+#   define C4_UNLIKELY20
 #endif
 
 

--- a/ext/c4core.src/c4/memory_util.cpp
+++ b/ext/c4core.src/c4/memory_util.cpp
@@ -8,7 +8,7 @@ namespace c4 {
 void mem_repeat(void* dest, void const* pattern, size_t pattern_size, size_t num_times)
 {
     C4_ASSERT( ! mem_overlaps(dest, pattern, num_times*pattern_size, pattern_size));
-    if(C4_UNLIKELY(num_times == 0))
+    if C4_UNLIKELY(num_times == 0)
         return;
     char *C4_RESTRICT begin = static_cast<char*>(dest);
     char *C4_RESTRICT end   = begin + (num_times * pattern_size);

--- a/ext/c4core.src/c4/substr.hpp
+++ b/ext/c4core.src/c4/substr.hpp
@@ -385,7 +385,7 @@ public:
     C4_ALWAYS_INLINE C4_PURE int compare(C const c) const noexcept
     {
         C4_XASSERT((str != nullptr) || len == 0);
-        if(C4_LIKELY(str != nullptr && len > 0))
+        if C4_LIKELY(str != nullptr && len > 0)
             return (*str != c) ? *str - c : (static_cast<int>(len) - 1);
         else
             return -1;
@@ -393,12 +393,13 @@ public:
 
     C4_PURE int compare(C const* C4_RESTRICT that, size_t sz) const noexcept
     {
+        C4_SUPPRESS_WARNING_GCC_PUSH
         #if defined(__GNUC__) && (__GNUC__ >= 6)
-        C4_SUPPRESS_WARNING_GCC_WITH_PUSH("-Wnull-dereference")
+        C4_SUPPRESS_WARNING_GCC("-Wnull-dereference")
         #endif
         C4_XASSERT(that || sz  == 0);
         C4_XASSERT(str  || len == 0);
-        if(C4_LIKELY(str && that))
+        if C4_LIKELY(str && that)
         {
             {
                 const size_t min = len < sz ? len : sz;
@@ -419,9 +420,7 @@ public:
             return 0;
         }
         return len < sz ? -1 : 1;
-        #if defined(__GNUC__) && (__GNUC__ >= 6)
         C4_SUPPRESS_WARNING_GCC_POP
-        #endif
     }
 
     template<class CharPtr>
@@ -484,7 +483,7 @@ public:
     /** true if that is a substring of *this (ie, from the same buffer) */
     C4_ALWAYS_INLINE C4_PURE bool is_super(ro_substr const that) const noexcept
     {
-        if(C4_LIKELY(len > 0))
+        if C4_LIKELY(len > 0)
             return that.str >= str && that.str+that.len <= str+len;
         else
             return that.len == 0 && that.str == str && str != nullptr;
@@ -1809,7 +1808,7 @@ public:
      * is an empty string, the output string is the empty string. */
     bool next_split(C sep, size_t *C4_RESTRICT start_pos, basic_substring *C4_RESTRICT out) const
     {
-        if(C4_LIKELY(*start_pos < len))
+        if C4_LIKELY(*start_pos < len)
         {
             for(size_t i = *start_pos; i < len; i++)
             {
@@ -1925,7 +1924,7 @@ public:
      */
     basic_substring pop_right(C sep=C('/'), bool skip_empty=false) const
     {
-        if(C4_LIKELY(len > 1))
+        if C4_LIKELY(len > 1)
         {
             auto pos = last_of(sep);
             if(pos != npos)
@@ -1978,7 +1977,7 @@ public:
      * the reciprocal part. */
     basic_substring pop_left(C sep = C('/'), bool skip_empty=false) const
     {
-        if(C4_LIKELY(len > 1))
+        if C4_LIKELY(len > 1)
         {
             auto pos = first_of(sep);
             if(pos != npos)

--- a/samples/quickstart.cpp
+++ b/samples/quickstart.cpp
@@ -6862,7 +6862,7 @@ struct PerTreeMemoryExample
         void *ptr = &memory_pool[alloc_size];
         alloc_size += len;
         ++num_allocs;
-        if(C4_UNLIKELY(alloc_size > memory_pool.size()))
+        if C4_UNLIKELY(alloc_size > memory_pool.size())
         {
             std::cerr << "out of memory! requested=" << alloc_size << " vs " << memory_pool.size() << " available" << std::endl; // LCOV_EXCL_LINE
             std::abort(); // LCOV_EXCL_LINE

--- a/src/c4/yml/emitter.def.hpp
+++ b/src/c4/yml/emitter.def.hpp
@@ -888,7 +888,7 @@ void Emitter<Writer>::visit_blck_(id_type node)
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), !ty.is_stream(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), ty.is_container() || ty.is_doc(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), m_tree->is_root(node) || (m_tree->parent_is_map(node) || m_tree->parent_is_seq(node)), m_tree, node);
-    if(C4_UNLIKELY(m_depth > m_opts.max_depth()))
+    if C4_UNLIKELY(m_depth > m_opts.max_depth())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, node, "max depth exceeded");
     if(ty.is_seq())
     {
@@ -911,7 +911,7 @@ void Emitter<Writer>::visit_flow_sl_(id_type node)
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), !ty.is_stream(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), ty.is_container() || ty.is_doc(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), m_tree->is_root(node) || (m_tree->parent_is_map(node) || m_tree->parent_is_seq(node)), m_tree, node);
-    if(C4_UNLIKELY(m_depth > m_opts.max_depth()))
+    if C4_UNLIKELY(m_depth > m_opts.max_depth())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, node, "max depth exceeded");
     if(ty.m_bits & SEQ)
     {
@@ -934,7 +934,7 @@ void Emitter<Writer>::visit_flow_ml_(id_type node)
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), !ty.is_stream(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), ty.is_container() || ty.is_doc(), m_tree, node);
     RYML_ASSERT_VISIT_CB_(m_tree->callbacks(), m_tree->is_root(node) || (m_tree->parent_is_map(node) || m_tree->parent_is_seq(node)), m_tree, node);
-    if(C4_UNLIKELY(m_depth > m_opts.max_depth()))
+    if C4_UNLIKELY(m_depth > m_opts.max_depth())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, node, "max depth exceeded");
     if(ty.m_bits & SEQ)
     {
@@ -1308,7 +1308,7 @@ void Emitter<Writer>::write_scalar_dquo_(csubstr s, id_type ilevel)
 template<class Writer>
 void Emitter<Writer>::write_scalar_plain_(csubstr s, id_type ilevel)
 {
-    if(C4_UNLIKELY(ilevel == 0 && (s.begins_with("...") || s.begins_with("---"))))
+    if C4_UNLIKELY(ilevel == 0 && (s.begins_with("...") || s.begins_with("---")))
     {
         indent_(ilevel + 1); // indent the next line
         ++ilevel;
@@ -1361,7 +1361,7 @@ void Emitter<Writer>::json_emit_(id_type id)
 {
     NodeType ty = m_tree->type(id);
     // JSON does not have streams
-    if(C4_UNLIKELY(ty.is_stream() && m_opts.json_err_on_stream()))
+    if C4_UNLIKELY(ty.is_stream() && m_opts.json_err_on_stream())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "found stream node");
     static_assert(STREAM & SEQ, "STREAM must be a SEQ");
     ty = detail::json_type_(ty);
@@ -1379,7 +1379,7 @@ void Emitter<Writer>::json_emit_(id_type id)
 template<class Writer>
 void Emitter<Writer>::json_visit_sl_(id_type id, NodeType ty, id_type depth)
 {
-    if(C4_UNLIKELY(depth > m_opts.max_depth()))
+    if C4_UNLIKELY(depth > m_opts.max_depth())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "max depth exceeded");
     if(ty.is_val())
     {
@@ -1426,7 +1426,7 @@ void Emitter<Writer>::json_visit_sl_(id_type id, NodeType ty, id_type depth)
 template<class Writer>
 void Emitter<Writer>::json_visit_ml_(id_type id, NodeType ty, id_type depth)
 {
-    if(C4_UNLIKELY(depth > m_opts.max_depth()))
+    if C4_UNLIKELY(depth > m_opts.max_depth())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "max depth exceeded");
     if(ty.is_val())
     {
@@ -1556,9 +1556,9 @@ write_nan:
 template<class Writer>
 void Emitter<Writer>::json_writek_(id_type id, NodeType ty)
 {
-    if(C4_UNLIKELY(ty.has_key_tag() && m_opts.json_err_on_tag()))
+    if C4_UNLIKELY(ty.has_key_tag() && m_opts.json_err_on_tag())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "JSON does not have tags");
-    if(C4_UNLIKELY(ty.has_key_anchor() && m_opts.json_err_on_anchor()))
+    if C4_UNLIKELY(ty.has_key_anchor() && m_opts.json_err_on_anchor())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "JSON does not have anchors");
     csubstr key = m_tree->key(id);
     if(key.len)
@@ -1577,9 +1577,9 @@ void Emitter<Writer>::json_writek_(id_type id, NodeType ty)
 template<class Writer>
 void Emitter<Writer>::json_writev_(id_type id, NodeType ty)
 {
-    if(C4_UNLIKELY(ty.has_val_tag() && m_opts.json_err_on_tag()))
+    if C4_UNLIKELY(ty.has_val_tag() && m_opts.json_err_on_tag())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "JSON does not have tags");
-    if(C4_UNLIKELY(ty.has_val_anchor() && m_opts.json_err_on_anchor()))
+    if C4_UNLIKELY(ty.has_val_anchor() && m_opts.json_err_on_anchor())
         RYML_ERR_VISIT_CB_(m_tree->callbacks(), m_tree, id, "JSON does not have anchors");
     csubstr val = m_tree->val(id);
     if(val.len)

--- a/src/c4/yml/error.hpp
+++ b/src/c4/yml/error.hpp
@@ -80,7 +80,7 @@ struct SubstrWriter_
 // doesn't fit
 inline C4_NO_INLINE csubstr _maybe_add_ellipsis(substr buf, size_t len)
 {
-    if(C4_UNLIKELY(len > buf.len))
+    if C4_UNLIKELY(len > buf.len)
     {
         const size_t numdots = (buf.len > 3) ? 3 : buf.len;
         buf.last(numdots).fill('.');
@@ -663,7 +663,7 @@ CharContainer format_exc(ExceptionT const& exc)
 
 #define RYML_CHECK_BASIC_(cond)                                         \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_basic((::c4::yml::ErrorDataBasic{RYML_LOC_HERE()}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -672,7 +672,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_PARSE_(cond, ymlloc)                                 \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_parse((::c4::yml::ErrorDataParse{RYML_LOC_HERE(), ymlloc}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -681,7 +681,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_VISIT_(cond, tree, node)                             \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_visit((::c4::yml::ErrorDataVisit{RYML_LOC_HERE(), tree, node}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -692,7 +692,7 @@ CharContainer format_exc(ExceptionT const& exc)
 
 #define RYML_CHECK_BASIC_CB_(cb, cond)                                  \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_basic((cb), (::c4::yml::ErrorDataBasic{RYML_LOC_HERE()}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -701,7 +701,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_PARSE_CB_(cb, cond, ymlloc)                          \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_parse((cb), (::c4::yml::ErrorDataParse{RYML_LOC_HERE(), ymlloc}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -710,7 +710,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_VISIT_CB_(cb, cond, tree, node)                      \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_visit((cb), (::c4::yml::ErrorDataVisit{RYML_LOC_HERE(), tree, node}), "check failed" RYML_MAYBE_MSG_(cond)); \
@@ -721,7 +721,7 @@ CharContainer format_exc(ExceptionT const& exc)
 
 #define RYML_CHECK_BASIC_CB_MSG_(cond, ...)                             \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_basic((::c4::yml::ErrorDataBasic{RYML_LOC_HERE()}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \
@@ -730,7 +730,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_PARSE_CB_MSG_(cond, ymlloc, ...)                     \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_parse((::c4::yml::ErrorDataParse{RYML_LOC_HERE(), ymlloc}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \
@@ -739,7 +739,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_VISIT_CB_MSG_(cond, tree, node, ...)                 \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_visit((::c4::yml::ErrorDataVisit{RYML_LOC_HERE(), tree, node}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \
@@ -750,7 +750,7 @@ CharContainer format_exc(ExceptionT const& exc)
 
 #define RYML_CHECK_BASIC_MSG_CB_(cb, cond, ...)                         \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_basic((cb), (::c4::yml::ErrorDataBasic{RYML_LOC_HERE()}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \
@@ -759,7 +759,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_PARSE_MSG_CB_(cb, cond, ymlloc, ...)                 \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_parse((cb), (::c4::yml::ErrorDataParse{RYML_LOC_HERE(), ymlloc}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \
@@ -768,7 +768,7 @@ CharContainer format_exc(ExceptionT const& exc)
     } while(false)
 #define RYML_CHECK_VISIT_MSG_CB_(cb, cond, tree, node, ...)             \
     do {                                                                \
-        if(C4_UNLIKELY(!(cond)))                                        \
+        if C4_UNLIKELY(!(cond))                                         \
         {                                                               \
             RYML_DEBUG_BREAK();                                         \
             ::c4::yml::err_visit((cb), (::c4::yml::ErrorDataVisit{RYML_LOC_HERE(), tree, node}), "check failed" RYML_MAYBE_MSG_CB_(cond) __VA_ARGS__); \

--- a/src/c4/yml/event_handler_tree.hpp
+++ b/src/c4/yml/event_handler_tree.hpp
@@ -78,13 +78,13 @@ public:
 
     void reset(Tree *tree, id_type id)
     {
-        if(C4_UNLIKELY(!tree))
+        if C4_UNLIKELY(!tree)
             RYML_ERR_BASIC_CB_(m_stack.m_callbacks, "null tree");
-        if(C4_UNLIKELY(id >= tree->capacity()))
+        if C4_UNLIKELY(id >= tree->capacity())
             RYML_ERR_VISIT_CB_(tree->callbacks(), tree, id, "invalid node");
-        if(C4_UNLIKELY(!tree->is_root(id)))
-            if(C4_UNLIKELY(tree->is_map(tree->parent(id))))
-                if(C4_UNLIKELY(!tree->has_key(id)))
+        if C4_UNLIKELY(!tree->is_root(id))
+            if C4_UNLIKELY(tree->is_map(tree->parent(id)))
+                if C4_UNLIKELY(!tree->has_key(id))
                     RYML_ERR_BASIC_CB_(tree->callbacks(), "destination node belongs to a map and has no key");
         m_tree = tree;
         if(m_tree->is_root(id))
@@ -372,7 +372,7 @@ public:
      */
     void actually_val_is_first_key_of_new_map_flow()
     {
-        if(C4_UNLIKELY(m_tree->is_container(m_curr->node_id)))
+        if C4_UNLIKELY(m_tree->is_container(m_curr->node_id))
             RYML_ERR_PARSE_CB_(m_stack.m_callbacks, m_curr->pos, "ryml trees cannot handle containers as keys");
         RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, m_parent);
         RYML_ASSERT_VISIT_CB_(m_stack.m_callbacks, m_tree->is_seq(m_parent->node_id), m_tree, m_parent->node_id);
@@ -578,7 +578,7 @@ public:
     void add_directive_tag(csubstr handle, csubstr prefix)
     {
         _c4dbgpf("%TAG directive! handle={} prefix={} id={}", handle, prefix, m_curr_doc);
-        if(C4_UNLIKELY(!m_tree->m_tag_directives.add(handle, prefix, m_curr_doc)))
+        if C4_UNLIKELY(!m_tree->m_tag_directives.add(handle, prefix, m_curr_doc))
             RYML_ERR_PARSE_CB_(m_stack.m_callbacks, m_curr->pos, "too many %TAG directives");
     }
 

--- a/src/c4/yml/file.hpp
+++ b/src/c4/yml/file.hpp
@@ -57,7 +57,7 @@ struct ScopedFILE
 inline void file_put_contents(void const* buf, size_t sz, FILE *file, const char* filename=nullptr)
 {
     size_t written = std::fwrite(buf, 1, sz, file); // NOLINT
-    if(C4_UNLIKELY(written != sz))
+    if C4_UNLIKELY(written != sz)
         RYML_ERR_BASIC_("{}: failed file write: expected={}B actual={}B", filename ? filename : "file", sz, written); // LCOV_EXCL_LINE
 }
 
@@ -107,7 +107,7 @@ inline void file_get_contents(const char *filename, FILE *fp, size_t filesz, voi
 {
     RYML_ASSERT_BASIC_(filesz <= bufsz);(void)bufsz;
     size_t read = std::fread(buf, 1, filesz, fp); // NOLINT(clang-analyzer-unix.Errno)
-    if(C4_UNLIKELY(read != filesz))
+    if C4_UNLIKELY(read != filesz)
         RYML_ERR_BASIC_("{}: failed file read: expected={}B actual={}B", filename, filesz, read); // LCOV_EXCL_LINE
 }
 
@@ -151,7 +151,7 @@ void file_get_contents(ContiguousContainer *v, const char *filename, const char 
     size_t vsz = static_cast<size_t>(v->size());
     size_t fsz = file_get_contents(filename, f.file, dat, vsz);
     size_t num_elms = fsz / sizeof(value_type);
-    if(C4_UNLIKELY(fsz != num_elms * sizeof(value_type)))
+    if C4_UNLIKELY(fsz != num_elms * sizeof(value_type))
         RYML_ERR_BASIC_("{}: file size ({}B) not a multiple of element size ({}B)", filename, fsz, sizeof(value_type));
     v->resize(static_cast<size_type>(num_elms));
     if(fsz > vsz * sizeof(value_type))

--- a/src/c4/yml/node.hpp
+++ b/src/c4/yml/node.hpp
@@ -352,7 +352,7 @@ public:
         // (or the caller told us so)
         // use the adapter ctor to accomodate legacy read() implementations
         const ReadResult result(read((ConstImpl const&)*this, v), id_);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             err_visit_(tree_, result.node, "could not deserialize node");
     }
     /** (2) like (1), but for wrapper tag types such as @ref
@@ -369,7 +369,7 @@ public:
         // (or the caller told us so)
         // use the adapter ctor to accomodate legacy read() implementations
         const ReadResult result(read((ConstImpl const&)*this, wrapper), id_);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             err_visit_(tree_, result.node, "could not deserialize node");
     }
 
@@ -392,7 +392,7 @@ public:
         // everything (or the caller told us so)
         // use the adapter ctor to accomodate legacy read_key() implementations
         const ReadResult result(read_key((ConstImpl const&)*this, k), id_);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             err_visit_(tree_, result.node, "could not deserialize key");
     }
     /** (2) like (1), but for wrapper tag types such as @ref
@@ -409,7 +409,7 @@ public:
         // everything (or the caller told us so)
         // use the adapter ctor to accomodate legacy read_key() implementations
         const ReadResult result(read_key((ConstImpl const&)*this, wrapper), id_);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             err_visit_(tree_, result.node, "could not deserialize key");
     }
 
@@ -588,20 +588,20 @@ protected: // error helpers
 
     void check_val_() const
     {
-        if(C4_UNLIKELY(!tree_))
+        if C4_UNLIKELY(!tree_)
             err_basic_("node not readable");
-        else if(C4_UNLIKELY(!(((Impl const* C4_RESTRICT)this)->readable())))
+        else if C4_UNLIKELY(!(((Impl const* C4_RESTRICT)this)->readable()))
             err_visit_(tree_, id_, "node not readable");
-        else if(C4_UNLIKELY(!(tree_->type(id_) & (VAL|MAP|SEQ))))
+        else if C4_UNLIKELY(!(tree_->type(id_) & (VAL|MAP|SEQ)))
             err_visit_(tree_, id_, "node has no contents");
     }
     void check_key_() const
     {
-        if(C4_UNLIKELY(!tree_))
+        if C4_UNLIKELY(!tree_)
             err_basic_("node not readable");
-        else if(C4_UNLIKELY(!(((Impl const* C4_RESTRICT)this)->readable())))
+        else if C4_UNLIKELY(!(((Impl const* C4_RESTRICT)this)->readable()))
             err_visit_(tree_, id_, "node not readable");
-        else if(C4_UNLIKELY(!(tree_->type(id_) & KEY)))
+        else if C4_UNLIKELY(!(tree_->type(id_) & KEY))
             err_visit_(tree_, id_, "node has no key");
     }
 
@@ -807,9 +807,9 @@ private:
 
     void check_readable_() const
     {
-        if(C4_UNLIKELY(!m_tree))
+        if C4_UNLIKELY(!m_tree)
             RYML_ERR_BASIC_("invalid node");
-        if(C4_UNLIKELY(!m_tree || m_id == NONE || (m_id > m_tree->capacity())))
+        if C4_UNLIKELY(!m_tree || m_id == NONE || (m_id > m_tree->capacity()))
             RYML_ERR_VISIT_CB_(m_tree->m_callbacks, m_tree, m_id, "invalid node");
     }
 
@@ -1152,16 +1152,16 @@ private:
 
     void check_readable_() const
     {
-        if(C4_UNLIKELY(!m_tree))
+        if C4_UNLIKELY(!m_tree)
             err_basic_("invalid node");
-        if(C4_UNLIKELY((m_id == NONE || (m_id > m_tree->capacity())) ||
+        if C4_UNLIKELY((m_id == NONE || (m_id > m_tree->capacity()) ||
                        (m_seed.str != nullptr || m_seed.len != (size_t)NONE)))
             err_visit_(m_tree, m_id, "invalid node");
     }
 
     void check_writeable_() const
     {
-        if(C4_UNLIKELY(!m_tree))
+        if C4_UNLIKELY(!m_tree)
             err_basic_("invalid node");
     }
 

--- a/src/c4/yml/parse.cpp
+++ b/src/c4/yml/parse.cpp
@@ -28,48 +28,48 @@ namespace {
 // so many things can go wrong...
 void check_(Tree *tree)
 {
-    if(C4_UNLIKELY(!tree))
+    if C4_UNLIKELY(!tree)
         RYML_ERR_BASIC_("null tree");
-    if(C4_UNLIKELY(tree->empty()))
+    if C4_UNLIKELY(tree->empty())
         tree->reserve();
 }
 void check_(NodeRef &node)
 {
     check_(node.tree());
-    if(C4_UNLIKELY(node.id() == NONE))
+    if C4_UNLIKELY(node.id() == NONE)
         RYML_ERR_VISIT_CB_(node.tree()->m_callbacks, node.tree(), node.id(), "invalid node");
     node.create();
 }
 void check_(Parser *parser)
 {
-    if(C4_UNLIKELY(!parser))
+    if C4_UNLIKELY(!parser)
         RYML_ERR_BASIC_("null parser");
-    if(C4_UNLIKELY(!parser->m_evt_handler))
+    if C4_UNLIKELY(!parser->m_evt_handler)
         // the parser callbacks are from the handler. do not use parser->callbacks()
         RYML_ERR_BASIC_("null handler");
 }
 void check_(Parser *parser, Tree *tree)
 {
-    if(C4_UNLIKELY(!parser && !tree))
+    if C4_UNLIKELY(!parser && !tree)
     {
         RYML_ERR_BASIC_("null parser and tree");
     }
-    else if(C4_UNLIKELY(!parser))
+    else if C4_UNLIKELY(!parser)
     {
         RYML_ERR_BASIC_CB_(tree->callbacks(), "null parser");
     }
-    else if(C4_UNLIKELY(!tree))
+    else if C4_UNLIKELY(!tree)
     {
-        if(C4_UNLIKELY(!parser->m_evt_handler))
+        if C4_UNLIKELY(!parser->m_evt_handler)
             RYML_ERR_BASIC_("null tree and handler");
         else
             RYML_ERR_BASIC_CB_(parser->callbacks(), "null tree");
     }
-    if(C4_UNLIKELY(!parser->m_evt_handler))
+    if C4_UNLIKELY(!parser->m_evt_handler)
     {
         RYML_ERR_BASIC_("null handler");
     }
-    if(C4_UNLIKELY(tree->empty()))
+    if C4_UNLIKELY(tree->empty())
     {
         tree->reserve();
     }
@@ -81,7 +81,7 @@ void check_(Parser *parser, NodeRef &node)
 }
 void checksrc_(Tree *tree, csubstr src)
 {
-    if(C4_UNLIKELY(src.len && !src.str))
+    if C4_UNLIKELY(src.len && !src.str)
         RYML_ERR_BASIC_CB_(tree->callbacks(), "null source buffer");
 }
 substr cpsrc_(Tree *tree, csubstr src)
@@ -138,7 +138,7 @@ C4_ALWAYS_INLINE void reset_handler_(Parser *parser, Tree *tree, id_type node_id
     RYML_ASSERT_BASIC_(parser); // LCOV_EXCL_LINE lcov weirdly fails here
     RYML_ASSERT_BASIC_(parser->m_evt_handler);
     RYML_ASSERT_BASIC_(tree);
-    if(C4_UNLIKELY(node_id == NONE || node_id >= tree->capacity()))
+    if C4_UNLIKELY(node_id == NONE || node_id >= tree->capacity())
         RYML_ERR_VISIT_CB_(tree->m_callbacks, tree, node_id, "invalid node");
     parser->m_evt_handler->reset(tree, node_id);
     RYML_ASSERT_BASIC_(parser->m_evt_handler->m_tree == tree);

--- a/src/c4/yml/parse_engine.def.hpp
+++ b/src/c4/yml/parse_engine.def.hpp
@@ -694,7 +694,7 @@ void ParseEngine<EventHandler>::_skip_comment()
     {
         RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, col > 0, m_evt_handler->m_curr->pos);
         const char prev = lc.full.str[col - 1u];
-        if(C4_UNLIKELY(prev != ' ' && prev != '\t'))
+        if C4_UNLIKELY(prev != ' ' && prev != '\t')
             _c4err("comment not preceded by whitespace");
     }
     _c4dbgpf("comment was '{}'", m_evt_handler->m_curr->line_contents.rem);
@@ -805,7 +805,7 @@ csubstr ParseEngine<EventHandler>::_scan_tag()
     {
         _c4dbgp("begins with '!'");
         _set_first(t, t.first_of(" ,]}\t"));
-        if(C4_UNLIKELY(t.first_of("[{") != npos))
+        if C4_UNLIKELY(t.first_of("[{") != npos)
             _c4err("invalid tag");
         _line_progressed(t.len);
         if(m_options.resolve_tags_all() || (m_options.resolve_tags() && is_custom_tag(t)))
@@ -815,7 +815,7 @@ csubstr ParseEngine<EventHandler>::_scan_tag()
     {
         _c4dbgp("begins with '!<'");
         size_t pos = t.find('>');
-        if(C4_UNLIKELY(pos == npos))
+        if C4_UNLIKELY(pos == npos)
             _c4err("invalid tag");
         _set_first_strict(t, pos+1);
         _line_progressed(t.len);
@@ -834,7 +834,7 @@ csubstr ParseEngine<EventHandler>::_scan_tag(csubstr *orig)
     {
         _c4dbgp("begins with '!'");
         _set_first(t, t.first_of(" ,\t"));
-        if(C4_UNLIKELY(t.first_of("[{") != npos))
+        if C4_UNLIKELY(t.first_of("[{") != npos)
             _c4err("invalid tag");
         _line_progressed(t.len);
         *orig = t;
@@ -845,7 +845,7 @@ csubstr ParseEngine<EventHandler>::_scan_tag(csubstr *orig)
     {
         _c4dbgp("begins with '!<'");
         size_t pos = t.find('>');
-        if(C4_UNLIKELY(pos == npos))
+        if C4_UNLIKELY(pos == npos)
             _c4err("invalid tag");
         _set_first_strict(t, pos+1);
         _line_progressed(t.len);
@@ -986,12 +986,12 @@ bool ParseEngine<EventHandler>::_scan_scalar_plain_handle_newline(csubstr s, siz
             next_line = next_line.first(next_line.first_of("\n\r"));
             _c4dbgpf("newl[PLAIN]: has indentation. next_line={}", prs_(next_line));
             RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, next_line_indentation <= next_line.len, m_evt_handler->m_curr->pos);
-            if(C4_LIKELY(next_line_indentation >= m_evt_handler->m_curr->indref))
+            if C4_LIKELY(next_line_indentation >= m_evt_handler->m_curr->indref)
             {
                 _c4dbgp("newl[PLAIN]: larger indentation");
                 next_line = next_line.sub(next_line_indentation);
             }
-            else if(C4_UNLIKELY(next_line.len && next_line.triml(' ').len))
+            else if C4_UNLIKELY(next_line.len && next_line.triml(' ').len)
             {
                 _c4dbgp("newl[PLAIN]: err, smaller indentation");
                 _line_progressed(m_evt_handler->m_curr->line_contents.rem.len);
@@ -1365,7 +1365,7 @@ bool ParseEngine<EventHandler>::_scan_scalar_map_json(ScannedScalar *C4_RESTRICT
 
 ended_scalar:
 
-    if(C4_LIKELY(i > 0))
+    if C4_LIKELY(i > 0)
     {
         _line_progressed(i);
         sc->scalar = s.first(i);
@@ -1461,7 +1461,7 @@ bool ParseEngine<EventHandler>::_scan_scalar_plain_blck(ScannedScalar *C4_RESTRI
                     _c4dbgpf("followed by '{}'", i+1 == s.len ? csubstr("\\n") : _c4prc(s.str[i+1]));
                     _line_progressed(i);
                     // ': ' is accepted only on the first line
-                    if(C4_LIKELY(m_evt_handler->m_curr->pos.line == start_line))
+                    if C4_LIKELY(m_evt_handler->m_curr->pos.line == start_line)
                     {
                         _c4dbgp("start line. scalar ends here");
                         goto ended_scalar;
@@ -1624,7 +1624,7 @@ next_is_empty:
 template<class EventHandler>
 void ParseEngine<EventHandler>::_scan_line()
 {
-    if(C4_LIKELY(m_evt_handler->m_curr->pos.offset < _buf().len))
+    if C4_LIKELY(m_evt_handler->m_curr->pos.offset < _buf().len)
         m_evt_handler->m_curr->line_contents.reset_with_next_line(_buf(), m_evt_handler->m_curr->pos.offset);
     else
         m_evt_handler->m_curr->line_contents.reset_with_next_line(_buf().last(0), 0);
@@ -1721,9 +1721,9 @@ void ParseEngine<EventHandler>::_end_flow_container(size_t orig_indent, bool mul
     if(has_all(RMAP|RBLCK) && has_none(RKCL|RVAL|RNXT))
     {
         _c4dbgp("flow container: end as vanilla block map key!");
-        if(C4_UNLIKELY(multiline))
+        if C4_UNLIKELY(multiline)
             _c4err("multiline key is invalid");
-        if(C4_UNLIKELY(!_maybe_scan_following_colon()))
+        if C4_UNLIKELY(!_maybe_scan_following_colon())
             _c4err("could not find ':' colon after key");
         _maybe_skip_whitespace_tokens();
         addrem_flags(RVAL, RKEY|RKCL|RNXT);
@@ -1733,7 +1733,7 @@ void ParseEngine<EventHandler>::_end_flow_container(size_t orig_indent, bool mul
         _c4dbgp("end_flow_container: now not in flow!");
         if(has_any(RUNK|RSEQ|RKCL) && _maybe_scan_following_colon())
         {
-            if(C4_UNLIKELY(multiline))
+            if C4_UNLIKELY(multiline)
                 _c4err("multiline key is invalid");
             _flow_container_was_a_key(orig_indent);
         }
@@ -1955,7 +1955,7 @@ void ParseEngine<EventHandler>::_check_doc_end_tokens() const
 {
     csubstr rem = m_evt_handler->m_curr->line_contents.rem;
     RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, !rem.begins_with_any(". \t"), m_evt_handler->m_curr->pos);
-    if(C4_UNLIKELY(rem.len && !rem.begins_with('#')))
+    if C4_UNLIKELY(rem.len && !rem.begins_with('#'))
     {
         _c4err("parse error");
     }
@@ -1974,9 +1974,9 @@ template<class EventHandler>
 void ParseEngine<EventHandler>::_end_stream()
 {
     _c4dbgpf("end_stream, level={} node_id={}", m_evt_handler->m_curr->level, m_evt_handler->m_curr->node_id);
-    if(C4_UNLIKELY(has_all(RSEQ|RFLOW)))
+    if C4_UNLIKELY(has_all(RSEQ|RFLOW))
         _c4err("missing terminating ]");
-    else if(C4_UNLIKELY(has_all(RMAP|RFLOW)))
+    else if C4_UNLIKELY(has_all(RMAP|RFLOW))
         _c4err("missing terminating }");
     if(m_evt_handler->m_stack.size() > 1)
         _handle_indentation_pop(m_evt_handler->m_stack.begin());
@@ -1998,7 +1998,7 @@ void ParseEngine<EventHandler>::_end_stream()
         }
     }
     m_evt_handler->end_stream();
-    if(C4_UNLIKELY(m_has_directives))
+    if C4_UNLIKELY(m_has_directives)
         _c4err("directives cannot be used without a document");
 }
 
@@ -2113,7 +2113,7 @@ void ParseEngine<EventHandler>::_handle_indentation_pop_from_block_map()
 template<class EventHandler>
 void ParseEngine<EventHandler>::_check_valid_newline_in_quoted_scalar()
 {
-    if(C4_UNLIKELY(has_all(RMAP|RBLCK|RKEY)))
+    if C4_UNLIKELY(has_all(RMAP|RBLCK|RKEY))
     {
         _c4err("multiline quoted keys are invalid");
     }
@@ -2128,7 +2128,7 @@ void ParseEngine<EventHandler>::_check_valid_newline_in_quoted_scalar()
                                 m_evt_handler->m_curr->pos);
             csubstr trimmed = m_evt_handler->m_curr->line_contents.rem.sub(m_evt_handler->m_curr->line_contents.indentation);
             _c4dbgpf("trimmed.len={} line={}", trimmed.len, prs_(m_evt_handler->m_curr->line_contents.rem, true));
-            if(C4_UNLIKELY(!!trimmed.len))
+            if C4_UNLIKELY(!!trimmed.len)
             {
                 _c4err("bad indentation");
             }
@@ -2157,7 +2157,7 @@ ScannedScalar ParseEngine<EventHandler>::_scan_scalar_squot()
     {
         const csubstr line = m_evt_handler->m_curr->line_contents.rem;
         _c4dbgpf("scanning single quoted scalar @ line[{}]: {}", m_evt_handler->m_curr->pos.line, prs_(line));
-        if(C4_UNLIKELY(m_evt_handler->m_curr->at_line_beginning() && _is_doc_token(line)))
+        if C4_UNLIKELY(m_evt_handler->m_curr->at_line_beginning() && _is_doc_token(line))
             _c4err("token can not appear at line begin");
         for(size_t i = 0; i < line.len; ++i)
         {
@@ -2226,7 +2226,7 @@ ScannedScalar ParseEngine<EventHandler>::_scan_scalar_dquot()
         #endif
         csubstr rem = m_evt_handler->m_curr->line_contents.rem;
         _c4dbgpf("scanning double quoted scalar @ line[{}]:  line='{}'", m_evt_handler->m_curr->pos.line, rem);
-        if(C4_UNLIKELY(m_evt_handler->m_curr->at_line_beginning() && _is_doc_token(rem)))
+        if C4_UNLIKELY(m_evt_handler->m_curr->at_line_beginning() && _is_doc_token(rem))
             _c4err("token can not appear at line begin");
         for(size_t i = 0; i < rem.len; ++i)
         {
@@ -2321,11 +2321,11 @@ void ParseEngine<EventHandler>::_scan_block(ScannedBlock *C4_RESTRICT sb, size_t
         if( ! rest.empty())
         {
             _c4dbgpf("blck: parse indentation digits: {}", prs_(rest));
-            if(C4_UNLIKELY(rest.len > 1))
+            if C4_UNLIKELY(rest.len > 1)
                 _c4err("parse error: invalid indentation");
-            if(C4_UNLIKELY( ! c4::atou(rest, &indentation)))
+            if C4_UNLIKELY( ! c4::atou(rest, &indentation))
                 _c4err("parse error: could not read indentation as decimal"); // LCOV_EXCL_LINE
-            if(C4_UNLIKELY( ! indentation))
+            if C4_UNLIKELY( ! indentation)
                 _c4err("parse error: null indentation");
             _c4dbgpf("blck: indentation specified: {}. add {} from curr state -> {}", indentation, m_evt_handler->m_curr->indref, indentation+indref);
             indentation += m_evt_handler->m_curr->indref;
@@ -2334,7 +2334,7 @@ void ParseEngine<EventHandler>::_scan_block(ScannedBlock *C4_RESTRICT sb, size_t
         {
             rest = t.triml(" \t");
             _c4dbgpf("blck: digits empty. t={} trimmed={} iscomm={} t.iscomm={}", prs_(t), prs_(rest), rest.begins_with('#'), t.begins_with('#'));
-            if(C4_UNLIKELY(rest.len && (rest.str[0] != '#' || t.str[0] == '#')))
+            if C4_UNLIKELY(rest.len && (rest.str[0] != '#' || t.str[0] == '#'))
                 _c4err("parse error: invalid token");
         }
     }
@@ -2402,7 +2402,7 @@ void ParseEngine<EventHandler>::_scan_block(ScannedBlock *C4_RESTRICT sb, size_t
             if(fns != npos) // non-empty line
             {
                 _c4dbgpf("blck: line not empty. indref={} indprov={} indentation={}", indref, provisional_indentation, lc.indentation);
-                if(C4_UNLIKELY(lc.full.begins_with('\t')))
+                if C4_UNLIKELY(lc.full.begins_with('\t'))
                     _c4err("parse error");
                 if(provisional_indentation == npos)
                 {
@@ -2833,16 +2833,16 @@ template<class FilterProcessor>
 void ParseEngine<EventHandler>::_filter_dquoted_backslash_decode(FilterProcessor &C4_RESTRICT proc, size_t sz)
 {
     const size_t szp1 = sz + 1u;
-    if(C4_UNLIKELY(proc.rpos + szp1 >= proc.src.len))
+    if C4_UNLIKELY(proc.rpos + szp1 >= proc.src.len)
         _c4err("codepoint requires {} hex digits. scalar pos={}", sz, proc.rpos);
     char readbuf[8];
     csubstr codepoint = proc.src.sub(proc.rpos + 2u, sz);
     _c4dbgfdq("utf8 ~~~{}~~~ rpos={} rem=~~~{}~~~", codepoint, proc.rpos, proc.src.sub(proc.rpos));
     uint32_t codepoint_val = {};
-    if(C4_UNLIKELY(!read_hex(codepoint, &codepoint_val)))
+    if C4_UNLIKELY(!read_hex(codepoint, &codepoint_val))
         _c4err("failed to parse codepoint. scalar pos={}", proc.rpos);
     const size_t numbytes = decode_code_point((uint8_t*)readbuf, sizeof(readbuf), codepoint_val);
-    if(C4_UNLIKELY(numbytes == 0))
+    if C4_UNLIKELY(numbytes == 0)
         _c4err("failed to decode code point={}", proc.rpos);
     RYML_ASSERT_PARSE_CB_(callbacks(), numbytes <= 4, m_evt_handler->m_curr->pos);
     proc.translate_esc_bulk(readbuf, numbytes, /*nread*/szp1);
@@ -3719,7 +3719,7 @@ csubstr ParseEngine<EventHandler>::_filter_scalar_dquot(substr s)
 {
     _c4dbgpf("filtering dquo scalar: s={}", prs_(s));
     FilterResultExtending r = this->filter_scalar_dquoted_in_place(s, s.len);
-    if(C4_LIKELY(r.valid()))
+    if C4_LIKELY(r.valid())
     {
         _c4dbgpf("filtering dquo scalar: success! s={}", prs_(r.get()));
         return r.get();
@@ -3777,7 +3777,7 @@ csubstr ParseEngine<EventHandler>::_filter_scalar_literal(substr s, size_t inden
     _c4dbgpf("filtering block literal scalar: s={}", prs_(s));
     FilterResult r = this->filter_scalar_block_literal_in_place(s, s.len, indentation, chomp);
     csubstr result;
-    if(C4_LIKELY(r.valid()))
+    if C4_LIKELY(r.valid())
     {
         result = r.get();
     }
@@ -3801,7 +3801,7 @@ csubstr ParseEngine<EventHandler>::_filter_scalar_folded(substr s, size_t indent
     _c4dbgpf("filtering block folded scalar: s={}", prs_(s));
     FilterResult r = this->filter_scalar_block_folded_in_place(s, s.len, indentation, chomp);
     csubstr result;
-    if(C4_LIKELY(r.valid()))
+    if C4_LIKELY(r.valid())
     {
         result = r.get();
     }
@@ -4138,7 +4138,7 @@ csubstr ParseEngine<EventHandler>::location_contents(Location const& loc) const
 template<class EventHandler>
 Location ParseEngine<EventHandler>::val_location(const char *val) const
 {
-    if(C4_UNLIKELY(val == nullptr))
+    if C4_UNLIKELY(val == nullptr)
         return {m_evt_handler->m_curr->pos.name, 0, 0, 0};
     RYML_CHECK_BASIC_CB_(m_evt_handler->m_stack.m_callbacks, m_options.locations());
     // NOTE: if any of these checks fails, the parser needs to be
@@ -4269,7 +4269,7 @@ void ParseEngine<EventHandler>::_handle_flow_line_beginning()
 {
     _c4dbgpf("flow: indref={} indentation={}", m_evt_handler->m_curr->indref, m_evt_handler->m_curr->line_contents.indentation);
     RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, m_evt_handler->m_curr->at_line_beginning(), m_evt_handler->m_curr->pos);
-    if(C4_UNLIKELY(m_evt_handler->m_curr->indentation_lt()))
+    if C4_UNLIKELY(m_evt_handler->m_curr->indentation_lt())
     {
         csubstr trimmed = m_evt_handler->m_curr->line_contents.rem.sub(m_evt_handler->m_curr->line_contents.indentation);
         _c4dbgpf("flow: after indentation={}", prs_(trimmed));
@@ -4329,7 +4329,7 @@ template<class EventHandler>
 void ParseEngine<EventHandler>::_handle_colon()
 {
     size_t curr = m_evt_handler->m_curr->pos.line;
-    if(C4_UNLIKELY(m_prev_colon != npos && curr == m_prev_colon))
+    if C4_UNLIKELY(m_prev_colon != npos && curr == m_prev_colon)
     {
         _c4dbgpf("colon: prevline={} currline={}", m_prev_colon, curr);
         _c4err("two colons on same line");
@@ -4355,7 +4355,7 @@ void ParseEngine<EventHandler>::_add_annotation(Annotation *C4_RESTRICT dst, csu
 {
     _c4dbgpf("store annotation[{}]: '{}' indentation={} line={}", dst->num_entries, maybe_null_str_(str), indentation, line);
     RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, dst->num_entries < C4_COUNTOF(dst->annotations), m_evt_handler->m_curr->pos); // NOLINT(bugprone-sizeof-expression)
-    if(C4_UNLIKELY(dst->num_entries && dst->annotations[0].line == line))
+    if C4_UNLIKELY(dst->num_entries && dst->annotations[0].line == line)
     {
         _c4err("parse error");
     }
@@ -4371,7 +4371,7 @@ void ParseEngine<EventHandler>::_add_annotation(Annotation *C4_RESTRICT dst, csu
 {
     _c4dbgpf("store annotation[{}]: '{}'->'{}' indentation={} line={}", dst->num_entries, orig, maybe_null_str_(str), indentation, line);
     RYML_ASSERT_PARSE_CB_(m_evt_handler->m_stack.m_callbacks, dst->num_entries < C4_COUNTOF(dst->annotations), m_evt_handler->m_curr->pos); // NOLINT(bugprone-sizeof-expression)
-    if(C4_UNLIKELY(dst->num_entries && dst->annotations[0].line == line))
+    if C4_UNLIKELY(dst->num_entries && dst->annotations[0].line == line)
     {
         _c4err("parse error");
     }
@@ -4397,7 +4397,7 @@ bool ParseEngine<EventHandler>::_handle_annotations_before_unexpected_flow_token
     if(m_pending_tags.num_entries)
     {
         _c4dbgpf("handle_annotations_before_unexpected_flow_comma_rkey, #tags={}", m_pending_tags.num_entries);
-        if(C4_LIKELY(m_pending_tags.num_entries == 1))
+        if C4_LIKELY(m_pending_tags.num_entries == 1)
         {
              m_evt_handler->set_key_tag(m_pending_tags.annotations[0].str);
             _clear_annotations(&m_pending_tags);
@@ -4410,7 +4410,7 @@ bool ParseEngine<EventHandler>::_handle_annotations_before_unexpected_flow_token
     if(m_pending_anchors.num_entries)
     {
         _c4dbgpf("handle_annotations_before_unexpected_flow_comma, #anchors={}", m_pending_tags.num_entries);
-        if(C4_LIKELY(m_pending_anchors.num_entries == 1))
+        if C4_LIKELY(m_pending_anchors.num_entries == 1)
         {
             m_evt_handler->set_key_anchor(m_pending_anchors.annotations[0].str);
             _clear_annotations(&m_pending_anchors);
@@ -4432,7 +4432,7 @@ void ParseEngine<EventHandler>::_handle_annotations_before_blck_key_scalar()
     if(m_pending_tags.num_entries)
     {
         _c4dbgpf("annotations_before_blck_key_scalar, #tags={}", m_pending_tags.num_entries);
-        if(C4_LIKELY(m_pending_tags.num_entries == 1))
+        if C4_LIKELY(m_pending_tags.num_entries == 1)
         {
              m_evt_handler->set_key_tag(m_pending_tags.annotations[0].str);
             _clear_annotations(&m_pending_tags);
@@ -4445,7 +4445,7 @@ void ParseEngine<EventHandler>::_handle_annotations_before_blck_key_scalar()
     if(m_pending_anchors.num_entries)
     {
         _c4dbgpf("annotations_before_blck_key_scalar, #anchors={}", m_pending_anchors.num_entries);
-        if(C4_LIKELY(m_pending_anchors.num_entries == 1))
+        if C4_LIKELY(m_pending_anchors.num_entries == 1)
         {
             m_evt_handler->set_key_anchor(m_pending_anchors.annotations[0].str);
             _clear_annotations(&m_pending_anchors);
@@ -4464,7 +4464,7 @@ void ParseEngine<EventHandler>::_handle_annotations_before_blck_val_scalar()
     if(m_pending_tags.num_entries)
     {
         _c4dbgpf("annotations_before_blck_val_scalar, #tags={}", m_pending_tags.num_entries);
-        if(C4_LIKELY(m_pending_tags.num_entries == 1))
+        if C4_LIKELY(m_pending_tags.num_entries == 1)
         {
              m_evt_handler->set_val_tag(m_pending_tags.annotations[0].str);
             _clear_annotations(&m_pending_tags);
@@ -4477,7 +4477,7 @@ void ParseEngine<EventHandler>::_handle_annotations_before_blck_val_scalar()
     if(m_pending_anchors.num_entries)
     {
         _c4dbgpf("annotations_before_blck_val_scalar, #anchors={}", m_pending_anchors.num_entries);
-        if(C4_LIKELY(m_pending_anchors.num_entries == 1))
+        if C4_LIKELY(m_pending_anchors.num_entries == 1)
         {
             m_evt_handler->set_val_anchor(m_pending_anchors.annotations[0].str);
             _clear_annotations(&m_pending_anchors);
@@ -4631,7 +4631,7 @@ size_t ParseEngine<EventHandler>::_select_indentation_from_annotations(size_t va
 template<class EventHandler>
 void ParseEngine<EventHandler>::_handle_keyref(csubstr alias)
 {
-    if(C4_LIKELY(!(m_pending_anchors.num_entries | m_pending_tags.num_entries)))
+    if C4_LIKELY(!(m_pending_anchors.num_entries | m_pending_tags.num_entries))
         m_evt_handler->set_key_ref(alias);
     else
         _c4err("aliases cannot have anchors or tags");
@@ -4640,7 +4640,7 @@ void ParseEngine<EventHandler>::_handle_keyref(csubstr alias)
 template<class EventHandler>
 void ParseEngine<EventHandler>::_handle_valref(csubstr alias)
 {
-    if(C4_LIKELY(!(m_pending_anchors.num_entries | m_pending_tags.num_entries)))
+    if C4_LIKELY(!(m_pending_anchors.num_entries | m_pending_tags.num_entries))
         m_evt_handler->set_val_ref(alias);
     else
         _c4err("aliases cannot have anchors or tags");
@@ -4785,7 +4785,7 @@ void ParseEngine<EventHandler>::_handle_directive(csubstr directive)
     {
         csubstr handle;
         csubstr prefix;
-        if(C4_UNLIKELY(!_validate_directive_tag(&directive, &handle, &prefix)))
+        if C4_UNLIKELY(!_validate_directive_tag(&directive, &handle, &prefix))
         {
             err = "invalid %TAG directive";
             goto directive_error; // NOLINT
@@ -4795,12 +4795,12 @@ void ParseEngine<EventHandler>::_handle_directive(csubstr directive)
     else if(isdirective(directive, "%YAML"))
     {
         csubstr version;
-        if(C4_UNLIKELY(!_validate_directive_yaml(&directive, &version)))
+        if C4_UNLIKELY(!_validate_directive_yaml(&directive, &version))
         {
             err = "invalid %YAML directive";
             goto directive_error; // NOLINT
         }
-        if(C4_UNLIKELY(m_has_directives_yaml))
+        if C4_UNLIKELY(m_has_directives_yaml)
         {
             err = "multiple %YAML directives";
             goto directive_error; // NOLINT
@@ -4815,13 +4815,13 @@ void ParseEngine<EventHandler>::_handle_directive(csubstr directive)
     _line_progressed(pos);
     rem = rem.sub(pos);
     _c4dbgpf("handle_directive: rest={}", prs_(rem));
-    if(C4_UNLIKELY(rem.len && !rem.begins_with('#')))
+    if C4_UNLIKELY(rem.len && !rem.begins_with('#'))
     {
         err = "invalid tokens after directive";
         goto directive_error; // NOLINT
     }
 directive_error:
-    if(C4_UNLIKELY(err != nullptr))
+    if C4_UNLIKELY(err != nullptr)
         _c4err(err);
 }
 
@@ -5008,7 +5008,7 @@ seqjson_start:
     _c4dbgt("seqjson: go again", 0);
     if(_finished_line())
     {
-        if(C4_LIKELY(!_finished_file()))
+        if C4_LIKELY(!_finished_file())
         {
             _line_ended();
             _scan_line();
@@ -5183,7 +5183,7 @@ mapjson_start:
     _c4dbgt("mapjson: go again", 0);
     if(_finished_line())
     {
-        if(C4_LIKELY(!_finished_file()))
+        if C4_LIKELY(!_finished_file())
         {
             _line_ended();
             _scan_line();
@@ -5448,7 +5448,7 @@ seqimap_start:
     _c4dbgt("seqimap: go again", 0);
     if(_finished_line())
     {
-        if(C4_LIKELY(!_finished_file()))
+        if C4_LIKELY(!_finished_file())
         {
             _line_ended();
             _scan_line();
@@ -5672,7 +5672,7 @@ seqflow_start:
     _c4dbgt("seqflow: go again", 0);
     if(_finished_line())
     {
-        if(C4_LIKELY(!_finished_file()))
+        if C4_LIKELY(!_finished_file())
         {
             _line_ended();
             _scan_line();
@@ -6122,7 +6122,7 @@ mapflow_start:
     _c4dbgt("mapflow: go again", 0);
     if(_finished_line())
     {
-        if(C4_LIKELY(!_finished_file()))
+        if C4_LIKELY(!_finished_file())
         {
             _line_ended();
             _scan_line();
@@ -6446,7 +6446,7 @@ seqblck_start:
         // handle indentation
         //
         _c4dbgpf("seqblck[RNXT]: indref={} indentation={}", m_evt_handler->m_curr->indref, m_evt_handler->m_curr->line_contents.indentation);
-        if(C4_LIKELY(m_evt_handler->m_curr->at_line_beginning()))
+        if C4_LIKELY(m_evt_handler->m_curr->at_line_beginning())
         {
             _c4dbgp("seqblck[RNXT]: at line begin");
             if(m_evt_handler->m_curr->indentation_ge())
@@ -6511,7 +6511,7 @@ seqblck_start:
                || m_evt_handler->m_curr->line_contents.indentation > 0
                || !_is_doc_begin_token(m_evt_handler->m_curr->line_contents.rem))
             {
-                if(C4_LIKELY(_is_blck_seq_token_maybe(m_evt_handler->m_curr->line_contents.rem)))
+                if C4_LIKELY(_is_blck_seq_token_maybe(m_evt_handler->m_curr->line_contents.rem))
                 {
                     _c4dbgp("seqblck[RNXT]: expect next val");
                     addrem_flags(RVAL, RNXT);
@@ -6538,7 +6538,7 @@ seqblck_start:
             // terminating the seq, ie, after `]`). All other cases
             // (ie colon after scalars) are caught elsewhere (ie, in
             // RVAL state).
-            if(C4_LIKELY(m_evt_handler->m_parent && (m_evt_handler->m_parent->flags & RMAP)))
+            if C4_LIKELY(m_evt_handler->m_parent && (m_evt_handler->m_parent->flags & RMAP))
             {
                 _c4dbgp("seqblck[RNXT]: actually this seq was '?' key of parent map");
                 m_evt_handler->end_seq_block();
@@ -6716,11 +6716,11 @@ mapblck_start:
         }
         // block scalars (| and >) can not be used as keys unless they
         // appear in an explicit QMRK scope (ie, after the ? token),
-        else if(C4_UNLIKELY(first == '|'))
+        else if C4_UNLIKELY(first == '|')
         {
             _c4err("block map: literal keys must be enclosed in '?'");
         }
-        else if(C4_UNLIKELY(first == '>'))
+        else if C4_UNLIKELY(first == '>')
         {
             _c4err("block map: folded keys must be enclosed in '?'");
         }
@@ -7050,7 +7050,7 @@ mapblck_start:
         }
         else if(first == '-' && _is_blck_seq_token_maybe(m_evt_handler->m_curr->line_contents.rem))
         {
-            if(C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token()))
+            if C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token())
                 _c4err("parse error");
             _c4dbgp("mapblck[RVAL]: start val seqblck");
             _handle_block_check_leading_tabs(startcol);
@@ -7127,7 +7127,7 @@ mapblck_start:
         }
         else if(first == '?')
         {
-            if(C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token()))
+            if C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token())
                 _c4err("parse error");
             _c4dbgp("mapblck[RVAL]: start val mapblck");
             addrem_flags(RNXT, RVAL);
@@ -7598,7 +7598,7 @@ bool ParseEngine<EventHandler>::_handle_map_block_rkcl()
             if(!m_evt_handler->m_curr->line_contents.rem.len)
                 return true; // continue in mapblck
         }
-        else if(C4_UNLIKELY(m_evt_handler->m_curr->indentation_lt()))
+        else if C4_UNLIKELY(m_evt_handler->m_curr->indentation_lt())
         {
             _c4err("invalid indentation");
         }
@@ -7691,7 +7691,7 @@ bool ParseEngine<EventHandler>::_handle_map_block_rkcl()
     else/* if(m_was_inside_qmrk) */
     {
         _c4dbgp("mapblck[RKCL]: missing :");
-        if(C4_UNLIKELY(!m_evt_handler->m_curr->indentation_eq()))
+        if C4_UNLIKELY(!m_evt_handler->m_curr->indentation_eq())
             _c4err("parse error"); // LCOV_EXCL_LINE
         m_evt_handler->set_val_scalar_plain_empty();
         m_evt_handler->add_sibling();
@@ -7880,7 +7880,7 @@ void ParseEngine<EventHandler>::_handle_unk()
         else if(first == '%')
         {
             _c4dbgpf("directive: {}", m_evt_handler->m_curr->line_contents.rem);
-            if(C4_UNLIKELY(has_any(RDOC) || (!m_doc_empty && has_none(NDOC))))
+            if C4_UNLIKELY(has_any(RDOC) || (!m_doc_empty && has_none(NDOC)))
                 _c4err("need document footer before directives");
             _handle_directive(m_evt_handler->m_curr->line_contents.rem);
             return;
@@ -7913,7 +7913,7 @@ void ParseEngine<EventHandler>::_handle_unk()
     {
         _c4dbgp("runk: flow seq?");
         _handle_unk_begin_doc();
-        if(C4_LIKELY( ! _annotations_require_key_container()))
+        if C4_LIKELY( ! _annotations_require_key_container())
         {
             _c4dbgp("runk: it's a seq, flow");
             _handle_annotations_before_blck_val_scalar();
@@ -7938,7 +7938,7 @@ void ParseEngine<EventHandler>::_handle_unk()
     {
         _c4dbgp("runk: flow map?");
         _handle_unk_begin_doc();
-        if(C4_LIKELY( ! _annotations_require_key_container()))
+        if C4_LIKELY( ! _annotations_require_key_container())
         {
             _c4dbgp("runk: it's a map, flow");
             _handle_annotations_before_blck_val_scalar();
@@ -7962,7 +7962,7 @@ void ParseEngine<EventHandler>::_handle_unk()
     else if(first == '-' && _is_blck_token(m_evt_handler->m_curr->line_contents.rem))
     {
         _c4dbgp("runk: it's a seq, block");
-        if(C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token()))
+        if C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token())
             startindent = _handle_unk_check_left_tokens(startindent, m_evt_handler->m_curr->pos.col, /*skip_annotations*/false);
         _handle_unk_begin_doc();
         _handle_annotations_before_blck_val_scalar();
@@ -7975,7 +7975,7 @@ void ParseEngine<EventHandler>::_handle_unk()
     else if(first == '?' && _is_blck_token(m_evt_handler->m_curr->line_contents.rem))
     {
         _c4dbgp("runk: it's a map + this key is complex");
-        if(C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token()))
+        if C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token())
             startindent = _handle_unk_check_left_tokens(startindent, m_evt_handler->m_curr->pos.col, /*skip_annotations*/false);
         _handle_block_check_leading_tabs(startcol);
         _handle_unk_begin_doc();
@@ -8001,7 +8001,7 @@ void ParseEngine<EventHandler>::_handle_unk()
         if(m_doc_empty || (m_pending_anchors.num_entries | m_pending_tags.num_entries))
         {
             _c4dbgp("runk: it's a map with an empty key");
-            if(C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token()))
+            if C4_UNLIKELY(!m_evt_handler->m_curr->at_first_token())
                 startindent = _handle_unk_check_left_tokens(startindent, m_evt_handler->m_curr->pos.col);
             _handle_block_check_leading_tabs(startcol);
             const size_t startline = m_evt_handler->m_curr->pos.line; // save
@@ -8070,7 +8070,7 @@ void ParseEngine<EventHandler>::_handle_unk()
         const size_t startscalar = _handle_block_get_whitespace_mark();
         const size_t startline = m_evt_handler->m_curr->pos.line; // save
         auto beginmap = [&](size_t startindent_){
-            if(C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline))
+            if C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline)
                 _c4err("multiline scalars cannot be used as implicit keys");
             _handle_block_check_leading_tabs(startcol, startscalar);
             _handle_annotations_before_start_mapblck(startline);
@@ -8120,7 +8120,7 @@ void ParseEngine<EventHandler>::_handle_unk()
             else
             {
                 _c4dbgp("runk: start new block map, set single-quoted scalar as key");
-                if(C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline))
+                if C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline)
                     _c4err("multiline key");
                 if(!firsttoken)
                     startindent = _handle_unk_check_left_tokens(startindent, col);
@@ -8147,7 +8147,7 @@ void ParseEngine<EventHandler>::_handle_unk()
             else
             {
                 _c4dbgp("runk: start new block map, set double-quoted scalar as key");
-                if(C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline))
+                if C4_UNLIKELY(m_evt_handler->m_curr->pos.line > startline)
                     _c4err("multiline key");
                 if(!firsttoken)
                     startindent = _handle_unk_check_left_tokens(startindent, col);

--- a/src/c4/yml/scalar_charconv.hpp
+++ b/src/c4/yml/scalar_charconv.hpp
@@ -183,11 +183,11 @@ template<class T>
 C4_NODISCARD bool from_chars_float(csubstr scalar, T *C4_RESTRICT val) RYML_NOEXCEPT
 {
     static_assert(std::is_floating_point<T>::value, "must be floating point");
-    if(C4_LIKELY(scalar.len > 0))
+    if C4_LIKELY(scalar.len > 0)
     {
         if(scalar.str[0] == '+')
             scalar = scalar.sub(1);
-        if(C4_LIKELY(from_chars(scalar, val)))
+        if C4_LIKELY(from_chars(scalar, val))
             return true;
         else if(scalar.len == 4 || scalar.len == 5)
             return detail::from_chars_float_yaml_special(scalar, val);
@@ -203,11 +203,11 @@ size_t to_chars_float(substr buf, T val) RYML_NOEXCEPT
 {
     static_assert(std::is_floating_point<T>::value, "must be floating point");
     C4_SUPPRESS_WARNING_GCC_CLANG_WITH_PUSH("-Wfloat-equal");
-    if(C4_UNLIKELY(std::isnan(val)))
+    if C4_UNLIKELY(std::isnan(val))
         return to_chars(buf, csubstr(".nan"));
-    else if(C4_UNLIKELY(val == std::numeric_limits<T>::infinity()))
+    else if C4_UNLIKELY(val == std::numeric_limits<T>::infinity())
         return to_chars(buf, csubstr(".inf"));
-    else if(C4_UNLIKELY(val == -std::numeric_limits<T>::infinity()))
+    else if C4_UNLIKELY(val == -std::numeric_limits<T>::infinity())
         return to_chars(buf, csubstr("-.inf"));
     return to_chars(buf, val);
     C4_SUPPRESS_WARNING_GCC_CLANG_POP
@@ -226,7 +226,7 @@ size_t to_chars_float(substr buf, T val) RYML_NOEXCEPT
 template<class T>
 C4_NODISCARD C4_ALWAYS_INLINE bool from_chars_integral(csubstr scalar, T *val) RYML_NOEXCEPT
 {
-    if(C4_LIKELY(scalar.len > 0))
+    if C4_LIKELY(scalar.len > 0)
     {
         if(scalar.str[0] == '+')
             scalar = scalar.sub(1);

--- a/src/c4/yml/std/map.hpp
+++ b/src/c4/yml/std/map.hpp
@@ -47,16 +47,16 @@ C4_ALWAYS_INLINE void write(c4::yml::NodeRef *n, std::map<K, V, Less, Alloc> con
 template<class K, class V, class Less, class Alloc>
 ReadResult read(c4::yml::Tree const* tree, c4::yml::id_type id, std::map<K, V, Less, Alloc> * m)
 {
-    if(C4_UNLIKELY(!tree->is_map(id)))
+    if C4_UNLIKELY(!tree->is_map(id))
         return ReadResult(id);
     for(id_type child = tree->first_child(id); child != NONE; child = tree->next_sibling(child))
     {
         K k{};
         ReadResult result = tree->deserialize_key(child, &k);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             return result;
         result = tree->deserialize(child, &(*m)[std::move(k)]);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             return result;
     }
     return ReadResult();
@@ -69,16 +69,16 @@ ReadResult read(c4::yml::Tree const* tree, c4::yml::id_type id, std::map<K, V, L
 template<class K, class V, class Less, class Alloc>
 ReadResult read(c4::yml::ConstNodeRef const& n, std::map<K, V, Less, Alloc> * m)
 {
-    if(C4_UNLIKELY(!n.is_map()))
+    if C4_UNLIKELY(!n.is_map())
         return ReadResult(n.id());
     for(ConstNodeRef const& C4_RESTRICT ch : n)
     {
         K k{};
         ReadResult result = ch.deserialize_key(&k);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             return result;
         result = ch.deserialize(&(*m)[std::move(k)]);
-        if(C4_UNLIKELY(!result))
+        if C4_UNLIKELY(!result)
             return result;
     }
     return ReadResult();

--- a/src/c4/yml/std/vector.hpp
+++ b/src/c4/yml/std/vector.hpp
@@ -51,7 +51,7 @@ void write(NodeRef *n, std::vector<T, Alloc> const& vec)
 template<class T, class Alloc>
 ReadResult read(Tree const *tree, id_type id, std::vector<T, Alloc> *vec)
 {
-    if(C4_UNLIKELY(!tree->is_seq(id)))
+    if C4_UNLIKELY(!tree->is_seq(id))
         return ReadResult(id);
     vec->clear();
     #if C4_CPP < 17 // prior to C++17, emplace_back() does not return a reference
@@ -85,7 +85,7 @@ ReadResult read(ConstNodeRef const& node, std::vector<T, Alloc> *vec)
     // is not available in the tree implementation, so we need to
     // provide this as a hook for that. If that's not required, then
     // the tree implementation will get called anyway.
-    if(C4_UNLIKELY(!node.is_seq()))
+    if C4_UNLIKELY(!node.is_seq())
         return ReadResult(node.id());
     vec->clear();
     #if C4_CPP < 17 // prior to C++17, emplace_back() does not return a reference
@@ -118,7 +118,7 @@ ReadResult read(ConstNodeRef const& node, std::vector<T, Alloc> *vec)
 template<class Alloc>
 ReadResult read(Tree const* tree, id_type id, std::vector<bool, Alloc> *vec)
 {
-    if(C4_UNLIKELY(!tree->is_seq(id)))
+    if C4_UNLIKELY(!tree->is_seq(id))
         return ReadResult(id);
     vec->clear();
     bool tmp = {};

--- a/src/c4/yml/tag.cpp
+++ b/src/c4/yml/tag.cpp
@@ -276,7 +276,7 @@ bool read_hex_char(csubstr suffix, size_t pos, char *out)
         return false;
     suffix = suffix.range(pos + 1, pos + 3);
     uint8_t val = 0;
-    if(C4_UNLIKELY(!read_hex(suffix, &val) || val > 127))
+    if C4_UNLIKELY(!read_hex(suffix, &val) || val > 127)
         return false;
     *out = static_cast<char>(val);
     return true;
@@ -311,7 +311,7 @@ size_t transform_tag(substr output, csubstr handle, csubstr prefix, csubstr tag,
     for(size_t pos = 0; pos < rest.len; ++pos)
     {
         char c = rest.str[pos];
-        if(C4_LIKELY(is_valid_tag_char(c)))
+        if C4_LIKELY(is_valid_tag_char(c))
         {
             if(c != '%')
             {
@@ -467,7 +467,7 @@ csubstr TagDirectives::resolve(substr buf, size_t *bufsz, csubstr tag, id_type i
         if(tag.begins_with('<'))
         {
             _c4dbgp("tagd: already resolved");
-            if(C4_UNLIKELY(!tag.ends_with('>')))
+            if C4_UNLIKELY(!tag.ends_with('>'))
             {
                 errmsg = "malformed tag";
                 goto err; // NOLINT
@@ -477,7 +477,7 @@ csubstr TagDirectives::resolve(substr buf, size_t *bufsz, csubstr tag, id_type i
         else if(tag.begins_with("!<"))
         {
             _c4dbgp("tagd: already resolved");
-            if(C4_UNLIKELY(!tag.ends_with('>')))
+            if C4_UNLIKELY(!tag.ends_with('>'))
             {
                 errmsg = "malformed tag";
                 goto err; // NOLINT
@@ -497,7 +497,7 @@ csubstr TagDirectives::resolve(substr buf, size_t *bufsz, csubstr tag, id_type i
             handle = "!!";
             prefix = "tag:yaml.org,2002:";
         }
-        else if(C4_UNLIKELY(is_custom_tag(tag)))
+        else if C4_UNLIKELY(is_custom_tag(tag))
         {
             _c4dbgp("tagd: custom_tag");
             _c4dbgpf("tag '{}' at id={}: no matching directive was found", tag, id);

--- a/src/c4/yml/tree.cpp
+++ b/src/c4/yml/tree.cpp
@@ -1925,7 +1925,7 @@ bool Tree::_location_from_node(Parser const& parser, id_type node, Location *C4_
     if(ty.has_key())
     {
         csubstr k = key(node);
-        if(C4_LIKELY(k.str != nullptr))
+        if C4_LIKELY(k.str != nullptr)
         {
             RYML_ASSERT_BASIC_CB_(m_callbacks, k.is_sub(parser.source()));
             RYML_ASSERT_BASIC_CB_(m_callbacks, parser.source().is_super(k));
@@ -1937,7 +1937,7 @@ bool Tree::_location_from_node(Parser const& parser, id_type node, Location *C4_
     if(ty.has_val())
     {
         csubstr v = val(node);
-        if(C4_LIKELY(v.str != nullptr))
+        if C4_LIKELY(v.str != nullptr)
         {
             RYML_ASSERT_BASIC_CB_(m_callbacks, v.is_sub(parser.source()));
             RYML_ASSERT_BASIC_CB_(m_callbacks, parser.source().is_super(v));

--- a/src/c4/yml/tree.hpp
+++ b/src/c4/yml/tree.hpp
@@ -551,7 +551,7 @@ public:
     bool has_other_siblings(id_type node) const
     {
         NodeData const *n = _p(node);
-        if(C4_LIKELY(n->m_parent != NONE))
+        if C4_LIKELY(n->m_parent != NONE)
         {
             n = _p(n->m_parent);
             return n->m_first_child != n->m_last_child;
@@ -771,7 +771,7 @@ public:
     template<class T>
     C4_ALWAYS_INLINE void save(id_type node, T const& val)
     {
-        if(C4_LIKELY(node != NONE && node < m_cap && node >= 0))
+        if C4_LIKELY(node != NONE && node < m_cap && node >= 0)
         {
             write(this, node, val);
             return;
@@ -781,7 +781,7 @@ public:
     template<class T>
     C4_ALWAYS_INLINE void save(id_type node, T const& val, NodeType more_flags)
     {
-        if(C4_LIKELY(node != NONE && node < m_cap && node >= 0))
+        if C4_LIKELY(node != NONE && node < m_cap && node >= 0)
         {
             write(this, node, val);
             _p(node)->m_type |= more_flags;
@@ -793,7 +793,7 @@ public:
     template<class T>
     C4_ALWAYS_INLINE void save_key(id_type node, T const& key)
     {
-        if(C4_LIKELY(node != NONE && node < m_cap && node >= 0))
+        if C4_LIKELY(node != NONE && node < m_cap && node >= 0)
         {
             write_key(this, node, key);
             return;
@@ -803,7 +803,7 @@ public:
     template<class T>
     C4_ALWAYS_INLINE void save_key(id_type node, T const& key, NodeType more_flags)
     {
-        if(C4_LIKELY(node != NONE && node < m_cap && node >= 0))
+        if C4_LIKELY(node != NONE && node < m_cap && node >= 0)
         {
             write_key(this, node, key);
             _p(node)->m_type |= more_flags;
@@ -872,10 +872,10 @@ public:
     {
         const bool can_read_val = (node != NONE && node < m_cap && node >= 0 && (_p(node)->m_type & (VAL|MAP|SEQ)));
         RYML_ASSERT_VISIT_CB_(m_callbacks, can_read_val, this, node);
-        if(C4_LIKELY(!check_readable || can_read_val))
+        if C4_LIKELY(!check_readable || can_read_val)
         {
             const ReadResult result(read(this, node, v), node);
-            if(C4_LIKELY(result))
+            if C4_LIKELY(result)
                 return;
             else
                 node = result.node;
@@ -890,10 +890,10 @@ public:
         RYML_CHECK_TYPE_IS_WRAPPER_LIKE_(Wrapper);
         const bool can_read_val = (node != NONE && node < m_cap && node >= 0 && (_p(node)->m_type & (VAL|MAP|SEQ)));
         RYML_ASSERT_VISIT_CB_(m_callbacks, can_read_val, this, node);
-        if(C4_LIKELY(!check_readable || can_read_val))
+        if C4_LIKELY(!check_readable || can_read_val)
         {
             const ReadResult result(read(this, node, w), node);
-            if(C4_LIKELY(result))
+            if C4_LIKELY(result)
                 return;
             else
                 node = result.node;
@@ -913,10 +913,10 @@ public:
     {
         const bool can_read_key = (node != NONE && node < m_cap && node >= 0 && (_p(node)->m_type & KEY));
         RYML_ASSERT_VISIT_CB_(m_callbacks, can_read_key, this, node);
-        if(C4_LIKELY(!check_readable || can_read_key))
+        if C4_LIKELY(!check_readable || can_read_key)
         {
             const ReadResult result(read_key(this, node, k), node);
-            if(C4_LIKELY(result))
+            if C4_LIKELY(result)
                 return;
             else
                 node = result.node;
@@ -931,10 +931,10 @@ public:
         RYML_CHECK_TYPE_IS_WRAPPER_LIKE_(Wrapper);
         bool can_read_key = (node != NONE && node < m_cap && node >= 0 && (_p(node)->m_type & KEY));
         RYML_ASSERT_VISIT_CB_(m_callbacks, can_read_key, this, node);
-        if(C4_LIKELY(!check_readable || can_read_key))
+        if C4_LIKELY(!check_readable || can_read_key)
         {
             const ReadResult result(read_key(this, node, w), node);
-            if(C4_LIKELY(result))
+            if C4_LIKELY(result)
                 return;
             else
                 node = result.node;
@@ -1756,7 +1756,7 @@ csubstr serialize_to_arena_scalar(Tree * tree, T const& a)
     substr buf = tree->arena_rem(); // buffer: the free part of the tree's arenra.
  again:
     size_t num = scalar_serialize(buf, a); // try to write into it
-    if(C4_LIKELY(num <= buf.len)) // was it enough?
+    if C4_LIKELY(num <= buf.len) // was it enough?
     {
         buf = buf.first(num); // fit the payload
     }

--- a/src_extra/c4/yml/extra/event_handler_ints.hpp
+++ b/src_extra/c4/yml/extra/event_handler_ints.hpp
@@ -877,10 +877,10 @@ private:
     /** @cond dev*/
     #define _add_scalar_(i, scalar)                                     \
     _c4dbgpf("{}/{}: scalar!", i, m_evt_size);                          \
-    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, _is_sub_(scalar));         \
-    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, m_evt[i] & ievt::WSTR);    \
-    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, ((i) + 3) < m_evt_size);   \
-    if(C4_LIKELY((scalar).is_sub(m_src)))                               \
+    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, _is_sub_(scalar));       \
+    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, m_evt[i] & ievt::WSTR);  \
+    RYML_ASSERT_BASIC_CB_(m_stack.m_callbacks, ((i) + 3) < m_evt_size); \
+    if C4_LIKELY((scalar).is_sub(m_src))                                \
     {                                                                   \
         m_evt[(i) + 1] = (ievt::evt_bits)((scalar).str - m_src.str);    \
     }                                                                   \
@@ -981,7 +981,7 @@ public:
     void add_directive_tag(csubstr handle, csubstr prefix)
     {
         _c4dbgpf("{}/{}: %TAG directive! handle={} prefix={} doc_id={}", m_evt_pos, m_evt_size, handle, prefix, m_curr_doc);
-        if(C4_UNLIKELY(!m_tag_directives.add(handle, prefix, m_curr_doc)))
+        if C4_UNLIKELY(!m_tag_directives.add(handle, prefix, m_curr_doc))
             RYML_ERR_PARSE_CB_(m_stack.m_callbacks, m_curr->pos, "too many %TAG directives");
         _send_str_(handle, ievt::TAGH);
         _send_str_(prefix, ievt::TAGP);
@@ -1139,13 +1139,13 @@ public:
     }
     substr arena_rem() // NOLINT
     {
-        return C4_LIKELY(m_arena_pos <= m_arena.len) ? m_arena.sub(m_arena_pos) : m_arena.last(0);
+        return C4_EXPECT(m_arena_pos <= m_arena.len, 1) ? m_arena.sub(m_arena_pos) : m_arena.last(0);
     }
     /** this may fail, in which case an empty string is returned */
     substr alloc_arena(size_t len)
     {
         substr s = arena_rem();
-        if(C4_LIKELY(len <= s.len))
+        if C4_LIKELY(len <= s.len)
             s.len = len;
         else
             s.str = nullptr;

--- a/test/test_lib/string.hpp
+++ b/test/test_lib/string.hpp
@@ -120,7 +120,7 @@ public:
 
     C4_ALWAYS_INLINE C4_HOT void append(char c)
     {
-        if(C4_UNLIKELY(m_size == m_capacity))
+        if C4_UNLIKELY(m_size == m_capacity)
             reserve(m_size + 1);
         m_str[m_size++] = c;
     }
@@ -129,7 +129,7 @@ public:
         if(cs.len)
         {
             const id_type ilen = (id_type)cs.len;
-            if(C4_UNLIKELY(m_size + ilen > m_capacity))
+            if C4_UNLIKELY(m_size + ilen > m_capacity)
                 reserve(m_size + ilen);
             memcpy(m_str + m_size, cs.str, cs.len);
             m_size += ilen;
@@ -140,7 +140,7 @@ public:
         RYML_ASSERT_BASIC_(pos <= m_size);
         if(pos < m_size)
         {
-            if(C4_UNLIKELY(m_size == m_capacity))
+            if C4_UNLIKELY(m_size == m_capacity)
                 reserve(m_size + 1);
             char *C4_RESTRICT src = m_str + pos;
             memmove(src + 1, src, m_size - pos);
@@ -160,7 +160,7 @@ public:
             if(pos < m_size)
             {
                 const id_type ilen = (id_type)cs.len;
-                if(C4_UNLIKELY(m_size + ilen > m_capacity))
+                if C4_UNLIKELY(m_size + ilen > m_capacity)
                     reserve(m_size + ilen);
                 char *C4_RESTRICT src = m_str + pos;
                 memmove(src + cs.len, src, m_size - pos);


### PR DESCRIPTION
`C4_LIKELY()` and `C4_UNLIKELY()` now use `[[likely]]` and `[[unlikely]]` in C++20. Every use of this macro needs to refactored:
    ```c++
    if(C4_LIKELY(condition)) ... // error now
    // needs to be rewritten as:
    if C4_LIKELY(condition)  ...
    // same for C4_UNLIKELY
    ```