### PR TITLE
Fix `c4_install_exports` call with system `c4core`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ endif()
 
 if(RYML_INSTALL)
     c4_install_target(ryml)
-    if(RYML_STANDALONE OR RYML_SYSTEM_C4CORE)
+    if(RYML_STANDALONE AND NOT RYML_SYSTEM_C4CORE)
         c4_install_exports()
     else()
         c4_install_exports(DEPENDENCIES c4core)


### PR DESCRIPTION
Fixes #659. Based on a suggestion by Sébastien Noel (@twolife) in a comment on that issue.