### PR TITLE
resolve: reject cyclic references instead of overflowing the stack

### DIFF
--- a/src/c4/yml/reference_resolver.cpp
+++ b/src/c4/yml/reference_resolver.cpp
@@ -190,6 +190,11 @@ void ReferenceResolver::resolve_()
         if( ! refdata.type.is_ref())
             continue;
         refdata.target = lookup_(&refdata);
+        // A reference whose target is itself or one of its ancestors describes a cyclic node.
+        // Resolving it materializes the target subtree (which contains this reference) into a
+        // location inside that same subtree, recursing without bound. Reject it instead.
+        if(refdata.target == refdata.node || m_tree->is_ancestor(refdata.node, refdata.target))
+            RYML_ERR_VISIT_CB_(m_tree->m_callbacks, m_tree, refdata.node, "cyclic reference: the alias refers to an ancestor anchor");
     }
     _c4dbgp("matching anchors/refs: finished");
 

--- a/test/test_anchor.cpp
+++ b/test/test_anchor.cpp
@@ -45,6 +45,23 @@ TEST(anchors, circular)
     EXPECT_EQ(t[0].val_ref(), "x");
 }
 
+TEST(anchors, err_on_circular_reference)
+{
+    // Resolving a reference whose target is itself or an ancestor would materialize the
+    // target subtree (which contains the reference) into a location inside itself, recursing
+    // without bound. It must be rejected rather than overflowing the stack.
+    {
+        Tree tree = parse_in_arena(R"(&x
+- *x
+)");
+        RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ tree.resolve(); }));
+    }
+    {
+        Tree tree = parse_in_arena("&x {a: *x}\n");
+        RYML_EXPECT_ERROR(check_error_visit(&tree, [&]{ tree.resolve(); }));
+    }
+}
+
 TEST(anchors, node_scalar_set_ref_when_empty)
 {
     {


### PR DESCRIPTION
Fixes the stack overflow in #656 (finding 1).

`Tree::resolve()` materializes each alias by duplicating its target subtree into the reference's location. When a reference's target is the reference node itself or one of its ancestors — a cyclic node such as `&x [*x]`, `&x {a: *x}`, or

```yaml
&x
- *x
```

— the target subtree contains the reference, so duplicating it recreates the reference inside the copy and `duplicate()`/`duplicate_children()` recurse without bound until the stack overflows. An 8-byte input is enough, and because it's a stack overflow it can't be caught through the error callbacks.

The parser already accepts these (see the existing `TEST(anchors, circular)`, which parses `&x\n- *x\n`); nothing rejected them at resolve time.

This adds a check in the reference-matching pass: once a reference's target is known, if the target is the reference itself or an ancestor of it, raise a visit error (`cyclic reference`) — the same mechanism used for other malformed reference situations. Non-cyclic references and valid anchor/alias resolution are unaffected.

A regression test is added next to `TEST(anchors, circular)`.

### Verification

- Built `src` + bundled `c4core` with the change and confirmed the three cyclic inputs above now raise the visit error instead of overflowing the stack, while valid anchored documents still resolve correctly (byte-identical output).
- Ran a ~210s libFuzzer + ASan campaign over `parse_in_arena` → `resolve()` → `emitrs_yaml` on the patched build, seeded with the crashing inputs the same harness found on unpatched `master`: the stack-overflow class is gone and no new crash appears.

Not addressed here: the unbounded alias-expansion (billion-laughs) DoS, also in #656 — that needs a separate expansion bound and is left for a follow-up.
